### PR TITLE
[Feat/#117] 사이드바 기능(프로필 이미지 업로드/삭제 기능, 로그아웃 기능)

### DIFF
--- a/src/app/(main)/my/components/bf-cache-guard/index.tsx
+++ b/src/app/(main)/my/components/bf-cache-guard/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * BFCache(Back-Forward Cache) 복원 감지 후 강제 새로고침.
+ *
+ * 브라우저는 페이지 이동 시 이전 페이지를 메모리에 캐시했다가,
+ * 뒤로가기 시 서버 요청 없이 즉시 복원한다. 이 경우 layout의
+ * 인증 가드가 다시 실행되지 않아 로그아웃 후에도 보호 페이지가
+ * 보일 수 있다.
+ *
+ * pageshow의 event.persisted가 true면 BFCache에서 복원된 것이므로,
+ * 강제 reload로 서버 요청을 발생시켜 layout 가드가 다시 동작하게 한다.
+ *
+ * 보호 영역(my/) 안에서만 사용한다.
+ */
+export function BFCacheGuard() {
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener('pageshow', handlePageShow);
+    return () => window.removeEventListener('pageshow', handlePageShow);
+  }, []);
+
+  return null;
+}

--- a/src/app/(main)/my/profile/apis/myInfo.ts
+++ b/src/app/(main)/my/profile/apis/myInfo.ts
@@ -30,3 +30,29 @@ export const updateMyInfo = async (body: UpdateMyInfoBody) => {
     body,
   });
 };
+
+/**
+ * 프로필 이미지 업로드 API 응답.
+ */
+export type UploadProfileImageResponse = {
+  profileImageUrl: string;
+};
+
+/**
+ * 프로필 이미지 파일을 업로드하고 URL을 받는다 (BFF 경유).
+ *
+ * 이 API는 URL만 생성하며, user 엔티티의 profileImageUrl을 직접 수정하지 않는다.
+ * user에 반영하려면 응답받은 URL로 updateMyInfo를 추가로 호출해야 한다.
+ */
+export const uploadProfileImage = async (file: File) => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  return await fetchInstanceClient<UploadProfileImageResponse>(
+    '/api/proxy/users/me/image',
+    {
+      method: 'POST',
+      body: formData,
+    }
+  );
+};

--- a/src/app/(main)/my/profile/components/profile-form/index.tsx
+++ b/src/app/(main)/my/profile/components/profile-form/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { UpdateMyInfoBody } from '@/app/(main)/my/profile/apis/myInfo';
@@ -41,11 +41,21 @@ export function ProfileForm() {
     mode: 'onTouched',
     resolver: zodResolver(profileSchema),
     defaultValues: {
-      nickname: user?.nickname ?? '',
+      nickname: '',
       newPassword: '',
       newPasswordConfirm: '',
     },
   });
+
+  useEffect(() => {
+    if (user) {
+      reset({
+        nickname: user.nickname,
+        newPassword: '',
+        newPasswordConfirm: '',
+      });
+    }
+  }, [user, reset]);
 
   if (!user) {
     return null;

--- a/src/app/(main)/my/profile/components/profile-form/index.tsx
+++ b/src/app/(main)/my/profile/components/profile-form/index.tsx
@@ -48,14 +48,14 @@ export function ProfileForm() {
   });
 
   useEffect(() => {
-    if (user) {
+    if (user && !isDirty) {
       reset({
         nickname: user.nickname,
         newPassword: '',
         newPasswordConfirm: '',
       });
     }
-  }, [user, reset]);
+  }, [user, reset, isDirty]);
 
   if (!user) {
     return null;

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_NAME,
+} from '@/shared/apis/auth/auth.constants';
+
+/**
+ * 로그아웃 BFF.
+ *
+ * 백엔드에 별도 로그아웃 엔드포인트가 없으므로,
+ * 클라이언트가 가진 인증 쿠키(accessToken, refreshToken)를 만료시켜
+ * 로그아웃 상태로 만든다.
+ *
+ * httpOnly 쿠키는 JS로 삭제할 수 없으므로 서버에서 Set-Cookie 헤더로 처리해야 한다.
+ */
+export const POST = async () => {
+  const cookieStore = await cookies();
+
+  cookieStore.delete(ACCESS_TOKEN_COOKIE_NAME);
+  cookieStore.delete(REFRESH_TOKEN_COOKIE_NAME);
+
+  return new NextResponse(null, { status: 204 });
+};

