### PR TITLE
[Feat/#47] Input 컴포넌트 focus/error 상태 스타일 적용

### DIFF
--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useId } from 'react';
+import { useId } from 'react';
 import type { InputProps } from '@/shared/components/input/input.types';
 import { cn } from '@/shared/utils/cn';
 
@@ -19,70 +19,69 @@ import { cn } from '@/shared/utils/cn';
  *   errorMessage="비밀번호가 일치하지 않습니다."
  * />
  */
-export const Input = forwardRef<HTMLInputElement, InputProps>(
-  (
-    { label, errorMessage, rightIcon, id, className, disabled, ...props },
-    ref
-  ) => {
-    const generatedId = useId();
-    const inputId = id ?? generatedId;
-    const hasError = Boolean(errorMessage);
+export function Input({
+  label,
+  errorMessage,
+  rightIcon,
+  id,
+  className,
+  disabled,
+  ref,
+  ...props
+}: InputProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const hasError = Boolean(errorMessage);
 
-    return (
-      <div className="flex w-full flex-col">
-        {label && (
-          <label
-            htmlFor={inputId}
-            className="mb-2 text-lg font-medium text-gray-950"
-          >
-            {label}
-          </label>
-        )}
+  return (
+    <div className="flex w-full flex-col">
+      {label && (
+        <label htmlFor={inputId} className="typo-lg-medium mb-2 text-gray-950">
+          {label}
+        </label>
+      )}
 
-        <div className="relative">
-          <input
-            ref={ref}
-            id={inputId}
-            disabled={disabled}
-            aria-invalid={hasError}
-            aria-describedby={hasError ? `${inputId}-error` : undefined}
-            className={cn(
-              'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400 focus:ring-1',
+      <div className="relative">
+        <input
+          ref={ref}
+          id={inputId}
+          disabled={disabled}
+          aria-invalid={hasError}
+          aria-describedby={hasError ? `${inputId}-error` : undefined}
+          className={cn(
+            'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400 focus:ring-1',
 
-              // 아이콘 유무에 따른 padding 조절
-              rightIcon ? 'pr-14 pl-5' : 'px-5',
-              'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
+            // 아이콘 유무에 따른 padding 조절
+            rightIcon ? 'pr-14 pl-5' : 'px-5',
+            'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
 
-              // 에러 상태 스타일
-              hasError
-                ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
-                : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100',
-              className
-            )}
-            {...props}
-          />
-
-          {rightIcon && (
-            <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
-              {rightIcon}
-            </span>
+            // 에러 상태 스타일
+            hasError
+              ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+              : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100',
+            className
           )}
-        </div>
+          {...props}
+        />
 
-        {hasError && (
-          <p
-            id={`${inputId}-error`}
-            className="mt-2 text-sm font-medium text-red-500"
-          >
-            {errorMessage}
-          </p>
+        {rightIcon && (
+          <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
+            {rightIcon}
+          </span>
         )}
-
-        {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
-        {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
       </div>
-    );
-  }
-);
 
-Input.displayName = 'Input';
+      {hasError && (
+        <p
+          id={`${inputId}-error`}
+          className="mt-2 text-sm font-medium text-red-500"
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
+      {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
+    </div>
+  );
+}

--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -1,20 +1,16 @@
 import { useId } from 'react';
-import clsx from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
 import type { InputProps } from '@/shared/components/input/input.types';
+import { cn } from '@/shared/utils/cn';
 
 /**
  * 공통 Input 컴포넌트
  *
  * - label, errorMessage, rightIcon UI를 지원한다.
  * - 기본 / focus / error 상태 스타일을 포함한다.
+ * - 유효성 검사 로직은 외부에서 처리하고, errorMessage 유무로 error UI만 표시한다.
  *
  * @example
- * <Input
- *   label="이메일"
- *   placeholder="이메일을 입력해 주세요"
- * />
+ * <Input label="이메일" placeholder="이메일을 입력해 주세요" />
  *
  * @example
  * <Input
@@ -38,7 +34,6 @@ export function Input({
 
   return (
     <div className="flex w-full flex-col">
-      {/* label 영역 */}
       {label ? (
         <label
           htmlFor={inputId}
@@ -48,28 +43,28 @@ export function Input({
         </label>
       ) : null}
 
-      {/* input + icon wrapper */}
       <div className="relative">
         <input
           id={inputId}
           disabled={disabled}
           aria-invalid={hasError}
           aria-describedby={hasError ? `${inputId}-error` : undefined}
-          className={twMerge(
-            clsx(
-              'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400',
-              rightIcon ? 'pr-14 pl-5' : 'px-5',
-              'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
-              hasError
-                ? 'border-red-500 focus:border-red-500'
-                : 'focus:border-primary-500 border-gray-100'
-            ),
+          className={cn(
+            'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400',
+
+            // 아이콘 유무에 따른 padding 조절
+            rightIcon ? 'pr-14 pl-5' : 'px-5',
+            'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
+
+            // 에러 상태 스타일
+            hasError
+              ? 'border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500'
+              : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100 focus:ring-1',
             className
           )}
           {...props}
         />
 
-        {/* 우측 아이콘 영역 */}
         {rightIcon ? (
           <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
             {rightIcon}
@@ -77,7 +72,6 @@ export function Input({
         ) : null}
       </div>
 
-      {/* 에러 메시지 */}
       {hasError ? (
         <p
           id={`${inputId}-error`}
@@ -88,7 +82,7 @@ export function Input({
       ) : null}
 
       {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
-      {/* TODO: 공통 아이콘 컴포넌트 (shared/assets/icons)로 교체 */}
+      {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
     </div>
   );
 }

--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { forwardRef, useId } from 'react';
 import type { InputProps } from '@/shared/components/input/input.types';
 import { cn } from '@/shared/utils/cn';
 
@@ -19,70 +19,70 @@ import { cn } from '@/shared/utils/cn';
  *   errorMessage="비밀번호가 일치하지 않습니다."
  * />
  */
-export function Input({
-  label,
-  errorMessage,
-  rightIcon,
-  id,
-  className,
-  disabled,
-  ...props
-}: InputProps) {
-  const generatedId = useId();
-  const inputId = id ?? generatedId;
-  const hasError = Boolean(errorMessage);
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { label, errorMessage, rightIcon, id, className, disabled, ...props },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const hasError = Boolean(errorMessage);
 
-  return (
-    <div className="flex w-full flex-col">
-      {label ? (
-        <label
-          htmlFor={inputId}
-          className="mb-2 text-lg font-medium text-gray-950"
-        >
-          {label}
-        </label>
-      ) : null}
+    return (
+      <div className="flex w-full flex-col">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="mb-2 text-lg font-medium text-gray-950"
+          >
+            {label}
+          </label>
+        )}
 
-      <div className="relative">
-        <input
-          id={inputId}
-          disabled={disabled}
-          aria-invalid={hasError}
-          aria-describedby={hasError ? `${inputId}-error` : undefined}
-          className={cn(
-            'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400',
+        <div className="relative">
+          <input
+            ref={ref}
+            id={inputId}
+            disabled={disabled}
+            aria-invalid={hasError}
+            aria-describedby={hasError ? `${inputId}-error` : undefined}
+            className={cn(
+              'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400 focus:ring-1',
 
-            // 아이콘 유무에 따른 padding 조절
-            rightIcon ? 'pr-14 pl-5' : 'px-5',
-            'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
+              // 아이콘 유무에 따른 padding 조절
+              rightIcon ? 'pr-14 pl-5' : 'px-5',
+              'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
 
-            // 에러 상태 스타일
-            hasError
-              ? 'border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500'
-              : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100 focus:ring-1',
-            className
+              // 에러 상태 스타일
+              hasError
+                ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+                : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100',
+              className
+            )}
+            {...props}
+          />
+
+          {rightIcon && (
+            <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
+              {rightIcon}
+            </span>
           )}
-          {...props}
-        />
+        </div>
 
-        {rightIcon ? (
-          <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
-            {rightIcon}
-          </span>
-        ) : null}
+        {hasError && (
+          <p
+            id={`${inputId}-error`}
+            className="mt-2 text-sm font-medium text-red-500"
+          >
+            {errorMessage}
+          </p>
+        )}
+
+        {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
+        {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
       </div>
+    );
+  }
+);
 
-      {hasError ? (
-        <p
-          id={`${inputId}-error`}
-          className="mt-2 text-sm font-medium text-red-500"
-        >
-          {errorMessage}
-        </p>
-      ) : null}
-
-      {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
-      {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
-    </div>
-  );
-}
+Input.displayName = 'Input';

--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -72,10 +72,7 @@ export function Input({
       </div>
 
       {hasError && (
-        <p
-          id={`${inputId}-error`}
-          className="mt-2 text-sm font-medium text-red-500"
-        >
+        <p id={`${inputId}-error`} className="typo-sm-medium mt-2 text-red-500">
           {errorMessage}
         </p>
       )}

--- a/src/shared/components/input/input.types.ts
+++ b/src/shared/components/input/input.types.ts
@@ -1,6 +1,6 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
+import { ComponentPropsWithRef, ReactNode } from 'react';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends ComponentPropsWithRef<'input'> {
   label?: string;
   errorMessage?: string;
   rightIcon?: ReactNode;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #47 

## 체크 사항

- [x] dev 최신 내용 반영
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 및 주석 삭제
- [x] 팀 내 컨벤션 준수
- [x] 기능 정상 동작

## 📌 작업 내용

>  상태별(기본, 포커스, 에러 상태) 스타일 적용
> useId를 사용하여 input id 고유값 생성 및 label 연결 처리
> rightIcon 유무에 따른 padding 동적 처리 (텍스트 겹침 방지)
> cn 유틸을 사용하여 className 병합 로직으로 통일

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
