### PR TITLE
[Feat/#29] 마이페이지용 타이틀+설명 공통 컴포넌트 추가

### DIFF
--- a/src/app/(main)/my/components/my-page-header/index.tsx
+++ b/src/app/(main)/my/components/my-page-header/index.tsx
@@ -2,6 +2,24 @@ import { MyPageHeaderProps } from '@/app/(main)/my/components/my-page-header/myP
 import { Heading } from '@/shared/components/heading';
 import { cn } from '@/shared/utils/cn';
 
+/**
+ * 마이페이지의 각 섹션 상단에 사용되는 헤더 컴포넌트
+ *
+ * @example
+ * // 1. 우측 액션 요소 X
+ * <MyPageHeader
+ * title="예약 현황"
+ * description="내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다."
+ * />
+ *
+ * // 2. 우측에 액션 요소 O
+ * <MyPageHeader
+ * title="내 체험 관리"
+ * description="체험을 등록하거나 수정 및 삭제가 가능합니다."
+ * >
+ * <button>체험 등록하기</button>
+ * </MyPageHeader>
+ */
 export function MyPageHeader({
   title,
   description,

--- a/src/app/(main)/my/components/my-page-header/index.tsx
+++ b/src/app/(main)/my/components/my-page-header/index.tsx
@@ -1,0 +1,20 @@
+import { MyPageHeaderProps } from '@/app/(main)/my/components/my-page-header/myPageHeader.types';
+import { Heading } from '@/shared/components/heading';
+import { cn } from '@/shared/utils/cn';
+
+export function MyPageHeader({
+  title,
+  description,
+  children,
+  className,
+}: MyPageHeaderProps) {
+  return (
+    <div className={cn('flex items-center justify-between', className)}>
+      <div>
+        <Heading>{title}</Heading>
+        <p className="typo-md-medium mt-2 text-gray-500">{description}</p>
+      </div>
+      {children && <div>{children}</div>}
+    </div>
+  );
+}

--- a/src/app/(main)/my/components/my-page-header/myPageHeader.types.ts
+++ b/src/app/(main)/my/components/my-page-header/myPageHeader.types.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+
+export interface MyPageHeaderProps {
+  title: string;
+  description: string;
+  children?: ReactNode;
+  className?: string;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #29 

## 체크 사항

- [x] dev 최신 내용 반영
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 및 주석 삭제
- [x] 팀 내 컨벤션 준수
- [x] 기능 정상 동작

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 마이페이지용 타이틀+설명 컴포넌트 작성
- `내 체험 관리` 페이지처럼 타이틀 옆에 무언가가 들어가야 할 경우에는 `children` 으로 넣을 수 있게 작성
( children이 없으면 타이틀+설명만 렌더링)

### 스크린샷 (선택)

테스트 한 모습
<img width="1254" height="176" alt="image" src="https://github.com/user-attachments/assets/0cab0e8b-d63b-4282-82c0-9021bdefea23" />

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.

`my/~` 도메인에서만 쓰는 거라 `my` 디렉토리에 `components` 폴더 만들어서 넣는 게 더 좋지 않을까 싶어서
위와 같이 작업했는데, 혹시 의견 있다면 편히 말씀 주세요!