--- a/src/shared/components/sidebar/index.tsx
+++ b/src/shared/components/sidebar/index.tsx
@@ -5,11 +5,12 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useMyInfo } from '@/app/(main)/my/profile/hooks/useMyInfo';
-import { IcEdit, IcProfile } from '@/shared/assets/icons';
+import { IcClose, IcEdit, IcProfile } from '@/shared/assets/icons';
 import { Button } from '@/shared/components/buttons';
 import { MENU_ITEMS } from '@/shared/components/sidebar/sidebar.constants';
 import type { SidebarProps } from '@/shared/components/sidebar/sidebar.types';
 import { IMAGE_INPUT_ACCEPT } from '@/shared/constants/image.constants';
+import { useRemoveProfileImageMutation } from '@/shared/hooks/useRemoveProfileImageMutation';
 import { useUpdateProfileImageMutation } from '@/shared/hooks/useUpdateProfileImageMutation';
 import { useShowToast } from '@/shared/store/useToastStore';
 import { cn } from '@/shared/utils/cn';
@@ -19,8 +20,8 @@ import { validateImageFile } from '@/shared/utils/validateImageFile';
  * 마이페이지에서 공용으로 사용하는 사이드바 컴포넌트.
  *
  * - 현재 경로에 해당하는 메뉴를 자동으로 활성화한다.
- * - 프로필 이미지, 프로필 이미지 수정, 로그아웃 등 사이드바 내부의 상태와 동작을 모두 자체적으로 관리한다.
  * - 프로필 이미지는 사용자 선택 즉시 업로드 + user 반영까지 자동 처리한다.
