### PR TITLE
[Fix/#157] 공통 드롭다운 수정

### DIFF
--- a/src/app/(main)/activity/components/activity-form/index.tsx
+++ b/src/app/(main)/activity/components/activity-form/index.tsx
@@ -26,7 +26,6 @@ export function ActivityForm({ children, onSubmit }: ActivityFormProps) {
         />
         <Dropdown
           label="카테고리"
-          name="category"
           options={CATEGORY_OPTIONS}
           value={category}
           placeholder="카테고리를 선택해 주세요"

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -17,6 +17,16 @@
 
   /* BreakPoint */
   --breakpoint-xs: 375px;
+
+  /* Focus ring */
+  --color-ring: var(--color-primary-500);
+}
+
+@layer base {
+  /* 키보드 포커스 outline 색상 */
+  :focus-visible {
+    outline-color: var(--color-primary-500);
+  }
 }
 
 /* Skeleton shimmer animation */

--- a/src/shared/components/dropdown/dropdown.constants.ts
+++ b/src/shared/components/dropdown/dropdown.constants.ts
@@ -10,9 +10,7 @@ export const FIELD_INPUT_FOCUS_CLASS = cn(
   'border-primary-500 ring-primary-500 ring-1'
 );
 
-export const FIELD_INPUT_ERROR_FOCUS_CLASS = cn(
-  'border-red-500 ring-1 ring-red-500'
-);
+export const FIELD_INPUT_ERROR_FOCUS_CLASS = cn('border-red-500 ring-red-500');
 
 export const TRIGGER_VARIANT_CLASS: Record<DropdownVariant, string> = {
   field: cn(

--- a/src/shared/components/dropdown/dropdown.constants.ts
+++ b/src/shared/components/dropdown/dropdown.constants.ts
@@ -1,16 +1,30 @@
 import type { DropdownVariant } from '@/shared/components/dropdown/dropdown.types';
+import { INPUT_STYLE } from '@/shared/components/input/input.constants';
+import { cn } from '@/shared/utils/cn';
 
 export const DEFAULT_OPTION_HEIGHT = 54;
 
 export const DEFAULT_MAX_VISIBLE_OPTIONS = 5;
 
+export const FIELD_INPUT_FOCUS_CLASS = cn(
+  'border-primary-500 ring-primary-500 ring-1'
+);
+
 export const TRIGGER_VARIANT_CLASS: Record<DropdownVariant, string> = {
-  field:
-    'h-14 w-full rounded-2xl border border-gray-300 bg-white px-5 typo-lg-medium text-gray-950',
-  chip: 'h-10 w-22 rounded-lg border border-gray-100 bg-white pl-4 pr-2.5 py-2.5 typo-lg-medium text-gray-950',
+  field: cn(
+    'h-14 w-full justify-between gap-3 rounded-2xl border border-gray-300 bg-white px-5 text-gray-950'
+  ),
+  fieldInput: cn(INPUT_STYLE, 'justify-between gap-3'),
+  chip: cn(
+    'h-10 w-22 justify-center gap-1.5 rounded-lg border border-gray-100 bg-white py-2.5 pr-2.5 pl-4 text-gray-950'
+  ),
 };
 
 export const MENU_VARIANT_CLASS: Record<DropdownVariant, string> = {
   field: 'w-full rounded-b-2xl border border-t-0 border-gray-300',
-  chip: 'min-w-36 rounded-lg border border-gray-100',
+  fieldInput: cn(
+    'w-full rounded-b-2xl border border-t-0',
+    FIELD_INPUT_FOCUS_CLASS
+  ),
+  chip: cn('min-w-36 rounded-lg border border-gray-100'),
 };

--- a/src/shared/components/dropdown/dropdown.constants.ts
+++ b/src/shared/components/dropdown/dropdown.constants.ts
@@ -10,6 +10,10 @@ export const FIELD_INPUT_FOCUS_CLASS = cn(
   'border-primary-500 ring-primary-500 ring-1'
 );
 
+export const FIELD_INPUT_ERROR_FOCUS_CLASS = cn(
+  'border-red-500 ring-1 ring-red-500'
+);
+
 export const TRIGGER_VARIANT_CLASS: Record<DropdownVariant, string> = {
   field: cn(
     'h-14 w-full justify-between gap-3 rounded-2xl border-gray-300 px-5'

--- a/src/shared/components/dropdown/dropdown.constants.ts
+++ b/src/shared/components/dropdown/dropdown.constants.ts
@@ -12,19 +12,16 @@ export const FIELD_INPUT_FOCUS_CLASS = cn(
 
 export const TRIGGER_VARIANT_CLASS: Record<DropdownVariant, string> = {
   field: cn(
-    'h-14 w-full justify-between gap-3 rounded-2xl border border-gray-300 bg-white px-5 text-gray-950'
+    'h-14 w-full justify-between gap-3 rounded-2xl border-gray-300 px-5'
   ),
   fieldInput: cn(INPUT_STYLE, 'justify-between gap-3'),
   chip: cn(
-    'h-10 w-22 justify-center gap-1.5 rounded-lg border border-gray-100 bg-white py-2.5 pr-2.5 pl-4 text-gray-950'
+    'h-10 w-22 justify-center gap-1.5 rounded-lg border-gray-100 py-2.5 pr-2.5 pl-4'
   ),
 };
 
 export const MENU_VARIANT_CLASS: Record<DropdownVariant, string> = {
-  field: 'w-full rounded-b-2xl border border-t-0 border-gray-300',
-  fieldInput: cn(
-    'w-full rounded-b-2xl border border-t-0',
-    FIELD_INPUT_FOCUS_CLASS
-  ),
-  chip: cn('min-w-36 rounded-lg border border-gray-100'),
+  field: cn('w-full rounded-b-2xl border-t-0 border-gray-300'),
+  fieldInput: cn('w-full rounded-b-2xl border-t-0', FIELD_INPUT_FOCUS_CLASS),
+  chip: cn('min-w-36 rounded-lg border-gray-100'),
 };

--- a/src/shared/components/dropdown/dropdown.types.ts
+++ b/src/shared/components/dropdown/dropdown.types.ts
@@ -1,5 +1,4 @@
-export type DropdownVariant = 'field' | 'chip';
-
+export type DropdownVariant = 'field' | 'fieldInput' | 'chip';
 export interface DropdownOption {
   label: string;
   value: string;

--- a/src/shared/components/dropdown/dropdown.types.ts
+++ b/src/shared/components/dropdown/dropdown.types.ts
@@ -18,5 +18,5 @@ export interface DropdownProps {
   menuClassName?: string;
   onChange: (value: string, option: DropdownOption) => void;
   label?: string;
-  name?: string;
+  errorMessage?: string;
 }

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -5,6 +5,7 @@ import { IcArrowDown } from '@/shared/assets/icons';
 import {
   DEFAULT_MAX_VISIBLE_OPTIONS,
   DEFAULT_OPTION_HEIGHT,
+  FIELD_INPUT_ERROR_FOCUS_CLASS,
   FIELD_INPUT_FOCUS_CLASS,
   MENU_VARIANT_CLASS,
   TRIGGER_VARIANT_CLASS,
@@ -144,7 +145,10 @@ export function Dropdown({
           // 추가 상태
           isOpen && isFieldVariant && 'rounded-b-none',
           isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS,
-          errorMessage && INPUT_ERROR_STYLE
+          errorMessage && INPUT_ERROR_STYLE,
+          errorMessage &&
+            variant === 'fieldInput' &&
+            FIELD_INPUT_ERROR_FOCUS_CLASS
         )}
         onClick={handleToggle}
       >
@@ -176,7 +180,11 @@ export function Dropdown({
             'z-dropdown absolute top-full left-0 overflow-y-auto border bg-white',
             // 상수 파일의 디자인 및 커스텀 클래스
             MENU_VARIANT_CLASS[variant],
-            menuClassName
+            menuClassName,
+            // 추가 상태
+            errorMessage &&
+              variant === 'fieldInput' &&
+              FIELD_INPUT_ERROR_FOCUS_CLASS
           )}
           style={{ maxHeight: menuMaxHeight }}
         >

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -13,7 +13,11 @@ import type {
   DropdownOption,
   DropdownProps,
 } from '@/shared/components/dropdown/dropdown.types';
-import { INPUT_LABEL_STYLE } from '@/shared/components/input/input.constants';
+import {
+  INPUT_ERROR_MESSAGE_STYLE,
+  INPUT_ERROR_STYLE,
+  INPUT_LABEL_STYLE,
+} from '@/shared/components/input/input.constants';
 import { cn } from '@/shared/utils/cn';
 
 /**
@@ -36,7 +40,6 @@ import { cn } from '@/shared/utils/cn';
  */
 export function Dropdown({
   label,
-  name,
   options,
   value,
   placeholder = '선택해주세요',
@@ -47,6 +50,7 @@ export function Dropdown({
   className,
   triggerClassName,
   menuClassName,
+  errorMessage,
   onChange,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -118,7 +122,6 @@ export function Dropdown({
         className
       )}
     >
-      <input type="hidden" name={name} value={value} />
       {label && (
         <label htmlFor={buttonId} className={cn(INPUT_LABEL_STYLE, 'block')}>
           {label}
@@ -140,7 +143,8 @@ export function Dropdown({
           triggerClassName,
           // 추가 상태
           isOpen && isFieldVariant && 'rounded-b-none',
-          isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS
+          isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS,
+          errorMessage && INPUT_ERROR_STYLE
         )}
         onClick={handleToggle}
       >
@@ -203,6 +207,10 @@ export function Dropdown({
             );
           })}
         </ul>
+      )}
+
+      {errorMessage && (
+        <p className={INPUT_ERROR_MESSAGE_STYLE}>{errorMessage}</p>
       )}
     </div>
   );

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -210,7 +210,9 @@ export function Dropdown({
       )}
 
       {errorMessage && (
-        <p className={INPUT_ERROR_MESSAGE_STYLE}>{errorMessage}</p>
+        <p className={cn(INPUT_ERROR_MESSAGE_STYLE, 'absolute top-full')}>
+          {errorMessage}
+        </p>
       )}
     </div>
   );

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -115,112 +115,112 @@ export function Dropdown({
   }, [isOpen]);
 
   return (
-    <div
-      ref={dropdownRef}
-      className={cn(
-        'relative',
-        isFieldVariant ? 'w-full' : 'inline-block',
-        className
-      )}
-    >
-      {label && (
-        <label htmlFor={buttonId} className={cn(INPUT_LABEL_STYLE, 'block')}>
-          {label}
-        </label>
-      )}
-      <button
-        id={buttonId}
-        type="button"
-        disabled={isDisabled}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-controls={isOpen ? listboxId : undefined}
+    <div>
+      <div
+        ref={dropdownRef}
         className={cn(
-          // 공통 필수 속성 및 비활성화 상태
-          'typo-lg-medium flex cursor-pointer items-center border bg-white text-gray-950 transition-colors',
-          'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
-          // 상수 파일의 디자인 및 커스텀 클래스
-          TRIGGER_VARIANT_CLASS[variant],
-          triggerClassName,
-          // 추가 상태
-          isOpen && isFieldVariant && 'rounded-b-none',
-          isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS,
-          errorMessage && INPUT_ERROR_STYLE,
-          errorMessage &&
-            variant === 'fieldInput' &&
-            FIELD_INPUT_ERROR_FOCUS_CLASS
+          'relative',
+          isFieldVariant ? 'w-full' : 'inline-block',
+          className
         )}
-        onClick={handleToggle}
       >
-        <span
-          className={cn(
-            variant === 'chip' ? 'shrink-0 whitespace-nowrap' : 'truncate',
-            isPlaceholder && 'text-gray-400'
-          )}
-        >
-          {triggerLabel}
-        </span>
-
-        <IcArrowDown
-          aria-hidden="true"
-          className={cn(
-            'shrink-0 transition-transform',
-            variant === 'chip' ? 'size-5' : 'size-6',
-            isOpen && 'rotate-180'
-          )}
-        />
-      </button>
-
-      {isOpen && (
-        <ul
-          id={listboxId}
-          role="listbox"
+        {label && (
+          <label htmlFor={buttonId} className={cn(INPUT_LABEL_STYLE, 'block')}>
+            {label}
+          </label>
+        )}
+        <button
+          id={buttonId}
+          type="button"
+          disabled={isDisabled}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? listboxId : undefined}
           className={cn(
             // 공통 필수 속성 및 비활성화 상태
-            'z-dropdown absolute top-full left-0 overflow-y-auto border bg-white',
+            'typo-lg-medium flex cursor-pointer items-center border bg-white text-gray-950 transition-colors',
+            'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
             // 상수 파일의 디자인 및 커스텀 클래스
-            MENU_VARIANT_CLASS[variant],
-            menuClassName,
+            TRIGGER_VARIANT_CLASS[variant],
+            triggerClassName,
             // 추가 상태
-            errorMessage &&
+            isOpen && isFieldVariant && 'rounded-b-none',
+            isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS,
+            errorMessage && INPUT_ERROR_STYLE,
+            isOpen &&
+              errorMessage &&
               variant === 'fieldInput' &&
               FIELD_INPUT_ERROR_FOCUS_CLASS
           )}
-          style={{ maxHeight: menuMaxHeight }}
+          onClick={handleToggle}
         >
-          {options.map((option) => {
-            const isSelected = option.value === value;
-            const isOptionDisabled = option.disabled;
+          <span
+            className={cn(
+              variant === 'chip' ? 'shrink-0 whitespace-nowrap' : 'truncate',
+              isPlaceholder && 'text-gray-400'
+            )}
+          >
+            {triggerLabel}
+          </span>
 
-            return (
-              <li key={option.value}>
-                <button
-                  type="button"
-                  role="option"
-                  disabled={isOptionDisabled}
-                  aria-selected={isSelected}
-                  className={cn(
-                    'typo-lg-medium flex w-full cursor-pointer items-center px-5 text-left text-gray-950 transition-colors',
-                    'hover:bg-primary-100 hover:text-primary-500',
-                    isSelected && 'bg-primary-100 text-primary-500',
-                    isOptionDisabled &&
-                      'cursor-not-allowed text-gray-400 hover:bg-white hover:text-gray-400'
-                  )}
-                  style={{ height: optionHeight }}
-                  onClick={() => handleOptionClick(option)}
-                >
-                  <span className="truncate">{option.label}</span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+          <IcArrowDown
+            aria-hidden="true"
+            className={cn(
+              'shrink-0 transition-transform',
+              variant === 'chip' ? 'size-5' : 'size-6',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </button>
 
+        {isOpen && (
+          <ul
+            id={listboxId}
+            role="listbox"
+            className={cn(
+              // 공통 필수 속성 및 비활성화 상태
+              'z-dropdown absolute top-full left-0 overflow-y-auto border bg-white',
+              // 상수 파일의 디자인 및 커스텀 클래스
+              MENU_VARIANT_CLASS[variant],
+              menuClassName,
+              // 추가 상태
+              errorMessage &&
+                variant === 'fieldInput' &&
+                FIELD_INPUT_ERROR_FOCUS_CLASS
+            )}
+            style={{ maxHeight: menuMaxHeight }}
+          >
+            {options.map((option) => {
+              const isSelected = option.value === value;
+              const isOptionDisabled = option.disabled;
+
+              return (
+                <li key={option.value}>
+                  <button
+                    type="button"
+                    role="option"
+                    disabled={isOptionDisabled}
+                    aria-selected={isSelected}
+                    className={cn(
+                      'typo-lg-medium flex w-full cursor-pointer items-center px-5 text-left text-gray-950 transition-colors',
+                      'hover:bg-primary-100 hover:text-primary-500',
+                      isSelected && 'bg-primary-100 text-primary-500',
+                      isOptionDisabled &&
+                        'cursor-not-allowed text-gray-400 hover:bg-white hover:text-gray-400'
+                    )}
+                    style={{ height: optionHeight }}
+                    onClick={() => handleOptionClick(option)}
+                  >
+                    <span className="truncate">{option.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
       {errorMessage && (
-        <p className={cn(INPUT_ERROR_MESSAGE_STYLE, 'absolute top-full')}>
-          {errorMessage}
-        </p>
+        <p className={INPUT_ERROR_MESSAGE_STYLE}>{errorMessage}</p>
       )}
     </div>
   );

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -136,7 +136,7 @@ export function Dropdown({
         aria-controls={isOpen ? listboxId : undefined}
         className={cn(
           // 공통 필수 속성 및 비활성화 상태
-          'typo-lg-medium flex cursor-pointer items-center transition-colors',
+          'typo-lg-medium flex cursor-pointer items-center border bg-white text-gray-950 transition-colors',
           'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
           // 상수 파일의 디자인 및 커스텀 클래스
           TRIGGER_VARIANT_CLASS[variant],
@@ -173,7 +173,7 @@ export function Dropdown({
           role="listbox"
           className={cn(
             // 공통 필수 속성 및 비활성화 상태
-            'z-dropdown absolute top-full left-0 overflow-y-auto bg-white',
+            'z-dropdown absolute top-full left-0 overflow-y-auto border bg-white',
             // 상수 파일의 디자인 및 커스텀 클래스
             MENU_VARIANT_CLASS[variant],
             menuClassName

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -5,6 +5,7 @@ import { IcArrowDown } from '@/shared/assets/icons';
 import {
   DEFAULT_MAX_VISIBLE_OPTIONS,
   DEFAULT_OPTION_HEIGHT,
+  FIELD_INPUT_FOCUS_CLASS,
   MENU_VARIANT_CLASS,
   TRIGGER_VARIANT_CLASS,
 } from '@/shared/components/dropdown/dropdown.constants';
@@ -19,6 +20,7 @@ import { cn } from '@/shared/utils/cn';
  * 공통 드롭다운 컴포넌트
  *
  * - `field`: 폼 입력처럼 사용하는 기본 드롭다운입니다.
+ * - `fieldInput`: Input 공통 컴포넌트와 Focus와 disabled를 공유하는 드롭다운입니다.
  * - `chip`: 가격 필터처럼 짧은 트리거 문구를 고정해서 사용하는 드롭다운입니다.
  * - 옵션 선택 시 `onChange`를 통해 선택한 값을 외부로 전달합니다.
  * - 옵션 데이터의 정렬, 필터링, API 연동은 사용하는 쪽에서 담당합니다.
@@ -55,6 +57,7 @@ export function Dropdown({
   const buttonId = `${dropdownId}-button`;
   const selectedOption = options.find((option) => option.value === value);
   const isDisabled = disabled || options.length === 0;
+  const isFieldVariant = variant === 'field' || variant === 'fieldInput';
 
   // 옵션 목록은 기본 5개까지만 노출하고, 초과 시 내부 스크롤됩니다.
   const menuMaxHeight = optionHeight * maxVisibleOptions;
@@ -62,7 +65,7 @@ export function Dropdown({
   const triggerLabel =
     variant === 'chip' ? placeholder : (selectedOption?.label ?? placeholder);
 
-  const isPlaceholder = !selectedOption && variant === 'field';
+  const isPlaceholder = !selectedOption && isFieldVariant;
 
   const handleToggle = () => {
     if (isDisabled) return;
@@ -111,7 +114,7 @@ export function Dropdown({
       ref={dropdownRef}
       className={cn(
         'relative',
-        variant === 'field' ? 'w-full' : 'inline-block',
+        isFieldVariant ? 'w-full' : 'inline-block',
         className
       )}
     >
@@ -129,13 +132,15 @@ export function Dropdown({
         aria-expanded={isOpen}
         aria-controls={isOpen ? listboxId : undefined}
         className={cn(
-          'flex cursor-pointer items-center transition-colors disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
-          variant === 'field'
-            ? 'justify-between gap-3'
-            : 'justify-center gap-1.5',
+          // 공통 필수 속성 및 비활성화 상태
+          'typo-lg-medium flex cursor-pointer items-center transition-colors',
+          'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400',
+          // 상수 파일의 디자인 및 커스텀 클래스
           TRIGGER_VARIANT_CLASS[variant],
-          isOpen && variant === 'field' && 'rounded-b-none',
-          triggerClassName
+          triggerClassName,
+          // 추가 상태
+          isOpen && isFieldVariant && 'rounded-b-none',
+          isOpen && variant === 'fieldInput' && FIELD_INPUT_FOCUS_CLASS
         )}
         onClick={handleToggle}
       >
@@ -163,7 +168,9 @@ export function Dropdown({
           id={listboxId}
           role="listbox"
           className={cn(
+            // 공통 필수 속성 및 비활성화 상태
             'z-dropdown absolute top-full left-0 overflow-y-auto bg-white',
+            // 상수 파일의 디자인 및 커스텀 클래스
             MENU_VARIANT_CLASS[variant],
             menuClassName
           )}

--- a/src/shared/components/input/input.constants.ts
+++ b/src/shared/components/input/input.constants.ts
@@ -6,9 +6,10 @@ export const INPUT_STYLE = cn(
   'focus:border-primary-500 focus:ring-primary-500 focus:ring-1'
 );
 
-export const INPUT_LABEL_STYLE = 'typo-lg-medium mb-2 text-gray-950';
+export const INPUT_LABEL_STYLE = cn('typo-lg-medium mb-2 text-gray-950');
 
-export const INPUT_ERROR_STYLE =
-  'border-red-500 focus:border-red-500 focus:ring-red-500';
+export const INPUT_ERROR_STYLE = cn(
+  'border-red-500 focus:border-red-500 focus:ring-red-500'
+);
 
-export const INPUT_ERROR_MESSAGE_STYLE = 'typo-sm-medium mt-2 text-red-500';
+export const INPUT_ERROR_MESSAGE_STYLE = cn('typo-sm-medium mt-2 text-red-500');

--- a/src/shared/components/input/input.constants.ts
+++ b/src/shared/components/input/input.constants.ts
@@ -1,9 +1,9 @@
 import { cn } from '@/shared/utils/cn';
 
 export const INPUT_STYLE = cn(
-  'typo-lg-medium min-h-13.5 w-full rounded-2xl border bg-white px-5 py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400 focus:ring-1',
+  'typo-lg-medium min-h-13.5 w-full rounded-2xl border border-gray-100 bg-white px-5 py-4 text-gray-950 transition-colors outline-none placeholder:text-gray-400',
   'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
-  'focus:border-primary-500 focus:ring-primary-500 border-gray-100'
+  'focus:border-primary-500 focus:ring-primary-500 focus:ring-1'
 );
 
 export const INPUT_LABEL_STYLE = 'typo-lg-medium mb-2 text-gray-950';


### PR DESCRIPTION
## 🔗 관련 이슈

- close #157 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

### 1. 공통 상수로 뺀 CSS 클래스 리스트 가독성 정렬
다음 문제를 확인하여 수정 대응 완료
- `Input` 및 `Dropdown` 의 클래스 상수에 `cn`이 기재되어 있지 않아 순서 정렬이 되지 않는 문제
- 다른 성격의 클래스가 묶여있어 가독성 저하 문제
- variants의 공통 클래스가 각각 따로 적혀 있는 문제

### 2. Dropdown에 variants 새로 추가
- 등록/수정 폼에 사용하기 위해 현재 기본 variants는 그대로 두고, 인풋 형태와 거의 동일한 형태의 variants를 새로 작성
- 이 variants용 focus 동작 추가

### 3. Dropdown에 에러 메세지 prop 추가
이 과정에서 사용되지 않는 input hidden 필드 삭제 (유효성 검사를 위해 추가했었으나 필요성이 사라짐)

### 4. 전체 focus 컬러 추가
사이트 일관성을 위해 focus 컬러 `primary-500` 적용

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
