### PR TITLE
[Feat/#107] 체험 등록에 이미지 등록 및 프리뷰 기능 추가

### DIFF
--- a/src/app/(main)/activity/add/page.tsx
+++ b/src/app/(main)/activity/add/page.tsx
@@ -2,8 +2,10 @@ import { Metadata } from 'next';
 import { FormImage } from '@/app/(main)/activity/components/form-image';
 import { FormTitle } from '@/app/(main)/activity/components/form-title';
 import { ReserveTimeList } from '@/app/(main)/activity/components/reserve-time-list';
+import { Button } from '@/shared/components/buttons';
 import { Heading } from '@/shared/components/heading';
 import { Input } from '@/shared/components/input';
+import { Textarea } from '@/shared/components/textarea';
 
 export const metadata: Metadata = {
   title: '내 체험 등록',
@@ -15,18 +17,26 @@ export default function ActivityAddPage() {
       <Heading>내 체험 등록</Heading>
       <form className="mt-6 flex flex-col gap-7.5">
         <section className="flex flex-col gap-6">
-          <Input label="제목" placeholder="제목을 입력해 주세요" />
+          <Input label="제목" placeholder="제목을 입력해 주세요" required />
           {/* TODO: 드롭다운 메뉴로 변경 */}
-          <Input label="카테고리" placeholder="카테고리를 선택해 주세요" />
-          {/* TODO: textarea로 변경 */}
-          <Input label="설명" placeholder="체험에 대한 설명을 입력해 주세요" />
+          <Input
+            label="카테고리"
+            placeholder="카테고리를 선택해 주세요"
+            required
+          />
+          <Textarea
+            label="설명"
+            placeholder="체험에 대한 설명을 입력해 주세요"
+            required
+          />
           <Input
             label="가격"
             type="number"
             placeholder="체험 금액을 입력해 주세요"
+            required
           />
           {/* TODO: 우편번호 서비스 연동 */}
-          <Input label="주소" placeholder="주소를 입력해 주세요" />
+          <Input label="주소" placeholder="주소를 입력해 주세요" required />
         </section>
         <section>
           <FormTitle>예약 가능한 시간대</FormTitle>
@@ -40,8 +50,11 @@ export default function ActivityAddPage() {
           <FormTitle>소개 이미지 등록</FormTitle>
           <FormImage isMultiple />
         </section>
+        {/* TODO: 버튼 이벤트 등록, 상황에 따라 별도 컴포넌트로 분리 */}
+        <Button type="submit" size="md" className="mx-auto w-30">
+          등록하기
+        </Button>
       </form>
-      {/* TODO: 버튼 추가 */}
     </div>
   );
 }

--- a/src/app/(main)/activity/add/page.tsx
+++ b/src/app/(main)/activity/add/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
-import { ActivityFormTitle } from '@/app/(main)/activity/components/activity-form-title';
 import { FormImage } from '@/app/(main)/activity/components/form-image';
+import { FormTitle } from '@/app/(main)/activity/components/form-title';
 import { ReserveTimeList } from '@/app/(main)/activity/components/reserve-time-list';
 import { Heading } from '@/shared/components/heading';
 import { Input } from '@/shared/components/input';
@@ -29,15 +29,15 @@ export default function ActivityAddPage() {
           <Input label="주소" placeholder="주소를 입력해 주세요" />
         </section>
         <section>
-          <ActivityFormTitle>예약 가능한 시간대</ActivityFormTitle>
+          <FormTitle>예약 가능한 시간대</FormTitle>
           <ReserveTimeList />
         </section>
         <section>
-          <ActivityFormTitle>배너 이미지 등록</ActivityFormTitle>
+          <FormTitle>배너 이미지 등록</FormTitle>
           <FormImage />
         </section>
         <section>
-          <ActivityFormTitle>소개 이미지 등록</ActivityFormTitle>
+          <FormTitle>소개 이미지 등록</FormTitle>
           <FormImage isMultiple />
         </section>
       </form>

--- a/src/app/(main)/activity/add/page.tsx
+++ b/src/app/(main)/activity/add/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { ActivityFormTitle } from '@/app/(main)/activity/components/activity-form-title';
+import { FormImage } from '@/app/(main)/activity/components/form-image';
 import { ReserveTimeList } from '@/app/(main)/activity/components/reserve-time-list';
 import { Heading } from '@/shared/components/heading';
 import { Input } from '@/shared/components/input';
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function ActivityAddPage() {
   return (
-    <div className="mx-auto mt-7.5 max-w-175 md:mt-10">
+    <div className="mx-auto mt-7.5 mb-9 max-w-175 md:mt-10 md:mb-16 2xl:mb-30">
       <Heading>내 체험 등록</Heading>
       <form className="mt-6 flex flex-col gap-7.5">
         <section className="flex flex-col gap-6">
@@ -33,11 +34,11 @@ export default function ActivityAddPage() {
         </section>
         <section>
           <ActivityFormTitle>배너 이미지 등록</ActivityFormTitle>
-          {/* TODO: 배너 이미지 등록 추가 */}
+          <FormImage />
         </section>
         <section>
           <ActivityFormTitle>소개 이미지 등록</ActivityFormTitle>
-          {/* TODO: 소개 이미지 등록 추가 */}
+          <FormImage isMultiple />
         </section>
       </form>
       {/* TODO: 버튼 추가 */}

--- a/src/app/(main)/activity/components/form-image-preview/index.tsx
+++ b/src/app/(main)/activity/components/form-image-preview/index.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import { IcClose } from '@/shared/assets/icons';
+
+export interface FormImagePreviewProps {
+  imageUrl: string;
+  imageId: string;
+  onImageDelete: (deleteImageId: string) => void;
+}
+
+export function FormImagePreview({
+  imageUrl,
+  imageId,
+  onImageDelete,
+}: FormImagePreviewProps) {
+  return (
+    <>
+      <figure className="relative aspect-square overflow-hidden rounded-xl border border-gray-100">
+        <Image
+          src={imageUrl}
+          fill
+          className="object-cover"
+          alt="업로드 된 이미지 미리보기"
+        />
+      </figure>
+      <button
+        type="button"
+        onClick={() => onImageDelete(imageId)}
+        aria-label="업로드된 이미지 삭제"
+        className="absolute -top-1.5 -right-1.5 flex h-6.5 w-6.5 cursor-pointer items-center justify-center rounded-full bg-gray-950"
+      >
+        <IcClose className="w-[60%] text-white" />
+      </button>
+    </>
+  );
+}

--- a/src/app/(main)/activity/components/form-image-preview/index.tsx
+++ b/src/app/(main)/activity/components/form-image-preview/index.tsx
@@ -28,7 +28,7 @@ export function FormImagePreview({
         aria-label="업로드된 이미지 삭제"
         className="absolute -top-1.5 -right-1.5 flex h-6.5 w-6.5 cursor-pointer items-center justify-center rounded-full bg-gray-950"
       >
-        <IcClose className="w-[60%] text-white" />
+        <IcClose className="w-3/5 text-white" />
       </button>
     </>
   );

--- a/src/app/(main)/activity/components/form-image/FormImage.types.ts
+++ b/src/app/(main)/activity/components/form-image/FormImage.types.ts
@@ -1,0 +1,10 @@
+import { ComponentProps } from 'react';
+
+export interface FormImageProps extends Omit<
+  ComponentProps<'input'>,
+  'onChange'
+> {
+  errorMessage?: string;
+  isMultiple?: boolean;
+  onChange?: (file: File[] | File | null) => void;
+}

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -98,7 +98,7 @@ export function FormImage({
 
   return (
     <div className="flex w-full flex-col gap-4">
-      <div className="grid h-31.5 w-full grid-cols-5 gap-3 2xl:gap-3.5">
+      <div className="grid w-full grid-cols-3 gap-3 md:grid-cols-5 2xl:gap-3.5">
         <AddImageButton
           id={inputId}
           errorId={errorId}

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -6,6 +6,7 @@ import { FormImagePreview } from '@/app/(main)/activity/components/form-image-pr
 import { AddImageButton } from '@/shared/components/buttons';
 import { INPUT_ERROR_MESSAGE_STYLE } from '@/shared/components/input/input.constants';
 import { useShowToast } from '@/shared/store/useToastStore';
+import { generateId } from '@/shared/utils/generateId';
 
 const MAX_IMAGE_COUNT = 4;
 
@@ -58,7 +59,7 @@ export function FormImage({
       const url = URL.createObjectURL(file);
       objectUrls.current.push(url);
       return {
-        id: crypto.randomUUID(),
+        id: generateId(),
         url,
         file,
       };

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { FormImageProps } from '@/app/(main)/activity/components/form-image/FormImage.types';
 import { FormImagePreview } from '@/app/(main)/activity/components/form-image-preview';
 import { AddImageButton } from '@/shared/components/buttons';
+import { INPUT_ERROR_MESSAGE_STYLE } from '@/shared/components/input/input.constants';
 import { useShowToast } from '@/shared/store/useToastStore';
 
 const MAX_IMAGE_COUNT = 4;
@@ -45,7 +46,10 @@ export function FormImage({
       const url = URL.createObjectURL(file);
       objectUrls.current.push(url);
       return {
-        id: crypto.randomUUID(),
+        id:
+          typeof crypto !== 'undefined' && crypto.randomUUID
+            ? crypto.randomUUID()
+            : Math.random().toString(36).substring(2, 11),
         url,
         file,
       };
@@ -131,7 +135,7 @@ export function FormImage({
       </div>
 
       {errorMessage && (
-        <p id={errorId} className="typo-lg-regular text-error">
+        <p id={errorId} className={INPUT_ERROR_MESSAGE_STYLE}>
           {errorMessage}
         </p>
       )}

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -6,6 +6,8 @@ import { FormImagePreview } from '@/app/(main)/activity/components/form-image-pr
 import { AddImageButton } from '@/shared/components/buttons';
 import { useShowToast } from '@/shared/store/useToastStore';
 
+const MAX_IMAGE_COUNT = 4;
+
 export function FormImage({
   id,
   errorMessage,
@@ -30,7 +32,7 @@ export function FormImage({
     const files = e.target.files ? Array.from(e.target.files) : null;
     if (!files) return;
 
-    if (isMultiple && imageFiles.length + files.length > 4) {
+    if (isMultiple && imageFiles.length + files.length > MAX_IMAGE_COUNT) {
       showToast({
         theme: 'error',
         message: '이미지는 최대 4장까지만 등록 가능합니다.',
@@ -43,13 +45,16 @@ export function FormImage({
       const url = URL.createObjectURL(file);
       objectUrls.current.push(url);
       return {
-        id: `${file.name} - ${Date.now()}`,
+        id: crypto.randomUUID(),
         url,
         file,
       };
     });
 
     setImageFiles((prev) => {
+      if (!isMultiple && prev.length > 0) {
+        URL.revokeObjectURL(prev[0].url);
+      }
       const updatedFiles = isMultiple
         ? [...prev, ...newImageFiles]
         : [...newImageFiles];
@@ -114,16 +119,15 @@ export function FormImage({
           multiple={isMultiple}
           {...props}
         />
-        {imageFiles &&
-          imageFiles.map((image) => (
-            <div className="relative aspect-square w-full" key={image.id}>
-              <FormImagePreview
-                imageUrl={image.url}
-                imageId={image.id}
-                onImageDelete={handleImageDelete}
-              />
-            </div>
-          ))}
+        {imageFiles.map((image) => (
+          <div className="relative aspect-square w-full" key={image.id}>
+            <FormImagePreview
+              imageUrl={image.url}
+              imageId={image.id}
+              onImageDelete={handleImageDelete}
+            />
+          </div>
+        ))}
       </div>
 
       {errorMessage && (

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -47,40 +47,44 @@ export function FormImage({
       };
     });
 
-    setImageFiles((prev) => {
-      if (!isMultiple && prev.length > 0) {
-        URL.revokeObjectURL(prev[0].url);
-      }
-      const updatedFiles = isMultiple
-        ? [...prev, ...newImageFiles]
-        : [...newImageFiles];
-
-      onChange?.(
-        isMultiple
-          ? updatedFiles.map((item) => item.file)
-          : updatedFiles[0].file
+    if (!isMultiple && imageFiles.length > 0) {
+      URL.revokeObjectURL(imageFiles[0].url);
+      objectUrls.current = objectUrls.current.filter(
+        (prevUrl) => prevUrl !== imageFiles[0].url
       );
-      return updatedFiles;
-    });
+    }
+
+    const updatedFiles = isMultiple
+      ? [...imageFiles, ...newImageFiles]
+      : [...newImageFiles];
+
+    setImageFiles(updatedFiles);
+    onChange?.(
+      isMultiple ? updatedFiles.map((item) => item.file) : updatedFiles[0].file
+    );
 
     if (inputRef.current) inputRef.current.value = '';
   };
 
   const handleImageDelete = (deleteImageId: string) => {
-    setImageFiles((prev) => {
-      const filteredFiles = prev.filter((image) => image.id !== deleteImageId);
+    const filteredFiles = imageFiles.filter(
+      (image) => image.id !== deleteImageId
+    );
+    const deletedImage = imageFiles.find((image) => image.id === deleteImageId);
 
-      const deletedImage = prev.find((image) => image.id === deleteImageId);
-      if (deletedImage) URL.revokeObjectURL(deletedImage.url);
-
-      onChange?.(
-        isMultiple
-          ? filteredFiles.map((item) => item.file)
-          : filteredFiles[0]?.file || null
+    if (deletedImage) {
+      URL.revokeObjectURL(deletedImage.url);
+      objectUrls.current = objectUrls.current.filter(
+        (prevUrl) => prevUrl !== deletedImage.url
       );
+    }
 
-      return filteredFiles;
-    });
+    setImageFiles(filteredFiles);
+    onChange?.(
+      isMultiple
+        ? filteredFiles.map((item) => item.file)
+        : filteredFiles[0]?.file || null
+    );
 
     if (inputRef.current) {
       inputRef.current.value = '';

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -18,6 +18,8 @@ export function FormImage({
   >([]);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const objectUrls = useRef<string[]>([]);
+
   const showToast = useShowToast();
 
   const generatedId = useId();
@@ -37,11 +39,15 @@ export function FormImage({
       return;
     }
 
-    const newImageFiles = files.map((file) => ({
-      id: `${file.name} - ${Date.now()}`,
-      url: URL.createObjectURL(file),
-      file: file,
-    }));
+    const newImageFiles = files.map((file) => {
+      const url = URL.createObjectURL(file);
+      objectUrls.current.push(url);
+      return {
+        id: `${file.name} - ${Date.now()}`,
+        url,
+        file,
+      };
+    });
 
     setImageFiles((prev) => {
       const updatedFiles = isMultiple
@@ -81,12 +87,14 @@ export function FormImage({
   };
 
   useEffect(() => {
+    const urlsToRevoke = objectUrls.current;
+
     return () => {
-      imageFiles.forEach((image) => {
-        URL.revokeObjectURL(image.url);
+      urlsToRevoke.forEach((url) => {
+        URL.revokeObjectURL(url);
       });
     };
-  }, [imageFiles]);
+  }, []);
 
   return (
     <div className="flex w-full flex-col gap-4">

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -121,10 +121,10 @@ export function FormImage({
     <div className="flex w-full flex-col gap-4">
       <div className="grid w-full grid-cols-3 gap-3 md:grid-cols-5 2xl:gap-3.5">
         <AddImageButton
-          id={inputId}
           errorId={errorId}
           errorMessage={errorMessage}
           disabled={isMaxReached}
+          inputRef={inputRef}
           onDisabledClick={() => {
             showToast({
               theme: 'error',

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -109,10 +109,8 @@ export function FormImage({
   };
 
   useEffect(() => {
-    const urlsToRevoke = objectUrls.current;
-
     return () => {
-      urlsToRevoke.forEach((url) => {
+      objectUrls.current.forEach((url) => {
         URL.revokeObjectURL(url);
       });
     };

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -32,16 +32,33 @@ export function FormImage({
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files ? Array.from(e.target.files) : null;
-    if (!files) return;
+    if (!files || files.length === 0) return;
 
-    const newImageFiles = files.map((file) => {
+    let filesToAdd = files;
+    const remaining = MAX_IMAGE_COUNT - imageFiles.length;
+
+    if (isMultiple && remaining <= 0) {
+      showToast({
+        theme: 'error',
+        message: `이미지는 최대 ${MAX_IMAGE_COUNT}장까지만 등록 가능합니다.`,
+      });
+      if (inputRef.current) inputRef.current.value = '';
+      return;
+    }
+
+    if (isMultiple && files.length > remaining) {
+      showToast({
+        theme: 'error',
+        message: `${remaining}장만 추가되었습니다. 이미지는 최대 ${MAX_IMAGE_COUNT}장까지 등록 가능합니다.`,
+      });
+      filesToAdd = files.slice(0, remaining);
+    }
+
+    const newImageFiles = filesToAdd.map((file) => {
       const url = URL.createObjectURL(file);
       objectUrls.current.push(url);
       return {
-        id:
-          typeof crypto !== 'undefined' && crypto.randomUUID
-            ? crypto.randomUUID()
-            : Math.random().toString(36).substring(2, 11),
+        id: crypto.randomUUID(),
         url,
         file,
       };
@@ -56,7 +73,7 @@ export function FormImage({
 
     const updatedFiles = isMultiple
       ? [...imageFiles, ...newImageFiles]
-      : [...newImageFiles];
+      : newImageFiles;
 
     setImageFiles(updatedFiles);
     onChange?.(
@@ -67,10 +84,10 @@ export function FormImage({
   };
 
   const handleImageDelete = (deleteImageId: string) => {
+    const deletedImage = imageFiles.find((image) => image.id === deleteImageId);
     const filteredFiles = imageFiles.filter(
       (image) => image.id !== deleteImageId
     );
-    const deletedImage = imageFiles.find((image) => image.id === deleteImageId);
 
     if (deletedImage) {
       URL.revokeObjectURL(deletedImage.url);

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -28,19 +28,11 @@ export function FormImage({
   const generatedId = useId();
   const inputId = id ?? generatedId;
   const errorId = `${inputId}-error`;
+  const isMaxReached = isMultiple && imageFiles.length >= MAX_IMAGE_COUNT;
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files ? Array.from(e.target.files) : null;
     if (!files) return;
-
-    if (isMultiple && imageFiles.length + files.length > MAX_IMAGE_COUNT) {
-      showToast({
-        theme: 'error',
-        message: '이미지는 최대 4장까지만 등록 가능합니다.',
-      });
-      if (inputRef.current) inputRef.current.value = '';
-      return;
-    }
 
     const newImageFiles = files.map((file) => {
       const url = URL.createObjectURL(file);
@@ -112,6 +104,13 @@ export function FormImage({
           id={inputId}
           errorId={errorId}
           errorMessage={errorMessage}
+          disabled={isMaxReached}
+          onClick={() => {
+            showToast({
+              theme: 'error',
+              message: `이미지는 최대 ${MAX_IMAGE_COUNT}장까지만 등록 가능합니다.`,
+            });
+          }}
         />
         <input
           type="file"

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useId, useRef, useState } from 'react';
+import { FormImageProps } from '@/app/(main)/activity/components/form-image/FormImage.types';
+import { FormImagePreview } from '@/app/(main)/activity/components/form-image-preview';
+import { AddImageButton } from '@/shared/components/buttons';
+import { useShowToast } from '@/shared/store/useToastStore';
+
+export function FormImage({
+  id,
+  errorMessage,
+  isMultiple = false,
+  onChange,
+  ...props
+}: FormImageProps) {
+  const [imageFiles, setImageFiles] = useState<
+    Array<{ id: string; url: string; file: File }>
+  >([]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const showToast = useShowToast();
+
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const errorId = `${inputId}-error`;
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : null;
+    if (!files) return;
+
+    if (isMultiple && imageFiles.length + files.length > 4) {
+      showToast({
+        theme: 'error',
+        message: '이미지는 최대 4장까지만 등록 가능합니다.',
+      });
+      if (inputRef.current) inputRef.current.value = '';
+      return;
+    }
+
+    const newImageFiles = files.map((file) => ({
+      id: `${file.name} - ${Date.now()}`,
+      url: URL.createObjectURL(file),
+      file: file,
+    }));
+
+    setImageFiles((prev) => {
+      const updatedFiles = isMultiple
+        ? [...prev, ...newImageFiles]
+        : [...newImageFiles];
+
+      onChange?.(
+        isMultiple
+          ? updatedFiles.map((item) => item.file)
+          : updatedFiles[0].file
+      );
+      return updatedFiles;
+    });
+
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  const handleImageDelete = (deleteImageId: string) => {
+    setImageFiles((prev) => {
+      const filteredFiles = prev.filter((image) => image.id !== deleteImageId);
+
+      const deletedImage = prev.find((image) => image.id === deleteImageId);
+      if (deletedImage) URL.revokeObjectURL(deletedImage.url);
+
+      onChange?.(
+        isMultiple
+          ? filteredFiles.map((item) => item.file)
+          : filteredFiles[0]?.file || null
+      );
+
+      return filteredFiles;
+    });
+
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      imageFiles.forEach((image) => {
+        URL.revokeObjectURL(image.url);
+      });
+    };
+  }, [imageFiles]);
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="grid h-31.5 w-full grid-cols-5 gap-3 2xl:gap-3.5">
+        <AddImageButton
+          id={inputId}
+          errorId={errorId}
+          errorMessage={errorMessage}
+        />
+        <input
+          type="file"
+          id={inputId}
+          className="hidden"
+          accept="image/*"
+          onChange={handleImageChange}
+          ref={inputRef}
+          multiple={isMultiple}
+          {...props}
+        />
+        {imageFiles &&
+          imageFiles.map((image) => (
+            <div className="relative aspect-square w-full" key={image.id}>
+              <FormImagePreview
+                imageUrl={image.url}
+                imageId={image.id}
+                onImageDelete={handleImageDelete}
+              />
+            </div>
+          ))}
+      </div>
+
+      {errorMessage && (
+        <p id={errorId} className="typo-lg-regular text-error">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/activity/components/form-image/index.tsx
+++ b/src/app/(main)/activity/components/form-image/index.tsx
@@ -109,7 +109,7 @@ export function FormImage({
           errorId={errorId}
           errorMessage={errorMessage}
           disabled={isMaxReached}
-          onClick={() => {
+          onDisabledClick={() => {
             showToast({
               theme: 'error',
               message: `이미지는 최대 ${MAX_IMAGE_COUNT}장까지만 등록 가능합니다.`,

--- a/src/app/(main)/activity/components/form-title/index.tsx
+++ b/src/app/(main)/activity/components/form-title/index.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@/shared/components/heading';
 
-export function ActivityFormTitle({ children }: { children: React.ReactNode }) {
+export function FormTitle({ children }: { children: React.ReactNode }) {
   return (
     <Heading as="h3" textStyle="typo-lg-bold" className="mb-4.5">
       {children}

--- a/src/shared/components/buttons/add-image-button/index.tsx
+++ b/src/shared/components/buttons/add-image-button/index.tsx
@@ -1,38 +1,47 @@
 'use client';
 
-import { ButtonHTMLAttributes } from 'react';
 import { IcPlus } from '@/shared/assets/icons';
 import { cn } from '@/shared/utils/cn';
 
-export type AddImageButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+export interface AddImageButtonProps {
+  id: string;
+  errorId?: string;
+  errorMessage?: string;
+  className?: string;
+}
 
 /**
  * 이미지 등록 영역에 사용하는 정사각형 버튼
  *
- * 반응형으로만 작동: 기본 80×80 → md 이상 128×128
- *
  * @example
- * <AddImageButton onClick={openFilePicker} />
+ * <AddImageButton id={id} errorId={errorId} errorMessage={errorMessage} />
  */
-export function AddImageButton({ className, ...rest }: AddImageButtonProps) {
+export function AddImageButton({
+  id,
+  errorId,
+  errorMessage,
+  className,
+}: AddImageButtonProps) {
   return (
-    <button
-      type="button"
+    <label
+      aria-label="이미지 업로드"
+      aria-invalid={Boolean(errorMessage)}
+      aria-describedby={errorMessage ? errorId : undefined}
+      htmlFor={id}
       className={cn(
-        'group inline-flex cursor-pointer flex-col items-center justify-center',
+        'group flex cursor-pointer flex-col items-center justify-center',
+        'aspect-square w-full gap-1 md:gap-2',
         'rounded-2xl border border-gray-100 bg-white',
-        'transition-colors duration-200 hover:border-gray-300',
-        'h-20 w-20 gap-1 md:h-32 md:w-32 md:gap-2',
+        'text-gray-400 transition-colors duration-200 hover:border-gray-300 hover:text-gray-600',
         className
       )}
-      {...rest}
     >
-      <span className="block h-7.5 w-7.5 shrink-0 text-gray-400 transition-colors duration-200 group-hover:text-gray-600 md:h-10 md:w-10">
-        <IcPlus width="100%" height="100%" style={{ display: 'block' }} />
+      <span className="flex h-7.5 w-7.5 shrink-0 items-center justify-center md:h-10 md:w-10">
+        <IcPlus className="h-3.75 w-3.75 md:h-5 md:w-5" />
       </span>
-      <span className="md:text-md text-xs leading-4 font-medium text-gray-400 transition-colors duration-200 group-hover:text-gray-600">
+      <span className="md:text-md text-xs leading-4 font-medium">
         이미지 등록
       </span>
-    </button>
+    </label>
   );
 }

--- a/src/shared/components/buttons/add-image-button/index.tsx
+++ b/src/shared/components/buttons/add-image-button/index.tsx
@@ -39,7 +39,7 @@ export function AddImageButton({
       <span className="flex h-7.5 w-7.5 shrink-0 items-center justify-center md:h-10 md:w-10">
         <IcPlus className="h-3.75 w-3.75 md:h-5 md:w-5" />
       </span>
-      <span className="md:text-md text-xs leading-4 font-medium">
+      <span className="typo-xs-medium md:typo-md-medium leading-4">
         이미지 등록
       </span>
     </label>

--- a/src/shared/components/buttons/add-image-button/index.tsx
+++ b/src/shared/components/buttons/add-image-button/index.tsx
@@ -8,6 +8,8 @@ export interface AddImageButtonProps {
   errorId?: string;
   errorMessage?: string;
   className?: string;
+  disabled?: boolean;
+  onClick?: () => void;
 }
 
 /**
@@ -21,18 +23,29 @@ export function AddImageButton({
   errorId,
   errorMessage,
   className,
+  disabled,
+  onClick,
 }: AddImageButtonProps) {
   return (
     <label
       aria-label="이미지 업로드"
       aria-invalid={Boolean(errorMessage)}
       aria-describedby={errorMessage ? errorId : undefined}
-      htmlFor={id}
+      htmlFor={disabled ? undefined : id}
+      onClick={(e) => {
+        if (disabled) {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
       className={cn(
         'group flex cursor-pointer flex-col items-center justify-center',
         'aspect-square w-full gap-1 md:gap-2',
         'rounded-2xl border border-gray-100 bg-white',
         'text-gray-400 transition-colors duration-200 hover:border-gray-300 hover:text-gray-600',
+        disabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer text-gray-400 hover:border-gray-300 hover:text-gray-600',
         className
       )}
     >

--- a/src/shared/components/buttons/add-image-button/index.tsx
+++ b/src/shared/components/buttons/add-image-button/index.tsx
@@ -4,12 +4,12 @@ import { IcPlus } from '@/shared/assets/icons';
 import { cn } from '@/shared/utils/cn';
 
 export interface AddImageButtonProps {
-  id: string;
   errorId?: string;
   errorMessage?: string;
   className?: string;
   disabled?: boolean;
   onDisabledClick?: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
 }
 
 /**
@@ -19,23 +19,23 @@ export interface AddImageButtonProps {
  * <AddImageButton id={id} errorId={errorId} errorMessage={errorMessage} />
  */
 export function AddImageButton({
-  id,
   errorId,
   errorMessage,
   className,
   disabled,
   onDisabledClick,
+  inputRef,
 }: AddImageButtonProps) {
   return (
-    <label
-      aria-label="이미지 업로드"
-      aria-invalid={Boolean(errorMessage)}
+    <button
+      type="button"
+      aria-disabled={disabled}
       aria-describedby={errorMessage ? errorId : undefined}
-      htmlFor={disabled ? undefined : id}
-      onClick={(e) => {
+      onClick={() => {
         if (disabled) {
-          e.preventDefault();
           onDisabledClick?.();
+        } else {
+          inputRef.current?.click();
         }
       }}
       className={cn(
@@ -55,6 +55,6 @@ export function AddImageButton({
       <span className="typo-xs-medium md:typo-md-medium leading-4">
         이미지 등록
       </span>
-    </label>
+    </button>
   );
 }

--- a/src/shared/components/buttons/add-image-button/index.tsx
+++ b/src/shared/components/buttons/add-image-button/index.tsx
@@ -9,7 +9,7 @@ export interface AddImageButtonProps {
   errorMessage?: string;
   className?: string;
   disabled?: boolean;
-  onClick?: () => void;
+  onDisabledClick?: () => void;
 }
 
 /**
@@ -24,7 +24,7 @@ export function AddImageButton({
   errorMessage,
   className,
   disabled,
-  onClick,
+  onDisabledClick,
 }: AddImageButtonProps) {
   return (
     <label
@@ -35,17 +35,17 @@ export function AddImageButton({
       onClick={(e) => {
         if (disabled) {
           e.preventDefault();
-          onClick?.();
+          onDisabledClick?.();
         }
       }}
       className={cn(
-        'group flex cursor-pointer flex-col items-center justify-center',
+        'group flex flex-col items-center justify-center',
         'aspect-square w-full gap-1 md:gap-2',
-        'rounded-2xl border border-gray-100 bg-white',
-        'text-gray-400 transition-colors duration-200 hover:border-gray-300 hover:text-gray-600',
+        'rounded-2xl border border-gray-100 bg-white text-gray-400',
+        'transition-colors duration-200',
         disabled
           ? 'cursor-not-allowed opacity-50'
-          : 'cursor-pointer text-gray-400 hover:border-gray-300 hover:text-gray-600',
+          : 'cursor-pointer hover:border-gray-300 hover:text-gray-600',
         className
       )}
     >

--- a/src/shared/store/useToastStore.ts
+++ b/src/shared/store/useToastStore.ts
@@ -11,10 +11,7 @@ const useToastStore = create(
     combine({ toasts: [] as ToastData[] }, (set) => ({
       actions: {
         showToast: (params: Omit<ToastData, 'id'>) => {
-          const id =
-            typeof crypto !== 'undefined' && crypto.randomUUID
-              ? crypto.randomUUID()
-              : Math.random().toString(36).substring(2, 11);
+          const id = crypto.randomUUID();
           const newToast = {
             ...params,
             id,

--- a/src/shared/store/useToastStore.ts
+++ b/src/shared/store/useToastStore.ts
@@ -3,6 +3,7 @@ import { combine } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { MAX_TOASTS } from '@/shared/components/toast/toast.constants';
 import { ToastProps } from '@/shared/components/toast/toast.types';
+import { generateId } from '@/shared/utils/generateId';
 
 type ToastData = Omit<ToastProps, 'onClose'>;
 
@@ -11,7 +12,7 @@ const useToastStore = create(
     combine({ toasts: [] as ToastData[] }, (set) => ({
       actions: {
         showToast: (params: Omit<ToastData, 'id'>) => {
-          const id = crypto.randomUUID();
+          const id = generateId();
           const newToast = {
             ...params,
             id,

--- a/src/shared/utils/generateId.ts
+++ b/src/shared/utils/generateId.ts
@@ -1,0 +1,10 @@
+/**
+ * 범용 고유 ID 생성 함수
+ * @returns crypto.randomUUID() 기반 UUID 문자열, 미지원 환경에서는 랜덤 문자열
+ */
+export const generateId = () => {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).substring(2, 11)
+  );
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #107 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

내 체험 등록 페이지의 `배너 이미지 등록`, `소개 이미지 등록` 에서 사용할 이미지 등록 컴포넌트 추가
- 배너 이미지 등록은 1장만 등록할 수 있도록 설정
- 소개 이미지 등록은 Swagger 문서 참고하여 최대 4장까지만 등록할 수 있도록 설정
- 이미지 선택 시 프리뷰 기능 추가
- 프리뷰에서 이미지 삭제 기능 추가

그 외, `crypto` 로직의 경우 최신 버전에는 폴백이 불필요하다는 말을 보아 폴백 동작은 삭제하였습니다.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
