### PR TITLE
[Feat/#57] Footer 공통 컴포넌트 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,3 +1,5 @@
+import { Footer } from '@/shared/components/footer';
+
 type MainLayoutProps = Readonly<{
   children: React.ReactNode;
 }>;
@@ -14,10 +16,8 @@ export default function MainLayout({ children }: MainLayoutProps) {
           {children}
         </main>
       </div>
-      {/* TODO: 푸터 작업 */}
-      <footer className="bg-primary-50 flex h-20 shrink-0 items-center px-4">
-        Footer
-      </footer>
+
+      <Footer />
     </>
   );
 }

--- a/src/shared/components/footer/footer.constants.ts
+++ b/src/shared/components/footer/footer.constants.ts
@@ -1,0 +1,4 @@
+export const FOOTER_COPYRIGHT_TEXT = '© 2026 Codeit Sprint 22 Team 2';
+
+export const FOOTER_GITHUB_URL =
+  'https://github.com/anarose314/sprint-team2-globalnomad';

--- a/src/shared/components/footer/index.tsx
+++ b/src/shared/components/footer/index.tsx
@@ -1,0 +1,35 @@
+import { IcGithub } from '@/shared/assets/icons';
+import {
+  FOOTER_COPYRIGHT_TEXT,
+  FOOTER_GITHUB_URL,
+} from '@/shared/components/footer/footer.constants';
+
+/**
+ * 메인 페이지 공통 Footer 컴포넌트
+ *
+ * - 서비스 하단에 저작권 문구와 팀 GitHub 저장소 링크를 표시한다.
+ *
+ * @example
+ * <Footer />
+ */
+export function Footer() {
+  return (
+    <footer className="h-20 shrink-0 border-t border-gray-50 bg-white">
+      <div className="mx-auto flex h-full w-full max-w-380 min-w-0 items-center justify-between gap-4 px-4 md:px-10 2xl:px-0">
+        <p className="typo-md-medium truncate text-gray-500">
+          {FOOTER_COPYRIGHT_TEXT}
+        </p>
+
+        <a
+          href={FOOTER_GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="팀 GitHub 저장소 새 탭에서 열기"
+          className="flex h-8 w-8 shrink-0 items-center justify-center"
+        >
+          <IcGithub className="h-6 w-6 text-gray-600" aria-hidden="true" />
+        </a>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #57 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 메인 라우트 그룹에서 사용하는 Footer 공통 컴포넌트를 구현했습니다.
- Footer 왼쪽에 '© 2026 Codeit Sprint 22 Team 2' 문구를 표시했습니다.
- Footer 오른쪽에는 GitHub 아이콘 링크를 배치했습니다.
- GitHub 아이콘 클릭 시 팀 GitHub 저장소로 새 탭 이동되도록 구현했습니다.
- (main)/layout.tsx에 Footer를 연결했습니다.


### 스크린샷 (선택)
<img width="1110" height="682" alt="스크린샷 2026-05-05 오전 2 54 05" src="https://github.com/user-attachments/assets/aad13d8b-8177-41a0-9843-5d9f82c25731" />

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