+ * - 사용자가 업로드한 이미지가 있을 때만 close 버튼이 노출되며, 클릭 시 즉시 기본 이미지로 복원한다.
  * - variant에 따라 데스크탑 사이드바와 모바일 드로어 내부 메뉴로 재사용한다.
  */
 export function Sidebar({
@@ -31,11 +32,15 @@ export function Sidebar({
   const pathname = usePathname();
   const { data: user } = useMyInfo();
   const showToast = useShowToast();
-  const { mutate: updateProfileImage, isPending } =
+  const { mutate: updateProfileImage, isPending: isUploading } =
     useUpdateProfileImageMutation();
+  const { mutate: removeProfileImage, isPending: isRemoving } =
+    useRemoveProfileImageMutation();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const profileImageUrl = user?.profileImageUrl ?? '';
+  const hasProfileImage = Boolean(profileImageUrl);
+  const isProfileImageMutating = isUploading || isRemoving;
   const isDrawer = variant === 'drawer';
 
   const handleProfileEdit = () => {
@@ -44,7 +49,6 @@ export function Sidebar({
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    // input 값을 항상 리셋해 같은 파일을 다시 선택해도 change가 발생하게 함
     event.target.value = '';
 
     if (!file) return;
@@ -56,6 +60,10 @@ export function Sidebar({
     }
 
     updateProfileImage(file);
+  };
+
+  const handleProfileImageRemove = () => {
+    removeProfileImage();
   };
 
   const handleLogout = () => {
@@ -86,7 +94,7 @@ export function Sidebar({
             isDrawer ? 'w-24' : 'w-17.5 2xl:w-28'
           )}
         >
-          {profileImageUrl ? (
+          {hasProfileImage ? (
             <Image
               src={profileImageUrl}
               alt="프로필 이미지"
@@ -101,10 +109,11 @@ export function Sidebar({
           )}
         </div>
 
+        {/* 연필 버튼 — 항상 노출, 클릭 시 파일 선택 */}
         <button
           type="button"
           onClick={handleProfileEdit}
-          disabled={isPending}
+          disabled={isProfileImageMutating}
           aria-label="프로필 이미지 수정"
           className={cn(
             'absolute right-1 bottom-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1.75 text-white transition-colors hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
@@ -113,6 +122,22 @@ export function Sidebar({
         >
           <IcEdit className="h-full w-full" aria-hidden="true" />
         </button>
+
+        {/* close 버튼 — 사용자 업로드 이미지가 있을 때만 노출 */}
+        {hasProfileImage && (
+          <button
+            type="button"
+            onClick={handleProfileImageRemove}
+            disabled={isProfileImageMutating}
+            aria-label="프로필 이미지 삭제"
+            className={cn(
+              'absolute -top-1 -right-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1 text-white transition-colors hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
+              isDrawer ? 'h-6 w-6' : 'h-5 w-5 2xl:h-6 2xl:w-6'
+            )}
+          >
+            <IcClose className="h-full w-full" aria-hidden="true" />
+          </button>
+        )}
 
         <input
           ref={fileInputRef}

--- a/src/shared/components/sidebar/index.tsx
+++ b/src/shared/components/sidebar/index.tsx
@@ -1,22 +1,26 @@
 'use client';
 
+import { useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useMyInfo } from '@/app/(main)/my/profile/hooks/useMyInfo';
 import { IcEdit, IcProfile } from '@/shared/assets/icons';
 import { Button } from '@/shared/components/buttons';
 import { MENU_ITEMS } from '@/shared/components/sidebar/sidebar.constants';
 import type { SidebarProps } from '@/shared/components/sidebar/sidebar.types';
+import { IMAGE_INPUT_ACCEPT } from '@/shared/constants/image.constants';
+import { useUpdateProfileImageMutation } from '@/shared/hooks/useUpdateProfileImageMutation';
+import { useShowToast } from '@/shared/store/useToastStore';
 import { cn } from '@/shared/utils/cn';
-
-// TODO: 내 정보 API 연동 후 실제 프로필 이미지 URL로 교체
-const MOCK_PROFILE_IMAGE_URL = '';
+import { validateImageFile } from '@/shared/utils/validateImageFile';
 
 /**
  * 마이페이지에서 공용으로 사용하는 사이드바 컴포넌트.
  *
  * - 현재 경로에 해당하는 메뉴를 자동으로 활성화한다.
  * - 프로필 이미지, 프로필 이미지 수정, 로그아웃 등 사이드바 내부의 상태와 동작을 모두 자체적으로 관리한다.
+ * - 프로필 이미지는 사용자 선택 즉시 업로드 + user 반영까지 자동 처리한다.
  * - variant에 따라 데스크탑 사이드바와 모바일 드로어 내부 메뉴로 재사용한다.
  */
 export function Sidebar({
@@ -25,18 +29,38 @@ export function Sidebar({
   onLogout,
 }: SidebarProps) {
   const pathname = usePathname();
-  const profileImageUrl = MOCK_PROFILE_IMAGE_URL;
+  const { data: user } = useMyInfo();
+  const showToast = useShowToast();
+  const { mutate: updateProfileImage, isPending } =
+    useUpdateProfileImageMutation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const profileImageUrl = user?.profileImageUrl ?? '';
   const isDrawer = variant === 'drawer';
 
   const handleProfileEdit = () => {
-    // TODO: 프로필 수정 버튼 이벤트 연동 후 콘솔 로그 지우기
-    console.warn('프로필 수정 클릭');
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // input 값을 항상 리셋해 같은 파일을 다시 선택해도 change가 발생하게 함
+    event.target.value = '';
+
+    if (!file) return;
+
+    const validation = validateImageFile(file);
+    if (!validation.isValid) {
+      showToast({ theme: 'error', message: validation.message });
+      return;
+    }
+
+    updateProfileImage(file);
   };
 
   const handleLogout = () => {
     // TODO: 로그아웃 버튼 이벤트 연동 후 콘솔 로그 지우기
     console.warn('로그아웃 클릭');
-
     onLogout?.();
   };
 
@@ -68,6 +92,7 @@ export function Sidebar({
               alt="프로필 이미지"
               fill
               className="object-cover"
+              sizes="(min-width: 1536px) 112px, 70px"
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center text-blue-200">
@@ -79,14 +104,24 @@ export function Sidebar({
         <button
           type="button"
           onClick={handleProfileEdit}
+          disabled={isPending}
           aria-label="프로필 이미지 수정"
           className={cn(
-            'absolute right-1 bottom-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1.75 text-white transition-colors hover:bg-gray-500',
+            'absolute right-1 bottom-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1.75 text-white transition-colors hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
             isDrawer ? 'h-7.5 w-7.5' : 'h-6 w-6 2xl:h-7.5 2xl:w-7.5'
           )}
         >
           <IcEdit className="h-full w-full" aria-hidden="true" />
         </button>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={IMAGE_INPUT_ACCEPT}
+          onChange={handleFileChange}
+          className="hidden"
+          aria-hidden="true"
+        />
       </div>
 
       {/* 메뉴 영역 */}

--- a/src/shared/components/sidebar/index.tsx
+++ b/src/shared/components/sidebar/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/shared/components/buttons';
 import { MENU_ITEMS } from '@/shared/components/sidebar/sidebar.constants';
 import type { SidebarProps } from '@/shared/components/sidebar/sidebar.types';
 import { IMAGE_INPUT_ACCEPT } from '@/shared/constants/image.constants';
+import { useLogoutMutation } from '@/shared/hooks/useLogoutMutation';
 import { useRemoveProfileImageMutation } from '@/shared/hooks/useRemoveProfileImageMutation';
 import { useUpdateProfileImageMutation } from '@/shared/hooks/useUpdateProfileImageMutation';
 import { useShowToast } from '@/shared/store/useToastStore';
@@ -20,8 +21,8 @@ import { validateImageFile } from '@/shared/utils/validateImageFile';
  * 마이페이지에서 공용으로 사용하는 사이드바 컴포넌트.
  *
  * - 현재 경로에 해당하는 메뉴를 자동으로 활성화한다.
- * - 프로필 이미지는 사용자 선택 즉시 업로드 + user 반영까지 자동 처리한다.
- * - 사용자가 업로드한 이미지가 있을 때만 close 버튼이 노출되며, 클릭 시 즉시 기본 이미지로 복원한다.
+ * - 프로필 이미지 변경/제거를 자체적으로 처리한다.
+ * - 로그아웃 시 인증 쿠키 삭제, 캐시 클리어, 메인 페이지로 이동을 모두 처리한다.
  * - variant에 따라 데스크탑 사이드바와 모바일 드로어 내부 메뉴로 재사용한다.
  */
 export function Sidebar({
@@ -36,6 +37,7 @@ export function Sidebar({
     useUpdateProfileImageMutation();
   const { mutate: removeProfileImage, isPending: isRemoving } =
     useRemoveProfileImageMutation();
+  const { mutate: logout, isPending: isLoggingOut } = useLogoutMutation();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const profileImageUrl = user?.profileImageUrl ?? '';
@@ -67,8 +69,8 @@ export function Sidebar({
   };
 
   const handleLogout = () => {
-    // TODO: 로그아웃 버튼 이벤트 연동 후 콘솔 로그 지우기
-    console.warn('로그아웃 클릭');
+    onNavigate?.(); // 드로어 모드일 경우 드로어 먼저 닫기
+    logout();
     onLogout?.();
   };
 
@@ -109,7 +111,6 @@ export function Sidebar({
           )}
         </div>
 
-        {/* 연필 버튼 — 항상 노출, 클릭 시 파일 선택 */}
         <button
           type="button"
           onClick={handleProfileEdit}
@@ -123,7 +124,6 @@ export function Sidebar({
           <IcEdit className="h-full w-full" aria-hidden="true" />
         </button>
 
-        {/* close 버튼 — 사용자 업로드 이미지가 있을 때만 노출 */}
         {hasProfileImage && (
           <button
             type="button"
@@ -177,11 +177,12 @@ export function Sidebar({
       <Button
         type="button"
         onClick={handleLogout}
+        disabled={isLoggingOut}
         className={cn('mt-3.5 h-12 w-full 2xl:h-13.5', isDrawer && 'mt-auto')}
         size="lg"
         variant="secondary"
       >
-        로그아웃
+        {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
       </Button>
     </aside>
   );

--- a/src/shared/constants/image.constants.ts
+++ b/src/shared/constants/image.constants.ts
@@ -1,0 +1,20 @@
+/**
+ * 이미지 업로드 허용 최대 크기 (10MB).
+ */
+export const MAX_IMAGE_SIZE_MB = 10;
+export const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
+
+/**
+ * 이미지 업로드 허용 MIME 타입.
+ */
+export const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+] as const;
+
+/**
+ * HTML <input accept> 속성 값.
+ * 시스템 파일 선택 다이얼로그에서 1차 필터로 작동한다.
+ */
+export const IMAGE_INPUT_ACCEPT = ALLOWED_IMAGE_TYPES.join(',');

--- a/src/shared/hooks/useLogoutMutation.ts
+++ b/src/shared/hooks/useLogoutMutation.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '@/shared/apis/apiError';
+import { useShowToast } from '@/shared/store/useToastStore';
+
+/**
+ * 로그아웃 mutation 훅.
+ *
+ * 흐름:
+ * 1. /api/auth/logout 호출 (BFF가 httpOnly 쿠키 삭제)
+ * 2. React Query 캐시 전체 클리어
+ * 3. 토스트 노출 (full reload 전에 사용자가 인지하도록 잠시 대기)
+ * 4. window.location으로 메인 페이지 full reload
+ *    - router.push는 Next.js 클라이언트 캐시 때문에 뒤로가기 시 보호 페이지 복원 가능
+ *    - 로그아웃은 명확한 세션 종료 액션이므로 full reload로 확실히 전환
+ *
+ * @example
+ * ```ts
+ * const { mutate: logout, isPending } = useLogoutMutation();
+ * logout();
+ * ```
+ */
+export const useLogoutMutation = () => {
+  const queryClient = useQueryClient();
+  const showToast = useShowToast();
+
+  return useMutation<void, ApiError, void>({
+    mutationFn: async () => {
+      const response = await fetch('/api/auth/logout', { method: 'POST' });
+
+      if (!response.ok) {
+        throw new ApiError('로그아웃에 실패했습니다.', response.status);
+      }
+    },
+    onSuccess: () => {
+      queryClient.clear();
+      showToast({ theme: 'success', message: '로그아웃되었습니다.' });
+      // 토스트 인지 시간 확보 후 full reload
+      setTimeout(() => {
+        window.location.href = '/';
+      }, 100);
+    },
+    onError: (error) => {
+      showToast({
+        theme: 'error',
+        message: error.message ?? '로그아웃에 실패했습니다.',
+      });
+    },
+  });
+};

--- a/src/shared/hooks/useLogoutMutation.ts
+++ b/src/shared/hooks/useLogoutMutation.ts
@@ -37,7 +37,7 @@ export const useLogoutMutation = () => {
       // 토스트 인지 시간 확보 후 full reload
       setTimeout(() => {
         window.location.href = '/';
-      }, 100);
+      }, 500);
     },
     onError: (error) => {
       showToast({

--- a/src/shared/hooks/useRemoveProfileImageMutation.ts
+++ b/src/shared/hooks/useRemoveProfileImageMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateMyInfo } from '@/app/(main)/my/profile/apis/myInfo';
+import { ApiError } from '@/shared/apis/apiError';
+import type { User } from '@/shared/apis/auth/auth.types';
+import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { useShowToast } from '@/shared/store/useToastStore';
+
+/**
+ * 프로필 이미지 제거 mutation 훅.
+ *
+ * PATCH /users/me에 profileImageUrl을 null로 보내 user의 이미지 연결을 해제한다.
+ * '제거'라는 사용자 의도를 명확히 전달하기 위해 useUpdateMyInfoMutation과 분리한다.
+ *
+ * @example
+ * ```ts
+ * const { mutate: removeProfileImage, isPending } = useRemoveProfileImageMutation();
+ * removeProfileImage();
+ * ```
+ */
+export const useRemoveProfileImageMutation = () => {
+  const queryClient = useQueryClient();
+  const showToast = useShowToast();
+
+  return useMutation<User, ApiError, void>({
+    mutationFn: () => updateMyInfo({ profileImageUrl: null }),
+    onSuccess: (updatedUser) => {
+      queryClient.setQueryData(QUERY_KEYS.MY_INFO, updatedUser);
+      showToast({
+        theme: 'success',
+        message: '프로필 이미지가 삭제되었습니다.',
+      });
+    },
+    onError: (error) => {
+      showToast({
+        theme: 'error',
+        message: error.message ?? '이미지 삭제에 실패했습니다.',
+      });
+    },
+  });
+};

--- a/src/shared/hooks/useUpdateProfileImageMutation.ts
+++ b/src/shared/hooks/useUpdateProfileImageMutation.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  updateMyInfo,
+  uploadProfileImage,
+} from '@/app/(main)/my/profile/apis/myInfo';
+import { ApiError } from '@/shared/apis/apiError';
+import type { User } from '@/shared/apis/auth/auth.types';
+import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { useShowToast } from '@/shared/store/useToastStore';
+
+/**
+ * 프로필 이미지 변경 mutation 훅.
+ *
+ * 두 단계를 단일 mutation으로 묶어 처리한다:
+ * 1. POST /users/me/image — 이미지 업로드 후 URL 발급
+ * 2. PATCH /users/me — 받은 URL로 user의 profileImageUrl 갱신
+ *
+ * 어느 단계든 실패하면 onError로 흐른다.
+ * 성공 시 캐시(MY_INFO)에 업데이트된 user를 직접 반영하므로,
+ * useMyInfo를 호출하는 모든 컴포넌트(사이드바, 마이페이지 등)가 자동 리렌더된다.
+ */
+export const useUpdateProfileImageMutation = () => {
+  const queryClient = useQueryClient();
+  const showToast = useShowToast();
+
+  return useMutation<User, ApiError, File>({
+    mutationFn: async (file) => {
+      const { profileImageUrl } = await uploadProfileImage(file);
+      const updatedUser = await updateMyInfo({ profileImageUrl });
+      return updatedUser;
+    },
+    onSuccess: (updatedUser) => {
+      queryClient.setQueryData(QUERY_KEYS.MY_INFO, updatedUser);
+      showToast({
+        theme: 'success',
+        message: '프로필 이미지가 변경되었습니다.',
+      });
+    },
+    onError: (error) => {
+      showToast({
+        theme: 'error',
+        message: error.message ?? '이미지 변경에 실패했습니다.',
+      });
+    },
+  });
+};

--- a/src/shared/utils/validateImageFile.ts
+++ b/src/shared/utils/validateImageFile.ts
@@ -1,0 +1,52 @@
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE_BYTES,
+  MAX_IMAGE_SIZE_MB,
+} from '@/shared/constants/image.constants';
+
+/**
+ * 이미지 파일 검증 결과.
+ *
+ * - 통과: { isValid: true }
+ * - 실패: { isValid: false, message: 사용자에게 보여줄 메시지 }
+ */
+export type ImageFileValidationResult =
+  | { isValid: true }
+  | { isValid: false; message: string };
+
+/**
+ * 업로드 가능한 이미지 파일인지 검증한다.
+ *
+ * - 크기: 10MB 이하
+ * - 타입: JPEG, PNG, WebP
+ *
+ * @example
+ * ```ts
+ * const result = validateImageFile(file);
+ * if (!result.isValid) {
+ *   showToast({ theme: 'error', message: result.message });
+ *   return;
+ * }
+ * ```
+ */
+export const validateImageFile = (file: File): ImageFileValidationResult => {
+  if (
+    !ALLOWED_IMAGE_TYPES.includes(
+      file.type as (typeof ALLOWED_IMAGE_TYPES)[number]
+    )
+  ) {
+    return {
+      isValid: false,
+      message: 'JPG, PNG, WebP 형식만 업로드할 수 있습니다.',
+    };
+  }
+
+  if (file.size > MAX_IMAGE_SIZE_BYTES) {
+    return {
+      isValid: false,
+      message: `이미지는 ${MAX_IMAGE_SIZE_MB}MB 이하여야 합니다.`,
+    };
+  }
+
+  return { isValid: true };
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #117 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

## 기능

- [x] 프로필 이미지 변경 (연필 버튼 클릭 -> 파일 선택 -> 즉시 업로드 + user 반영)
- [x] 프로필 이미지 제거 (사용자 업로드 이미지가 있을 때만 close 버튼 노출,  클릭 시 즉시 기본 이미지로 복원)
- [x] 파일 사전 검증 (10MB 이하, JPG/PNG/WebP)
- [x] 로그아웃 (쿠키 삭제 + React Query 캐시 클리어 + 메인 페이지 이동 + 토스트)
- [x] 사이드바가 useMyInfo로 실제 데이터 표시 (기존 MOCK 제거)

### 두 개의 이미지 mutation 분리
같은 PATCH API를 호출하지만 사용자에게 보이는 의미가 다른 두 액션을 별도 mutation으로 분리:
- `useUpdateProfileImageMutation`: 이미지 변경 (POST /users/me/image → PATCH /users/me chain)
- `useRemoveProfileImageMutation`: 이미지 제거 (PATCH /users/me { profileImageUrl: null })

### 파일 검증 로직 분리
`src/shared/utils/validateImageFile.ts`로 분리. 추후 다른 이미지 첨부 기능(액티비티 등록 등)에서도 재사용 가능하도록.

### 캐시 동기화
모든 mutation이 `setQueryData(MY_INFO)`로 캐시 즉시 갱신. useMyInfo를 호출하는 모든 화면(사이드바, 마이페이지 등)이 자동 리렌더됩니다.

### 로그아웃 흐름
- `POST /api/auth/logout` BFF Route Handler 신설 (Next.js `cookies()` API로 httpOnly 쿠키 삭제)
- `useLogoutMutation`에서 캐시 클리어 + 토스트 + `window.location.href = '/'`로 full reload
  - `router.push` 대신 `window.location` 사용 이유: Next.js Router Cache가 뒤로가기 시 보호 페이지를 복원시키는 문제 회피

### 보호 페이지 캐시 정책
`my/layout.tsx`에 `export const dynamic = 'force-dynamic'` 추가. Next.js Router Cache가 클라이언트에 캐시한 보호 페이지를 뒤로가기 시 복원하는 문제를 막기 위해, 마이페이지 영역 layout은 항상 서버에서 새로 실행되도록 설정.

### react-hook-form 초기값 처리 패턴 변경
`defaultValues`에 비동기 데이터를 직접 박는 대신, 빈 값으로 초기화 후 `useEffect + reset` 패턴으로 데이터 도착 시 폼 갱신:
로그아웃 후 재로그인 시나리오에서 캐시가 비워진 상태로 폼이 마운트되어 닉네임이 표시되지 않는 문제 해결. (#116 Gemini 봇 리뷰 코멘트의 우려가 실제 발생한 케이스)

## 기술 검증

- PATCH `{ profileImageUrl: null }` 동작 확인: 응답으로 user 전체 반환, profileImageUrl이 null로 갱신됨
- 백엔드 측 닉네임/이미지 저장 확인: `GET /users/me` 직접 호출로 영구 저장 검증

## 신규/수정 파일

**신규**:
- `src/app/api/auth/logout/route.ts` (BFF, 쿠키 삭제)
- `src/shared/constants/image.constants.ts` (검증 규칙 상수)
- `src/shared/utils/validateImageFile.ts` (파일 검증)
- `src/shared/hooks/useUpdateProfileImageMutation.ts`
- `src/shared/hooks/useRemoveProfileImageMutation.ts`
- `src/shared/hooks/useLogoutMutation.ts`

**수정**:
- `src/app/(main)/my/profile/apis/myInfo.ts` (uploadProfileImage 추가)
- `src/app/(main)/my/profile/components/profile-form/index.tsx` (useEffect + reset 패턴)
- `src/app/(main)/my/layout.tsx` 
- `src/shared/components/sidebar/index.tsx` (mock 제거, 실제 동작 연결)
 
### 스크린샷 (선택)

**[기본 상태]**
<img width="594" height="327" alt="image" src="https://github.com/user-attachments/assets/0a24271f-b575-494e-8d58-31d94085b9a6" />


**[프로필 사진 업로드 시]**
<img width="597" height="333" alt="image" src="https://github.com/user-attachments/assets/a06d3485-2d63-4250-bb9f-81dd105b20f9" />
<img width="410" height="81" alt="image" src="https://github.com/user-attachments/assets/76fb2c5f-aef9-45eb-9046-38e1b216f956" />


**[프로필 사진 삭제 시]**
<img width="388" height="73" alt="image" src="https://github.com/user-attachments/assets/1f593fc3-24a7-4bee-bb08-de8e4697724f" />

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
