### PR TITLE
[Feat/#66] 메인 페이지 모든 체험 목록 API 연동

### DIFF
--- a/src/app/(main)/activity/apis/activities.ts
+++ b/src/app/(main)/activity/apis/activities.ts
@@ -1,0 +1,32 @@
+import type {
+  ActivitiesResponse,
+  FetchActivitiesParams,
+} from '@/app/(main)/activity/apis/activities.types';
+import { fetchInstance } from '@/shared/apis/fetchInstance.core';
+
+/**
+ * 체험 목록을 조회하는 API 함수
+ *
+ * - PR1에서는 모든 체험 목록을 최신순 페이지네이션으로 조회한다.
+ * - 검색, 카테고리, 가격 정렬은 이후 작업에서 파라미터를 확장한다.
+ *
+ * @example
+ * fetchActivities({ method: 'offset', page: 1, size: 6, sort: 'latest' })
+ */
+export const fetchActivities = async ({
+  method,
+  page,
+  size,
+  sort = 'latest',
+}: FetchActivitiesParams) => {
+  return await fetchInstance<ActivitiesResponse>('/activities', {
+    method: 'GET',
+    params: {
+      method,
+      page,
+      size,
+      sort,
+    },
+    cache: 'no-store',
+  });
+};

--- a/src/app/(main)/activity/apis/activities.types.ts
+++ b/src/app/(main)/activity/apis/activities.types.ts
@@ -6,7 +6,7 @@ export interface Activity {
   category: string;
   price: number;
   address: string;
-  bannerImageUrl: string;
+  bannerImageUrl?: string | null;
   rating: number;
   reviewCount: number;
   createdAt: string;

--- a/src/app/(main)/activity/apis/activities.types.ts
+++ b/src/app/(main)/activity/apis/activities.types.ts
@@ -1,0 +1,27 @@
+export interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ActivitiesResponse {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}
+
+export interface FetchActivitiesParams {
+  method: 'offset';
+  page: number;
+  size: number;
+  sort?: 'latest';
+}

--- a/src/app/(main)/activity/hooks/useActivities.ts
+++ b/src/app/(main)/activity/hooks/useActivities.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchActivities } from '@/app/(main)/activity/apis/activities';
+import type { FetchActivitiesParams } from '@/app/(main)/activity/apis/activities.types';
+import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+
+/**
+ * 서버 프리패칭과 클라이언트 훅에서 공통으로 사용하는 체험 목록 쿼리 옵션
+ */
+export const activitiesOptions = (params: FetchActivitiesParams) => ({
+  queryKey: [...QUERY_KEYS.ACTIVITIES, params],
+  queryFn: () => fetchActivities(params),
+});
+
+/**
+ * 메인 페이지 모든 체험 목록 조회 훅
+ *
+ * @example
+ * const { data, isPending, isError } = useActivities({
+ *   method: 'offset',
+ *   page: 1,
+ *   size: 6,
+ *   sort: 'latest',
+ * });
+ */
+export const useActivities = (params: FetchActivitiesParams) => {
+  return useQuery(activitiesOptions(params));
+};

--- a/src/app/(main)/activity/hooks/useActivities.ts
+++ b/src/app/(main)/activity/hooks/useActivities.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useQuery } from '@tanstack/react-query';
 import { fetchActivities } from '@/app/(main)/activity/apis/activities';
 import type { FetchActivitiesParams } from '@/app/(main)/activity/apis/activities.types';

--- a/src/app/(main)/activity/hooks/useActivities.ts
+++ b/src/app/(main)/activity/hooks/useActivities.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { fetchActivities } from '@/app/(main)/activity/apis/activities';
 import type { FetchActivitiesParams } from '@/app/(main)/activity/apis/activities.types';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
@@ -23,5 +23,8 @@ export const activitiesOptions = (params: FetchActivitiesParams) => ({
  * });
  */
 export const useActivities = (params: FetchActivitiesParams) => {
-  return useQuery(activitiesOptions(params));
+  return useQuery({
+    ...activitiesOptions(params),
+    placeholderData: keepPreviousData,
+  });
 };

