### PR TITLE
[Fix/#140] 예약 Status 실제 API Status와 글씨 통일

### DIFF
--- a/src/app/(main)/my/reservations/components/reserve-filter/reserveFilter.constants.ts
+++ b/src/app/(main)/my/reservations/components/reserve-filter/reserveFilter.constants.ts
@@ -1,9 +1,9 @@
 import { ReservationStatus } from '@/shared/constants/status.constants';
 
 export const FILTER_ORDER: ReservationStatus[] = [
-  'confirmed',
-  'canceled',
   'pending',
+  'canceled',
+  'confirmed',
   'declined',
   'completed',
 ];

--- a/src/shared/components/status-badge/index.tsx
+++ b/src/shared/components/status-badge/index.tsx
@@ -26,8 +26,8 @@ const badgeStyle = cva(
  * 상태값(`status`)에 따라 사전에 정의된 배경색과 텍스트 색상이 자동으로 매핑됩니다.
  *
  * @example
- * // (예: '예약 완료' 뱃지)
- * <StatusBadge status="pending" />
+ * // (예: '예약 승인' 뱃지)
+ * <StatusBadge status="confirmed" />
  */
 export function StatusBadge({ status, className }: StatusBadgeProps) {
   return (

--- a/src/shared/constants/status.constants.ts
+++ b/src/shared/constants/status.constants.ts
@@ -1,9 +1,9 @@
 export const STATUS_TEXT = {
-  canceled: '예약 취소',
-  pending: '예약 완료',
-  declined: '예약 거절',
-  completed: '체험 완료',
+  pending: '예약 신청',
   confirmed: '예약 승인',
+  declined: '예약 거절',
+  canceled: '예약 취소',
+  completed: '체험 완료',
 } as const;
 
 export type ReservationStatus = keyof typeof STATUS_TEXT;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #140 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

디자인이 잘못되어 있어 페이지 상 `pending` 상태의 Status 글자와 API Status가 안 맞는 현상 발견
Swagger와 디자인 시안 두 가지를 모두 참고하여 맞는 글자로 재수정

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
