### PR TITLE
[Feat/#43] 예약 현황 - 기본 레이아웃 구현, 사이드바 컴포넌트 연결

### DIFF
--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/index.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/index.tsx
@@ -1,0 +1,44 @@
+import { IcArrowLeft, IcArrowRight } from '@/shared/assets/icons';
+
+const DAYS_OF_WEEK = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const;
+
+export function ReservationCalendar() {
+  return (
+    <div className="md:shadow-card mt-4.5 min-h-[779px] w-full rounded-3xl border-0 bg-white pt-5 pb-2.5 shadow-none md:mt-6 2xl:mt-7.5">
+      <div className="flex h-full flex-col gap-7.5 px-5 md:px-8">
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            aria-label="이전 달"
+            className="flex h-8 w-8 items-center justify-center text-gray-950"
+          >
+            <IcArrowLeft className="h-6 w-6" />
+          </button>
+          <h3 className="typo-2lg-medium md:typo-xl-medium text-gray-950">
+            2026년 9월
+          </h3>
+          <button
+            type="button"
+            aria-label="다음 달"
+            className="flex h-8 w-8 items-center justify-center text-gray-950"
+          >
+            <IcArrowRight className="h-6 w-6" />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-7 border-b border-gray-50 pb-3">
+          {DAYS_OF_WEEK.map((day, index) => (
+            <span
+              key={`${day}-${index}`}
+              className="typo-lg-semibold flex items-center justify-center text-gray-950"
+            >
+              {day}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex-1 rounded-2xl border-0 bg-white" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/my/activities-dashboard/page.tsx
+++ b/src/app/(main)/my/activities-dashboard/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
-import {
-  IcArrowDown,
-  IcArrowNaviLeft,
-  IcArrowNaviRight,
-} from '@/shared/assets/icons';
+import { ReservationCalendar } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar';
+import { IcArrowDown } from '@/shared/assets/icons';
 
 export const metadata: Metadata = {
   title: '예약 현황',
@@ -27,42 +24,7 @@ export default function MyActivitiesDashboardPage() {
         <IcArrowDown className="h-6 w-6 text-gray-950" />
       </button>
 
-      <div className="md:shadow-card mt-4.5 h-[779px] w-full rounded-3xl border-0 bg-white pt-5 pb-2.5 shadow-none md:mt-6 2xl:mt-7.5">
-        <div className="flex h-full flex-col gap-7.5 px-5 md:px-8">
-          <div className="flex items-center justify-between">
-            <button
-              type="button"
-              aria-label="이전 달"
-              className="flex h-8 w-8 items-center justify-center text-gray-950"
-            >
-              <IcArrowNaviLeft className="h-6 w-6" />
-            </button>
-            <h3 className="typo-2lg-medium md:typo-xl-medium text-gray-950">
-              2026년 9월
-            </h3>
-            <button
-              type="button"
-              aria-label="다음 달"
-              className="flex h-8 w-8 items-center justify-center text-gray-950"
-            >
-              <IcArrowNaviRight className="h-6 w-6" />
-            </button>
-          </div>
-
-          <div className="grid grid-cols-7 border-b border-gray-50 pb-3">
-            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, index) => (
-              <span
-                key={`${day}-${index}`}
-                className="typo-lg-semibold flex items-center justify-center text-gray-950"
-              >
-                {day}
-              </span>
-            ))}
-          </div>
-
-          <div className="flex-1 rounded-2xl border-0 bg-white" />
-        </div>
-      </div>
+      <ReservationCalendar />
     </section>
   );
 }

--- a/src/app/(main)/my/activities-dashboard/page.tsx
+++ b/src/app/(main)/my/activities-dashboard/page.tsx
@@ -1,9 +1,66 @@
 import { Metadata } from 'next';
+import {
+  IcArrowDown,
+  IcArrowNaviLeft,
+  IcArrowNaviRight,
+} from '@/shared/assets/icons';
 
 export const metadata: Metadata = {
   title: '예약 현황',
 };
 
 export default function MyActivitiesDashboardPage() {
-  return <>MyActivitiesDashboardPage</>;
+  return (
+    <section className="mx-auto mb-[66px] w-full max-w-[327px] md:mx-0 md:mb-[172px] md:max-w-[476px] 2xl:mb-[160px] 2xl:max-w-[640px]">
+      <h2 className="typo-2lg-bold text-gray-950">예약 현황</h2>
+      <p className="typo-md-medium mt-2.5 text-gray-500 md:mt-2">
+        내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
+      </p>
+
+      <button
+        type="button"
+        className="shadow-custom mt-6 flex h-[54px] w-full cursor-pointer items-center justify-between rounded-2xl border border-gray-100 bg-white px-5 py-4 2xl:mt-7.5"
+      >
+        <span className="typo-lg-medium text-gray-950">
+          함께 배우면 즐거운 스트릿 댄스
+        </span>
+        <IcArrowDown className="h-6 w-6 text-gray-950" />
+      </button>
+
+      <div className="md:shadow-card mt-4.5 h-[779px] w-full rounded-3xl border-0 bg-white pt-5 pb-2.5 shadow-none md:mt-6 2xl:mt-7.5">
+        <div className="flex h-full flex-col gap-7.5 px-5 md:px-8">
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              aria-label="이전 달"
+              className="flex h-8 w-8 items-center justify-center text-gray-950"
+            >
+              <IcArrowNaviLeft className="h-6 w-6" />
+            </button>
+            <h3 className="typo-2lg-bold text-gray-950">2026년 9월</h3>
+            <button
+              type="button"
+              aria-label="다음 달"
+              className="flex h-8 w-8 items-center justify-center text-gray-950"
+            >
+              <IcArrowNaviRight className="h-6 w-6" />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-7 border-b border-gray-50 pb-3">
+            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, index) => (
+              <span
+                key={`${day}-${index}`}
+                className="typo-lg-semibold flex items-center justify-center text-gray-950"
+              >
+                {day}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex-1 rounded-2xl border-0 bg-white" />
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/app/(main)/my/activities-dashboard/page.tsx
+++ b/src/app/(main)/my/activities-dashboard/page.tsx
@@ -8,12 +8,13 @@ export const metadata: Metadata = {
 
 export default function MyActivitiesDashboardPage() {
   return (
-    <section className="mx-auto mb-[66px] w-[327px] md:mb-[172px] md:w-[476px] 2xl:mb-[160px] 2xl:w-[640px]">
+    <section className="mx-auto mb-[66px] md:mb-[172px] 2xl:mb-[160px]">
       <h2 className="typo-2lg-bold text-gray-950">예약 현황</h2>
       <p className="typo-md-medium mt-2.5 text-gray-500 md:mt-2">
         내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
       </p>
 
+      {/* TODO: 드롭다운 공통 컴포넌트로 교체 */}
       <button
         type="button"
         className="shadow-custom mt-6 flex h-[54px] w-full cursor-pointer items-center justify-between rounded-2xl border border-gray-100 bg-white px-5 py-4 2xl:mt-7.5"

--- a/src/app/(main)/my/activities-dashboard/page.tsx
+++ b/src/app/(main)/my/activities-dashboard/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function MyActivitiesDashboardPage() {
   return (
-    <section className="mx-auto mb-[66px] w-full max-w-[327px] md:mx-0 md:mb-[172px] md:max-w-[476px] 2xl:mb-[160px] 2xl:max-w-[640px]">
+    <section className="mx-auto mb-[66px] w-[327px] md:mb-[172px] md:w-[476px] 2xl:mb-[160px] 2xl:w-[640px]">
       <h2 className="typo-2lg-bold text-gray-950">예약 현황</h2>
       <p className="typo-md-medium mt-2.5 text-gray-500 md:mt-2">
         내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
@@ -37,7 +37,9 @@ export default function MyActivitiesDashboardPage() {
             >
               <IcArrowNaviLeft className="h-6 w-6" />
             </button>
-            <h3 className="typo-2lg-bold text-gray-950">2026년 9월</h3>
+            <h3 className="typo-2lg-medium md:typo-xl-medium text-gray-950">
+              2026년 9월
+            </h3>
             <button
               type="button"
               aria-label="다음 달"

--- a/src/app/(main)/my/layout.tsx
+++ b/src/app/(main)/my/layout.tsx
@@ -6,7 +6,7 @@ export default function MyPageLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="mx-auto mt-10 flex w-full max-w-245 md:gap-7.5 2xl:gap-12.5">
+    <div className="mx-auto mt-10 flex w-full max-w-245 items-start md:gap-7.5 2xl:gap-12.5">
       <Sidebar />
       <div className="flex-1">{children}</div>
     </div>

--- a/src/app/(main)/my/layout.tsx
+++ b/src/app/(main)/my/layout.tsx
@@ -6,9 +6,9 @@ export default function MyPageLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="mx-auto mt-10 flex w-fit items-start md:gap-7.5 2xl:gap-12.5">
+    <div className="mx-auto mt-10 flex w-full max-w-245 items-start md:gap-7.5 2xl:gap-12.5">
       <Sidebar />
-      <div>{children}</div>
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/src/app/(main)/my/layout.tsx
+++ b/src/app/(main)/my/layout.tsx
@@ -6,9 +6,9 @@ export default function MyPageLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="mx-auto mt-10 flex w-full max-w-245 items-start md:gap-7.5 2xl:gap-12.5">
+    <div className="mx-auto mt-10 flex w-fit items-start md:gap-7.5 2xl:gap-12.5">
       <Sidebar />
-      <div className="flex-1">{children}</div>
+      <div>{children}</div>
     </div>
   );
 }

--- a/src/shared/assets/icons/ic-arrow-down.svg
+++ b/src/shared/assets/icons/ic-arrow-down.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M11.2774 14.973C11.6388 15.3736 12.3612 15.3736 12.7226 14.973L17.272 9.9307C17.719 9.43527 17.2941 8.72798 16.5495 8.72798H7.45057C6.70593 8.72798 6.281 9.43527 6.728 9.9307L11.2774 14.973Z" fill="currentColor"/>
 </svg>

--- a/src/shared/assets/icons/ic-arrow-left.svg
+++ b/src/shared/assets/icons/ic-arrow-left.svg
@@ -1,3 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg iewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 7L11.7071 15.2929C11.3166 15.6834 11.3166 16.3166 11.7071 16.7071L20 25" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/shared/assets/icons/ic-arrow-left.svg
+++ b/src/shared/assets/icons/ic-arrow-left.svg
@@ -1,3 +1,3 @@
-<svg iewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 7L11.7071 15.2929C11.3166 15.6834 11.3166 16.3166 11.7071 16.7071L20 25" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/shared/assets/icons/ic-arrow-right.svg
+++ b/src/shared/assets/icons/ic-arrow-right.svg
@@ -1,3 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M11 7L19.2929 15.2929C19.6834 15.6834 19.6834 16.3166 19.2929 16.7071L11 25" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/shared/components/sidebar/index.tsx
+++ b/src/shared/components/sidebar/index.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
   };
 
   return (
-    <aside className="shadow-card hidden w-44.5 rounded-xl border border-gray-50 bg-white px-3.5 py-4 md:block 2xl:w-72.5 2xl:py-6">
+    <aside className="shadow-card hidden w-44.5 rounded-xl border border-gray-50 bg-white px-3.5 pt-4 pb-5 md:block 2xl:w-72.5 2xl:pt-6 2xl:pb-7">
       {/* 프로필 영역 */}
       <div className="relative mx-auto mb-3 w-fit 2xl:mb-6">
         <div className="relative aspect-square w-17.5 overflow-hidden rounded-full bg-blue-50 2xl:w-28">


### PR DESCRIPTION
## 🔗 관련 이슈

- close #43 

## 체크 사항

- [x] dev 최신 내용 반영
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 및 주석 삭제
- [x] 팀 내 컨벤션 준수
- [x] 기능 정상 동작

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- `src/app/(main)/my/activities-dashboard/page.tsx`
  - 제목/설명/드롭다운/달력 기본 레이아웃 추가
  - 반응형 폭 적용

- src/app/(main)/my/layout.tsx
  - items-start 추가로 사이드바 stretch 이슈 해결

- src/shared/components/sidebar/index.tsx
  - 로그아웃 버튼 하단 여백 소폭 증가(pb 조정)

### 스크린샷

<img width="2824" height="2622" alt="localhost_3000_my_activities-dashboard (3)" src="https://github.com/user-attachments/assets/4694d7ae-39b0-4e16-bfb9-510950c670d3" />