--- a/src/app/(main)/components/activity-card/activityCard.types.ts
+++ b/src/app/(main)/components/activity-card/activityCard.types.ts
@@ -4,7 +4,7 @@ export interface ActivityCardItem {
   price: number;
   rating: number;
   reviewCount: number;
-  bannerImageUrl: string;
+  bannerImageUrl?: string | null;
 }
 
 export interface ActivityCardProps {

--- a/src/app/(main)/components/activity-card/activityCard.types.ts
+++ b/src/app/(main)/components/activity-card/activityCard.types.ts
@@ -1,5 +1,12 @@
-import type { MainActivity } from '@/app/(main)/main.types';
+export interface ActivityCardItem {
+  id: number;
+  title: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  bannerImageUrl: string;
+}
 
 export interface ActivityCardProps {
-  activity: MainActivity;
+  activity: ActivityCardItem;
 }

--- a/src/app/(main)/components/activity-card/index.tsx
+++ b/src/app/(main)/components/activity-card/index.tsx
@@ -8,12 +8,15 @@ import { Heading } from '@/shared/components/heading';
  * 메인 페이지 체험 카드 컴포넌트
  *
  * - 체험 대표 이미지와 기본 정보를 표시한다.
+ * - 대표 이미지가 없는 경우 기본 배경 영역을 유지한다.
  * - 카드를 클릭하면 체험 상세 페이지로 이동한다.
  *
  * @example
  * <ActivityCard activity={activity} />
  */
 export function ActivityCard({ activity }: ActivityCardProps) {
+  const bannerImageUrl = activity.bannerImageUrl?.trim();
+
   return (
     <Link
       href={`/activity/${activity.id}`}
@@ -22,9 +25,9 @@ export function ActivityCard({ activity }: ActivityCardProps) {
     >
       <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
         <div className="relative aspect-square w-full bg-gray-200">
-          {activity.bannerImageUrl && (
+          {bannerImageUrl && (
             <Image
-              src={activity.bannerImageUrl}
+              src={bannerImageUrl}
               alt={`${activity.title} 대표 이미지`}
               fill
               sizes="(min-width: 1536px) 262px, (min-width: 768px) 33vw, 50vw"

--- a/src/app/(main)/components/activity-card/index.tsx
+++ b/src/app/(main)/components/activity-card/index.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+import Link from 'next/link';
 import type { ActivityCardProps } from '@/app/(main)/components/activity-card/activityCard.types';
 import { IcStar } from '@/shared/assets/icons';
 import { Heading } from '@/shared/components/heading';
@@ -5,47 +7,62 @@ import { Heading } from '@/shared/components/heading';
 /**
  * 메인 페이지 체험 카드 컴포넌트
  *
- * - 체험 이미지 영역과 텍스트 영역을 표시한다.
- * - 텍스트 영역은 이미지 하단부와 겹치며, 겹친 영역은 텍스트 영역이 차지한다.
- * - 현재 UI 단계에서는 이미지 원본이 확정되지 않아 이미지 영역을 placeholder로 표시한다.
+ * - 체험 대표 이미지와 기본 정보를 표시한다.
+ * - 카드를 클릭하면 체험 상세 페이지로 이동한다.
  *
  * @example
  * <ActivityCard activity={activity} />
  */
 export function ActivityCard({ activity }: ActivityCardProps) {
   return (
-    <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
-      <div className="relative aspect-square w-full bg-gray-200" />
-
-      <div className="z-base relative -mt-8.5 flex flex-col justify-between bg-white px-4 pt-3 pb-4.25 md:-mt-15 md:px-5 md:pt-5 md:pb-7.5">
-        <Heading
-          as="h3"
-          textStyle="typo-md-semibold"
-          className="md:typo-lg-semibold truncate text-gray-950"
-        >
-          {activity.title}
-        </Heading>
-
-        <div className="flex items-center gap-1">
-          <IcStar
-            className="h-3.5 w-3.5 shrink-0 text-yellow-500 md:h-4 md:w-4"
-            aria-hidden="true"
-          />
-          <span className="typo-xs-medium md:typo-sm-medium text-gray-950">
-            {activity.rating}
-          </span>
-          <span className="typo-xs-medium md:typo-sm-medium text-gray-400">
-            ({activity.reviewCount})
-          </span>
+    <Link
+      href={`/activity/${activity.id}`}
+      className="block h-full"
+      aria-label={`${activity.title} 상세 페이지로 이동`}
+    >
+      <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
+        <div className="relative aspect-square w-full bg-gray-200">
+          {activity.bannerImageUrl && (
+            <Image
+              src={activity.bannerImageUrl}
+              alt={`${activity.title} 대표 이미지`}
+              fill
+              sizes="(min-width: 1536px) 262px, (min-width: 768px) 33vw, 50vw"
+              className="object-cover"
+            />
+          )}
         </div>
 
-        <p className="typo-lg-bold 2xl:typo-xl-bold mt-1 wrap-anywhere text-gray-950">
-          {'₩' + activity.price.toLocaleString()}
-          <span className="typo-md-medium 2xl:typo-lg-medium text-gray-400">
-            {' /인'}
-          </span>
-        </p>
-      </div>
-    </article>
+        <div className="z-base relative -mt-8.5 flex flex-col justify-between bg-white px-4 pt-3 pb-4.25 md:-mt-15 md:px-5 md:pt-5 md:pb-7.5">
+          <Heading
+            as="h3"
+            textStyle="typo-md-semibold"
+            className="md:typo-lg-semibold truncate text-gray-950"
+          >
+            {activity.title}
+          </Heading>
+
+          <div className="flex items-center gap-1">
+            <IcStar
+              className="h-3.5 w-3.5 shrink-0 text-yellow-500 md:h-4 md:w-4"
+              aria-hidden="true"
+            />
+            <span className="typo-xs-medium md:typo-sm-medium text-gray-950">
+              {activity.rating}
+            </span>
+            <span className="typo-xs-medium md:typo-sm-medium text-gray-400">
+              ({activity.reviewCount})
+            </span>
+          </div>
+
+          <p className="typo-lg-bold 2xl:typo-xl-bold mt-1 wrap-anywhere text-gray-950">
+            {'₩' + activity.price.toLocaleString()}
+            <span className="typo-md-medium 2xl:typo-lg-medium text-gray-400">
+              {' /인'}
+            </span>
+          </p>
+        </div>
+      </article>
+    </Link>
   );
 }

--- a/src/app/(main)/components/all-activity-section/index.tsx
+++ b/src/app/(main)/components/all-activity-section/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
+import { useActivities } from '@/app/(main)/activity/hooks/useActivities';
 import { ActivityCard } from '@/app/(main)/components/activity-card';
 import {
-  MAIN_ACTIVITIES,
   MAIN_CATEGORIES,
+  MAIN_PAGE_SIZE,
   MAIN_SORT_OPTIONS,
 } from '@/app/(main)/main.constants';
 import { FilterButton } from '@/shared/components/buttons';
@@ -13,19 +14,28 @@ import { Heading } from '@/shared/components/heading';
 import { Pagination } from '@/shared/components/pagination';
 import { cn } from '@/shared/utils/cn';
 
-const TEMP_TOTAL_PAGES = 5;
-
 /**
  * 메인 페이지 모든 체험 섹션 컴포넌트
  *
- * - 모든 체험 영역의 제목, 정렬 드롭다운, 카테고리 필터 UI를 표시한다.
- * - 현재 UI 단계에서는 선택 상태와 필터링/정렬 로직을 포함하지 않는다.
+ * - 모든 체험 목록을 최신순 페이지네이션으로 조회한다.
+ * - PR1에서는 카테고리 필터와 가격 정렬 UI만 표시한다.
+ * - 검색, 카테고리, 가격 정렬 동작은 이후 작업에서 연결한다.
  *
  * @example
  * <AllActivitySection />
  */
 export function AllActivitySection() {
   const [currentPage, setCurrentPage] = useState(1);
+
+  const { data, isPending, isError } = useActivities({
+    method: 'offset',
+    page: currentPage,
+    size: MAIN_PAGE_SIZE,
+    sort: 'latest',
+  });
+
+  const activities = data?.activities ?? [];
+  const totalPages = data ? Math.ceil(data.totalCount / MAIN_PAGE_SIZE) : 0;
 
   return (
     <section>
@@ -44,9 +54,10 @@ export function AllActivitySection() {
           placeholder="정렬"
           onChange={() => undefined}
           menuClassName="left-auto right-0"
-          // TODO: 추후 정렬 기능 연동 예정
+          // TODO: 가격 정렬 기능은 PR2에서 연결 예정
         />
       </div>
+
       <ul className="scrollbar-hide mb-5 flex gap-3 overflow-x-auto">
         {MAIN_CATEGORIES.map((category) => (
           <li key={category.value} className="shrink-0">
@@ -54,37 +65,56 @@ export function AllActivitySection() {
               label={category.label}
               category={category.iconCategory}
               className="whitespace-nowrap"
+              // TODO: 카테고리 필터 기능은 PR2에서 연결 예정
             />
           </li>
         ))}
       </ul>
 
-      <ul
-        className={cn(
-          // 초소형 모바일
-          'grid w-full grid-cols-1 gap-4 gap-y-6',
-          // 일반 모바일
-          'xs:grid-cols-2',
-          // 태블릿
-          'md:grid-cols-3 md:gap-6',
-          // 데스크탑
-          '2xl:grid-cols-4'
-        )}
-      >
-        {MAIN_ACTIVITIES.map((activity) => (
-          <li key={activity.id}>
-            <ActivityCard activity={activity} />
-          </li>
-        ))}
-      </ul>
+      {isPending && (
+        <p className="typo-md-medium py-10 text-center text-gray-500">
+          체험을 불러오는 중입니다.
+        </p>
+      )}
 
-      <div className="mt-10">
-        <Pagination
-          currentPage={currentPage}
-          totalPages={TEMP_TOTAL_PAGES}
-          onPageChange={setCurrentPage}
-        />
-      </div>
+      {isError && (
+        <p className="typo-md-medium py-10 text-center text-red-500">
+          체험을 불러오지 못했습니다.
+        </p>
+      )}
+
+      {!isPending && !isError && activities.length === 0 && (
+        <p className="typo-md-medium py-10 text-center text-gray-500">
+          등록된 체험이 없습니다.
+        </p>
+      )}
+
+      {!isPending && !isError && activities.length > 0 && (
+        <>
+          <ul
+            className={cn(
+              'grid w-full grid-cols-1 gap-4 gap-y-6',
+              'xs:grid-cols-2',
+              'md:grid-cols-3 md:gap-6',
+              '2xl:grid-cols-4'
+            )}
+          >
+            {activities.map((activity) => (
+              <li key={activity.id}>
+                <ActivityCard activity={activity} />
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-10">
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/src/app/(main)/components/all-activity-section/index.tsx
+++ b/src/app/(main)/components/all-activity-section/index.tsx
@@ -106,13 +106,15 @@ export function AllActivitySection() {
             ))}
           </ul>
 
-          <div className="mt-10">
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
-            />
-          </div>
+          {totalPages > 1 && (
+            <div className="mt-10">
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </div>
+          )}
         </>
       )}
     </section>

--- a/src/app/(main)/components/all-activity-section/index.tsx
+++ b/src/app/(main)/components/all-activity-section/index.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useActivities } from '@/app/(main)/activity/hooks/useActivities';
 import { ActivityCard } from '@/app/(main)/components/activity-card';
 import {
   MAIN_CATEGORIES,
+  MAIN_DESKTOP_PAGE_SIZE,
+  MAIN_DESKTOP_PAGE_SIZE_MEDIA_QUERY,
   MAIN_PAGE_SIZE,
   MAIN_SORT_OPTIONS,
 } from '@/app/(main)/main.constants';
@@ -18,6 +20,7 @@ import { cn } from '@/shared/utils/cn';
  * 메인 페이지 모든 체험 섹션 컴포넌트
  *
  * - 모든 체험 목록을 최신순 페이지네이션으로 조회한다.
+ * - 모바일~태블릿에서는 한 페이지에 6개, 2xl 화면에서는 8개를 조회한다.
  * - PR1에서는 카테고리 필터와 가격 정렬 UI만 표시한다.
  * - 검색, 카테고리, 가격 정렬 동작은 이후 작업에서 연결한다.
  *
@@ -26,16 +29,38 @@ import { cn } from '@/shared/utils/cn';
  */
 export function AllActivitySection() {
   const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(MAIN_PAGE_SIZE);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(MAIN_DESKTOP_PAGE_SIZE_MEDIA_QUERY);
+
+    const updatePageSize = () => {
+      const nextPageSize = mediaQuery.matches
+        ? MAIN_DESKTOP_PAGE_SIZE
+        : MAIN_PAGE_SIZE;
+
+      setPageSize(nextPageSize);
+      setCurrentPage(1);
+    };
+
+    updatePageSize();
+
+    mediaQuery.addEventListener('change', updatePageSize);
+
+    return () => {
+      mediaQuery.removeEventListener('change', updatePageSize);
+    };
+  }, []);
 
   const { data, isPending, isError } = useActivities({
     method: 'offset',
     page: currentPage,
-    size: MAIN_PAGE_SIZE,
+    size: pageSize,
     sort: 'latest',
   });
 
   const activities = data?.activities ?? [];
-  const totalPages = data ? Math.ceil(data.totalCount / MAIN_PAGE_SIZE) : 0;
+  const totalPages = data ? Math.ceil(data.totalCount / pageSize) : 0;
 
   return (
     <section>

--- a/src/app/(main)/main.constants.ts
+++ b/src/app/(main)/main.constants.ts
@@ -26,7 +26,13 @@ export const MAIN_SORT_OPTIONS: MainSortOption[] = [
   { label: '높은 가격 순', value: 'price_desc' },
 ];
 
-// TODO: API 연동 시 더미 체험 목록 제거
+export const MAIN_PAGE_SIZE = 6;
+
+export const MAIN_DESKTOP_PAGE_SIZE = 8;
+
+export const MAIN_DESKTOP_PAGE_SIZE_MEDIA_QUERY = '(min-width: 1536px)';
+
+// TODO: 인기 체험 API 연동 시 더미 체험 목록 제거
 export const MAIN_ACTIVITIES: MainActivity[] = [
   {
     id: 1,
@@ -34,7 +40,7 @@ export const MAIN_ACTIVITIES: MainActivity[] = [
     price: 38000,
     rating: 4.9,
     reviewCount: 703,
-    bannerImageUrl: DUMMY_IMAGE_URL, // TODO: API 연동 시 실제 이미지 URL로 교체
+    bannerImageUrl: DUMMY_IMAGE_URL,
     category: 'art',
   },
   {
@@ -85,13 +91,3 @@ export const MAIN_ACTIVITIES: MainActivity[] = [
 ];
 
 export const POPULAR_ACTIVITIES = MAIN_ACTIVITIES.slice(0, 4);
-
-// TODO: API 연동 시 모든 체험 목록은 별도 응답 데이터로 교체
-export const ALL_ACTIVITIES = MAIN_ACTIVITIES.filter(
-  (activity) =>
-    !POPULAR_ACTIVITIES.some(
-      (popularActivity) => popularActivity.id === activity.id
-    )
-);
-
-export const MAIN_PAGE_SIZE = 6;

--- a/src/app/(main)/my/components/activity-card/index.tsx
+++ b/src/app/(main)/my/components/activity-card/index.tsx
@@ -1,21 +1,68 @@
+import Image from 'next/image';
 import Link from 'next/link';
-import { ActivityCardProps } from '@/app/(main)/my/components/activity-card/activityCard.types';
+import type { ActivityCardProps } from '@/app/(main)/components/activity-card/activityCard.types';
+import { IcStar } from '@/shared/assets/icons';
+import { Heading } from '@/shared/components/heading';
 
 /**
- * [예약 내역] 및 [내 체험 관리] 에서 사용하는 카드 형태의 링크 컴포넌트.
+ * 메인 페이지 체험 카드 컴포넌트
+ *
+ * - 체험 대표 이미지와 기본 정보를 표시한다.
+ * - 카드를 클릭하면 체험 상세 페이지로 이동한다.
+ *
  * @example
- * <ActivityCard href={`/activity/${activityId}`}>
- *   <div className="flex-1 px-4 py-4">카드 텍스트 내용</div>
- *   <figure className="relative w-1/3">이미지 영역</figure>
- * </ActivityCard>
+ * <ActivityCard activity={activity} />
  */
-export function ActivityCard({ href, children }: ActivityCardProps) {
+export function ActivityCard({ activity }: ActivityCardProps) {
   return (
     <Link
-      href={href}
-      className="shadow-card group flex min-h-45 justify-between overflow-hidden rounded-3xl"
+      href={`/activity/${activity.id}`}
+      className="block h-full"
+      aria-label={`${activity.title} 상세 페이지로 이동`}
     >
-      {children}
+      <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
+        <div className="relative aspect-square w-full bg-gray-200">
+          {activity.bannerImageUrl && (
+            <Image
+              src={activity.bannerImageUrl}
+              alt={`${activity.title} 대표 이미지`}
+              fill
+              sizes="(min-width: 1536px) 262px, (min-width: 768px) 33vw, 50vw"
+              className="object-cover"
+            />
+          )}
+        </div>
+
+        <div className="z-base relative -mt-8.5 flex flex-col justify-between bg-white px-4 pt-3 pb-4.25 md:-mt-15 md:px-5 md:pt-5 md:pb-7.5">
+          <Heading
+            as="h3"
+            textStyle="typo-md-semibold"
+            className="md:typo-lg-semibold truncate text-gray-950"
+          >
+            {activity.title}
+          </Heading>
+
+          <div className="flex items-center gap-1">
+            <IcStar
+              className="h-3.5 w-3.5 shrink-0 text-yellow-500 md:h-4 md:w-4"
+              aria-hidden="true"
+            />
+            <span className="typo-xs-medium md:typo-sm-medium text-gray-950">
+              {activity.rating}
+            </span>
+            <span className="typo-xs-medium md:typo-sm-medium text-gray-400">
+              ({activity.reviewCount})
+            </span>
+          </div>
+
+          <p className="typo-lg-bold 2xl:typo-xl-bold mt-1 wrap-anywhere text-gray-950">
+            {'₩' + activity.price.toLocaleString()}
+            <span className="typo-md-medium 2xl:typo-lg-medium text-gray-400">
+              {' /인'}
+            </span>
+          </p>
+        </div>
+      </article>
     </Link>
   );
 }

--- a/src/app/(main)/my/components/activity-card/index.tsx
+++ b/src/app/(main)/my/components/activity-card/index.tsx
@@ -1,68 +1,21 @@
-import Image from 'next/image';
 import Link from 'next/link';
-import type { ActivityCardProps } from '@/app/(main)/components/activity-card/activityCard.types';
-import { IcStar } from '@/shared/assets/icons';
-import { Heading } from '@/shared/components/heading';
+import { ActivityCardProps } from '@/app/(main)/my/components/activity-card/activityCard.types';
 
 /**
- * 메인 페이지 체험 카드 컴포넌트
- *
- * - 체험 대표 이미지와 기본 정보를 표시한다.
- * - 카드를 클릭하면 체험 상세 페이지로 이동한다.
- *
+ * [예약 내역] 및 [내 체험 관리] 에서 사용하는 카드 형태의 링크 컴포넌트.
  * @example
- * <ActivityCard activity={activity} />
+ * <ActivityCard href={`/activity/${activityId}`}>
+ *   <div className="flex-1 px-4 py-4">카드 텍스트 내용</div>
+ *   <figure className="relative w-1/3">이미지 영역</figure>
+ * </ActivityCard>
  */
-export function ActivityCard({ activity }: ActivityCardProps) {
+export function ActivityCard({ href, children }: ActivityCardProps) {
   return (
     <Link
-      href={`/activity/${activity.id}`}
-      className="block h-full"
-      aria-label={`${activity.title} 상세 페이지로 이동`}
+      href={href}
+      className="shadow-card group flex min-h-45 justify-between overflow-hidden rounded-3xl"
     >
-      <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
-        <div className="relative aspect-square w-full bg-gray-200">
-          {activity.bannerImageUrl && (
-            <Image
-              src={activity.bannerImageUrl}
-              alt={`${activity.title} 대표 이미지`}
-              fill
-              sizes="(min-width: 1536px) 262px, (min-width: 768px) 33vw, 50vw"
-              className="object-cover"
-            />
-          )}
-        </div>
-
-        <div className="z-base relative -mt-8.5 flex flex-col justify-between bg-white px-4 pt-3 pb-4.25 md:-mt-15 md:px-5 md:pt-5 md:pb-7.5">
-          <Heading
-            as="h3"
-            textStyle="typo-md-semibold"
-            className="md:typo-lg-semibold truncate text-gray-950"
-          >
-            {activity.title}
-          </Heading>
-
-          <div className="flex items-center gap-1">
-            <IcStar
-              className="h-3.5 w-3.5 shrink-0 text-yellow-500 md:h-4 md:w-4"
-              aria-hidden="true"
-            />
-            <span className="typo-xs-medium md:typo-sm-medium text-gray-950">
-              {activity.rating}
-            </span>
-            <span className="typo-xs-medium md:typo-sm-medium text-gray-400">
-              ({activity.reviewCount})
-            </span>
-          </div>
-
-          <p className="typo-lg-bold 2xl:typo-xl-bold mt-1 wrap-anywhere text-gray-950">
-            {'₩' + activity.price.toLocaleString()}
-            <span className="typo-md-medium 2xl:typo-lg-medium text-gray-400">
-              {' /인'}
-            </span>
-          </p>
-        </div>
-      </article>
+      {children}
     </Link>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,5 +1,55 @@
-import { MainContent } from '@/app/(main)/components/main-content';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+import type { ActivitiesResponse } from '@/app/(main)/activity/apis/activities.types';
+import { activitiesOptions } from '@/app/(main)/activity/hooks/useActivities';
+import { AllActivitySection } from '@/app/(main)/components/all-activity-section';
+import { MainBanner } from '@/app/(main)/components/main-banner';
+import { MainSearch } from '@/app/(main)/components/main-search';
+import { PopularActivitySection } from '@/app/(main)/components/popular-activity-section';
+import {
+  MAIN_PAGE_SIZE,
+  POPULAR_ACTIVITIES,
+} from '@/app/(main)/main.constants';
+import { fetchInstanceServer } from '@/shared/apis/fetchInstance.server';
 
-export default function HomePage() {
-  return <MainContent />;
+/**
+ * 메인 페이지
+ *
+ * - 배너, 검색, 인기 체험, 모든 체험 섹션을 렌더링한다.
+ * - PR1에서는 모든 체험 목록의 첫 페이지를 서버에서 미리 조회한다.
+ * - 검색, 카테고리, 정렬, 인기 체험 API 연동은 이후 작업에서 연결한다.
+ */
+export default async function HomePage() {
+  const queryClient = new QueryClient();
+
+  const activitiesParams = {
+    method: 'offset' as const,
+    page: 1,
+    size: MAIN_PAGE_SIZE,
+    sort: 'latest' as const,
+  };
+
+  await queryClient.prefetchQuery({
+    ...activitiesOptions(activitiesParams),
+    queryFn: () =>
+      fetchInstanceServer<ActivitiesResponse>('/activities', {
+        params: activitiesParams,
+      }),
+  });
+
+  return (
+    <div className="flex flex-col gap-10 py-6 md:gap-15 md:py-10 2xl:gap-20 2xl:py-15">
+      <MainBanner />
+      <MainSearch />
+
+      <PopularActivitySection activities={POPULAR_ACTIVITIES} />
+
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <AllActivitySection />
+      </HydrationBoundary>
+    </div>
+  );
 }

--- a/src/shared/constants/queryKeys.constants.ts
+++ b/src/shared/constants/queryKeys.constants.ts
@@ -1,4 +1,5 @@
 export const QUERY_KEYS = {
+  ACTIVITIES: ['activities'],
   MY_ACTIVITIES: ['myActivities'],
   MY_RESERVATIONS: ['myReservations'],
 } as const;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #66 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.
- 메인 페이지에 배너, 검색, 인기 체험, 모든 체험 섹션을 배치했습니다.
- 모든 체험 목록을 `GET /activities` API와 연결했습니다.
- 모든 체험 목록 첫 페이지를 서버에서 prefetch하고, `HydrationBoundary`를 통해 클라이언트 목록 컴포넌트에서 재사용하도록 구성했습니다.
- 모든 체험 목록 페이지네이션을 연결했습니다.
  - 현재 페이지 상태에 따라 목록 데이터를 다시 조회합니다.
  - API 응답의 `totalCount`를 기준으로 전체 페이지 수를 계산합니다.
- 체험 카드에 실제 `bannerImageUrl` 이미지를 표시했습니다.
- 체험 카드 클릭 시 `/activity/{id}` 상세 페이지로 이동하도록 연결했습니다.
- API 요청 상태에 따른 로딩 / 에러 / 빈 상태 UI를 추가했습니다.


### 스크린샷 (선택)
<img width="1439" height="773" alt="스크린샷 2026-05-11 오후 11 15 39" src="https://github.com/user-attachments/assets/4dc7cd82-de40-486f-aafa-e0b651a416c5" />

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.

## 참고
- 작업 중 잘못 수정된 마이페이지 체험 카드 파일은 원래 상태로 복구했습니다.
- 최종 변경사항에는 메인 페이지 관련 파일만 포함되도록 확인했습니다.