### PR TITLE
[Feat#48] Input 비밀번호 토글 기능 및 eye icon UI 구현

### DIFF
--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -1,4 +1,7 @@
-import { useId } from 'react';
+'use client';
+
+import { useId, useState } from 'react';
+import { IcEyeOff, IcEyeOn } from '@/shared/assets/icons';
 import type { InputProps } from '@/shared/components/input/input.types';
 import { cn } from '@/shared/utils/cn';
 
@@ -7,6 +10,8 @@ import { cn } from '@/shared/utils/cn';
  *
  * - label, errorMessage, rightIcon UI를 지원한다.
  * - 기본 / focus / error 상태 스타일을 포함한다.
+ * - type="password"이고 isPasswordToggle이 true일 경우 비밀번호 보기/숨김 기능을 지원한다.
+ * - password toggle이 활성화된 경우 rightIcon보다 eye icon을 우선 표시한다.
  * - 유효성 검사 로직은 외부에서 처리하고, errorMessage 유무로 error UI만 표시한다.
  *
  * @example
@@ -16,6 +21,7 @@ import { cn } from '@/shared/utils/cn';
  * <Input
  *   label="비밀번호"
  *   type="password"
+ *   isPasswordToggle
  *   errorMessage="비밀번호가 일치하지 않습니다."
  * />
  */
@@ -23,15 +29,30 @@ export function Input({
   label,
   errorMessage,
   rightIcon,
+  isPasswordToggle = false,
   id,
   className,
   disabled,
+  type = 'text',
   ref,
   ...props
 }: InputProps) {
   const generatedId = useId();
   const inputId = id ?? generatedId;
   const hasError = Boolean(errorMessage);
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const isPasswordType = type === 'password';
+  const shouldShowPasswordToggle = isPasswordType && isPasswordToggle;
+  const hasRightElement = shouldShowPasswordToggle || Boolean(rightIcon);
+
+  const inputType =
+    shouldShowPasswordToggle && isPasswordVisible ? 'text' : type;
+
+  const handleTogglePasswordVisibility = () => {
+    setIsPasswordVisible((prev) => !prev);
+  };
 
   return (
     <div className="flex w-full flex-col">
@@ -45,17 +66,14 @@ export function Input({
         <input
           ref={ref}
           id={inputId}
+          type={inputType}
           disabled={disabled}
           aria-invalid={hasError}
           aria-describedby={hasError ? `${inputId}-error` : undefined}
           className={cn(
             'typo-lg-medium h-13.5 w-full rounded-2xl border bg-white py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400 focus:ring-1',
-
-            // 아이콘 유무에 따른 padding 조절
-            rightIcon ? 'pr-14 pl-5' : 'px-5',
+            hasRightElement ? 'pr-14 pl-5' : 'px-5',
             'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
-
-            // 에러 상태 스타일
             hasError
               ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
               : 'focus:border-primary-500 focus:ring-primary-500 border-gray-100',
@@ -64,11 +82,21 @@ export function Input({
           {...props}
         />
 
-        {rightIcon && (
+        {shouldShowPasswordToggle ? (
+          <button
+            type="button"
+            onClick={handleTogglePasswordVisibility}
+            disabled={disabled}
+            aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
+            className="absolute top-1/2 right-5 flex -translate-y-1/2 cursor-pointer items-center justify-center text-gray-400 disabled:cursor-not-allowed"
+          >
+            {isPasswordVisible ? <IcEyeOn /> : <IcEyeOff />}
+          </button>
+        ) : rightIcon ? (
           <span className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-400">
             {rightIcon}
           </span>
-        )}
+        ) : null}
       </div>
 
       {hasError && (
@@ -76,9 +104,6 @@ export function Input({
           {errorMessage}
         </p>
       )}
-
-      {/* TODO: password 타입일 경우 eye 아이콘 토글 기능 추가 */}
-      {/* TODO: 공통 아이콘 컴포넌트(shared/assets/icons) 연결 */}
     </div>
   );
 }

--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -88,6 +88,7 @@ export function Input({
             onClick={handleTogglePasswordVisibility}
             disabled={disabled}
             aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
+            aria-controls={inputId}
             className="absolute top-1/2 right-5 flex -translate-y-1/2 cursor-pointer items-center justify-center text-gray-400 disabled:cursor-not-allowed"
           >
             {isPasswordVisible ? <IcEyeOn /> : <IcEyeOff />}

--- a/src/shared/components/input/index.tsx
+++ b/src/shared/components/input/index.tsx
@@ -10,8 +10,8 @@ import { cn } from '@/shared/utils/cn';
  *
  * - label, errorMessage, rightIcon UI를 지원한다.
  * - 기본 / focus / error 상태 스타일을 포함한다.
- * - type="password"이고 isPasswordToggle이 true일 경우 비밀번호 보기/숨김 기능을 지원한다.
- * - password toggle이 활성화된 경우 rightIcon보다 eye icon을 우선 표시한다.
+ * - type="password"일 경우 비밀번호 보기/숨김 기능을 지원한다.
+ * - password알 경우 rightIcon보다 eye icon을 우선 표시한다.
  * - 유효성 검사 로직은 외부에서 처리하고, errorMessage 유무로 error UI만 표시한다.
  *
  * @example
@@ -21,7 +21,6 @@ import { cn } from '@/shared/utils/cn';
  * <Input
  *   label="비밀번호"
  *   type="password"
- *   isPasswordToggle
  *   errorMessage="비밀번호가 일치하지 않습니다."
  * />
  */
@@ -29,7 +28,6 @@ export function Input({
   label,
   errorMessage,
   rightIcon,
-  isPasswordToggle = false,
   id,
   className,
   disabled,
@@ -44,7 +42,7 @@ export function Input({
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const isPasswordType = type === 'password';
-  const shouldShowPasswordToggle = isPasswordType && isPasswordToggle;
+  const shouldShowPasswordToggle = isPasswordType;
   const hasRightElement = shouldShowPasswordToggle || Boolean(rightIcon);
 
   const inputType =

--- a/src/shared/components/input/input.types.ts
+++ b/src/shared/components/input/input.types.ts
@@ -4,4 +4,5 @@ export interface InputProps extends ComponentPropsWithRef<'input'> {
   label?: string;
   errorMessage?: string;
   rightIcon?: ReactNode;
+  isPasswordToggle?: boolean;
 }

--- a/src/shared/components/input/input.types.ts
+++ b/src/shared/components/input/input.types.ts
@@ -4,5 +4,4 @@ export interface InputProps extends ComponentPropsWithRef<'input'> {
   label?: string;
   errorMessage?: string;
   rightIcon?: ReactNode;
-  isPasswordToggle?: boolean;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #48 

## 체크 사항

- [x] dev 최신 내용 반영
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 및 주석 삭제
- [x] 팀 내 컨벤션 준수
- [x] 기능 정상 동작

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.
- Input 컴포넌트에 비밀번호 토글 기능 추가
- type="password" + isPasswordToggle 조건에서 eye icon UI 렌더링
- eye icon 클릭 시 비밀번호 보기/숨김 토글 기능 구현
- 기존 rightIcon과 충돌하지 않도록 우선순위 분기 처리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
