### PR TITLE
[Feat/#192] 인증 토큰 자동 갱신 + 마이페이지 보호 라우트 구현

### DIFF
--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -1,0 +1,90 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { ApiError } from '@/shared/apis/apiError';
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  ACCESS_TOKEN_COOKIE_OPTIONS,
+  REFRESH_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_OPTIONS,
+} from '@/shared/apis/auth/auth.constants';
+import { fetchInstanceServer } from '@/shared/apis/fetchInstance.server';
+
+interface RefreshTokensResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * POST /api/auth/tokens
+ *
+ * 액세스 토큰 재발급 BFF 엔드포인트.
+ *
+ * 1. 쿠키에서 refreshToken을 꺼낸다.
+ * 2. 백엔드 `/auth/tokens` 를 refreshToken으로 인증하여 호출한다.
+ *    (백엔드 응답: { accessToken, refreshToken } — refresh token rotation)
+ * 3. 받은 두 토큰을 httpOnly 쿠키로 갱신하여 응답한다.
+ *
+ * 클라이언트(fetchInstance.client)가 401 응답을 받았을 때 자동으로 이 엔드포인트를
+ * 호출하여 토큰을 갱신하고 원래 요청을 재시도하는 흐름의 일부.
+ *
+ * 에러 처리:
+ * - 401: refreshToken 쿠키가 없거나, 백엔드가 갱신 거부
+ *        → 클라이언트는 완전 로그아웃 처리 (로그인 페이지로)
+ * - 4xx/5xx: 백엔드 에러 그대로 전달
+ * - 500: 예상치 못한 서버 에러
+ */
+export const POST = async () => {
+  // 1. 쿠키에서 refreshToken 꺼내기
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE_NAME)?.value;
+
+  if (!refreshToken) {
+    return NextResponse.json(
+      { message: '리프레시 토큰이 없습니다.' },
+      { status: 401 }
+    );
+  }
+
+  // 2. 백엔드로 토큰 재발급 요청
+  //    - 자동 accessToken 주입 막기 위해 accessToken: null
+  //    - Authorization 헤더에 refreshToken 직접 주입
+  let tokens: RefreshTokensResponse;
+  try {
+    tokens = await fetchInstanceServer<RefreshTokensResponse>('/auth/tokens', {
+      method: 'POST',
+      accessToken: null,
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      // 백엔드가 401 주면 그대로 401 (refreshToken 만료/무효 — 완전 로그아웃 필요)
+      return NextResponse.json(
+        { message: error.message },
+        { status: error.status }
+      );
+    }
+    return NextResponse.json(
+      { message: '토큰 재발급 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+
+  // 3. 두 쿠키 모두 갱신 (refresh token rotation 패턴)
+  const response = NextResponse.json({ success: true }, { status: 200 });
+
+  response.cookies.set(
+    ACCESS_TOKEN_COOKIE_NAME,
+    tokens.accessToken,
+    ACCESS_TOKEN_COOKIE_OPTIONS
+  );
+
+  response.cookies.set(
+    REFRESH_TOKEN_COOKIE_NAME,
+    tokens.refreshToken,
+    REFRESH_TOKEN_COOKIE_OPTIONS
+  );
+
+  return response;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,5 +30,5 @@ export const middleware = (request: NextRequest) => {
  * 추후 인증 필요한 다른 경로가 추가되면 matcher에 패턴 추가.
  */
 export const config = {
-  matcher: ['/my/:path*'],
+  matcher: ['/my', '/my/:path*'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ACCESS_TOKEN_COOKIE_NAME } from '@/shared/apis/auth/auth.constants';
+
+/**
+ * 인증이 필요한 경로 진입 시 accessToken 쿠키 존재 여부를 확인한다.
+ *
+ * 쿠키가 없으면 로그인 페이지로 redirect한다.
+ *
+ * 토큰이 만료되었더라도 쿠키 자체는 존재하므로 통과시킨다.
+ * 실제 만료 처리는 fetchInstance.client의 401 retry 로직이 담당한다.
+ * (refresh token으로 자동 갱신 후 재시도)
+ *
+ * fetchInstance.client.ts - 토큰 자동 갱신 로직
+ */
+export const middleware = (request: NextRequest) => {
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME);
+
+  if (!accessToken) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+};
+
+/**
+ * 미들웨어를 적용할 경로 패턴.
+ *
+ * `/my` 및 그 하위 모든 경로를 보호한다.
+ * 추후 인증 필요한 다른 경로가 추가되면 matcher에 패턴 추가.
+ */
+export const config = {
+  matcher: ['/my/:path*'],
+};

--- a/src/shared/apis/fetchInstance.client.ts
+++ b/src/shared/apis/fetchInstance.client.ts
@@ -113,7 +113,14 @@ export const fetchInstanceClient = async <T>(
     }
 
     // 갱신 성공 — 원래 요청을 한 번만 재시도
-    // 재시도가 또 401이면 무한 루프 방지 위해 그대로 throw
-    return fetchInstance<T>(endpoint, requestOptions);
+    // 재시도도 401이면 세션이 회복 불가능한 상태로 간주 → 세션 만료 처리
+    try {
+      return await fetchInstance<T>(endpoint, requestOptions);
+    } catch (retryError) {
+      if (retryError instanceof ApiError && retryError.status === 401) {
+        handleSessionExpired();
+      }
+      throw retryError;
+    }
   }
 };

--- a/src/shared/apis/fetchInstance.client.ts
+++ b/src/shared/apis/fetchInstance.client.ts
@@ -1,24 +1,80 @@
 /**
  * 브라우저 환경 (클라이언트 컴포넌트) 에서 사용하는 fetch 래퍼.
  *
- * 현재는 코어 fetchInstance 를 그대로 호출하는 얇은 래퍼.
- * 인증은 BFF (Next.js Route Handler) 의 httpOnly 쿠키로 처리되므로,
- * 클라이언트가 토큰을 직접 다루지 않는다.
+ * 코어 fetchInstance 위에 다음 기능을 추가한다:
+ * - `/api/`로 시작하는 endpoint는 BFF (same-origin) 호출로 자동 인식
+ * - 401 응답 시 자동으로 토큰 재발급 (single-flight) 후 원래 요청 재시도
+ * - refresh 자체 실패 시 세션 만료 처리 (토스트 안내 + 로그인 페이지 이동)
  *
- * 향후 클라이언트 측 공통 처리 (요청 로깅, 에러 변환 등) 가 필요해지면
- * 이 파일에 추가한다.
- *
+ * 인증은 BFF의 httpOnly 쿠키로 처리되므로, 클라이언트가 토큰을 직접 다루지 않는다.
  */
 
+import { ApiError } from '@/shared/apis/apiError';
 import {
   fetchInstance,
   type FetchInstanceOptions,
 } from '@/shared/apis/fetchInstance.core';
+import { useToastStore } from '@/shared/store/useToastStore';
+
+/** 토큰 재발급 BFF 엔드포인트 — retry 대상에서 제외 (무한 루프 방지) */
+const REFRESH_ENDPOINT = '/api/auth/tokens';
+
+/**
+ * 진행 중인 토큰 갱신 Promise.
+ *
+ * Single-flight 패턴: 여러 요청이 동시에 401을 받아도 refresh는 단 한 번만.
+ * 나머지 요청들은 이 Promise의 결과를 기다린다.
+ * (refresh token rotation 환경에서 동시 갱신 시도가 깨지는 것을 방지)
+ */
+let refreshPromise: Promise<void> | null = null;
+
+/**
+ * 토큰 재발급 시도.
+ *
+ * 동시 호출 시 진행 중인 Promise를 공유한다.
+ * BFF가 두 쿠키 모두 갱신하므로, 이 함수는 성공/실패만 알려주면 충분.
+ *
+ * @throws refresh 실패 시 (refreshToken 만료 등)
+ */
+const refreshTokens = (): Promise<void> => {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = fetch(REFRESH_ENDPOINT, { method: 'POST' })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Token refresh failed: ${response.status}`);
+      }
+    })
+    .finally(() => {
+      // 다음 갱신 시도 가능하도록 초기화
+      refreshPromise = null;
+    });
+
+  return refreshPromise;
+};
+
+/**
+ * 세션 만료 처리 — 토스트 안내 후 로그인 페이지로 강제 이동.
+ *
+ * window.location.href를 사용하여 풀 페이지 리로드를 강제한다.
+ * SPA navigation(router.push)은 클라이언트 상태가 남아있을 수 있어 부적합.
+ */
+const handleSessionExpired = () => {
+  useToastStore.getState().actions.showToast({
+    theme: 'warning',
+    message: '세션이 만료되었습니다. 다시 로그인해 주세요.',
+  });
+  window.location.href = '/login';
+};
 
 /**
  * 클라이언트 환경에서 호출하는 fetch.
  *
- * `/api/` 로 시작하는 endpoint 는 BFF (same-origin) 호출로 자동 인식하여 BASE_URL prepend 를 건너뛴다.
+ * `/api/` 로 시작하는 endpoint 는 BFF (same-origin) 호출로 자동 인식하여
+ * BASE_URL prepend 를 건너뛴다.
+ *
+ * 401 응답 시 자동으로 토큰 갱신을 시도하고, 성공하면 원래 요청을 재시도한다.
+ * 갱신 자체가 실패하면(401 응답) 세션 만료로 간주하여 로그인 페이지로 이동시킨다.
  */
 export const fetchInstanceClient = async <T>(
   endpoint: string,
@@ -29,9 +85,35 @@ export const fetchInstanceClient = async <T>(
   }
 
   const isBffCall = endpoint.startsWith('/api/');
-
-  return fetchInstance<T>(endpoint, {
+  const requestOptions: FetchInstanceOptions = {
     ...options,
     absoluteUrl: options.absoluteUrl ?? isBffCall,
-  });
+  };
+
+  try {
+    return await fetchInstance<T>(endpoint, requestOptions);
+  } catch (error) {
+    // 401 이외 에러, 또는 refresh 엔드포인트 자체의 에러는 그대로 전파
+    const shouldRetry =
+      error instanceof ApiError &&
+      error.status === 401 &&
+      endpoint !== REFRESH_ENDPOINT;
+
+    if (!shouldRetry) {
+      throw error;
+    }
+
+    // 토큰 갱신 시도 (single-flight)
+    try {
+      await refreshTokens();
+    } catch {
+      // refresh 실패 — 세션 만료 처리
+      handleSessionExpired();
+      throw error;
+    }
+
+    // 갱신 성공 — 원래 요청을 한 번만 재시도
+    // 재시도가 또 401이면 무한 루프 방지 위해 그대로 throw
+    return fetchInstance<T>(endpoint, requestOptions);
+  }
 };

--- a/src/shared/apis/fetchInstance.client.ts
+++ b/src/shared/apis/fetchInstance.client.ts
@@ -54,12 +54,27 @@ const refreshTokens = (): Promise<void> => {
 };
 
 /**
+ * 세션 만료 처리가 이미 실행되었는지 여부.
+ *
+ * 동시에 여러 요청이 401을 받고 refresh도 실패한 경우, 각 요청의 catch 블록이
+ * 각각 handleSessionExpired를 호출하여 토스트/navigation이 중복 실행되는 것을 방지.
+ *
+ * 페이지 이동(window.location.href)으로 모듈이 재로드되면 자연스럽게 reset된다.
+ */
+let isSessionExpiredHandled = false;
+
+/**
  * 세션 만료 처리 — 토스트 안내 후 로그인 페이지로 강제 이동.
  *
  * window.location.href를 사용하여 풀 페이지 리로드를 강제한다.
  * SPA navigation(router.push)은 클라이언트 상태가 남아있을 수 있어 부적합.
+ *
+ * 동시 호출되어도 한 번만 실행된다(guard).
  */
 const handleSessionExpired = () => {
+  if (isSessionExpiredHandled) return;
+  isSessionExpiredHandled = true;
+
   useToastStore.getState().actions.showToast({
     theme: 'warning',
     message: '세션이 만료되었습니다. 다시 로그인해 주세요.',

--- a/src/shared/store/useToastStore.ts
+++ b/src/shared/store/useToastStore.ts
@@ -7,7 +7,7 @@ import { generateId } from '@/shared/utils/generateId';
 
 type ToastData = Omit<ToastProps, 'onClose'>;
 
-const useToastStore = create(
+export const useToastStore = create(
   immer(
     combine({ toasts: [] as ToastData[] }, (set) => ({
       actions: {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #192 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용
**인증 토큰 자동 갱신 + 마이페이지 보호 라우트 구현**

### 흐름
1. **마이페이지 가드 (middleware)**
   - `/my/*` 진입 시 accessToken 쿠키 존재 확인
   - 없으면 `/login`으로 redirect
   - 페이지 렌더 전 차단 (깜빡임 없음)

2. **토큰 자동 갱신 (fetchInstance.client)**
   - 보호 API 호출 시 401 받으면 자동으로 `/api/auth/tokens` 호출
   - 새 토큰으로 원래 요청 재시도
   - 사용자는 갱신 흐름을 의식하지 못함

3. **갱신 BFF Route Handler**
   - 쿠키에서 refreshToken 꺼내 `Authorization: Bearer` 헤더로 백엔드 호출
   - 응답 받은 두 토큰을 httpOnly 쿠키로 갱신 (refresh token rotation)

### 새로 추가한 파일
- `src/middleware.ts`
- `src/app/api/auth/tokens/route.ts`

### 수정한 파일
- `src/shared/apis/fetchInstance.client.ts` - retry 로직 + single-flight 
- `src/shared/store/useToastStore.ts` - store export 추가 (fetchInstance에서 직접 접근용)

### 결정한 것
- 동시 요청 여러 개가 401 받아도 refresh는 단 한 번만. refresh token rotation 환경에서 동시 갱신 시도가 깨지는 것을 방지
- **미들웨어는 쿠키 존재만 체크**: 만료 검증은 fetchInstance.client가 책임진다. 책임 분리로 미들웨어를 단순/빠르게 유지
- **refresh 실패 시 window.location.href**: 풀 페이지 리로드로 모든 클라이언트 상태 초기화 (보안)

### 테스트 시나리오
- ✅ 로그아웃 상태에서 `/my/*` 진입 → `/login`으로 redirect
- ✅ 로그인 + 유효한 토큰 → 마이페이지 정상 표시
- ✅ 로그인 + 만료/깨진 토큰 → 자동 refresh 후 정상 표시 (DevTools에서 검증)
- ✅ 토큰 갱신 시 두 쿠키 모두 새 값으로 (rotation 확인)

### 향후 작업
- **미들웨어 레벨 refreshToken 자동 갱신**
  - 현재: accessToken 쿠키 없으면 /login으로 redirect
  - 개선: accessToken 없어도 refreshToken 유효하면 미들웨어에서 갱신 후 통과
  - 영향: accessToken 만료 후 ~ refreshToken 만료 전 (1일 ~ 30일) 사이에 방문하는 사용자에게 매끄러운 UX
- 로그인 페이지의 redirect query 처리 (`/login?from=/my/profile` → 로그인 후 원래 페이지로)
- 이미 로그인된 사용자가 `/login`, `/signup` 진입 시 메인으로 redirect

### 스크린샷 (선택)
- **accessToken 쿠키를 일부러 망가뜨려서 시도**
 - DevTools → Application → Cookies → accessToken 더블클릭 → 값 일부 수정 → API 호출 → 백엔드가 invalid token으로 401 → 우리 retry 발동 → refresh 호출 → 새 토큰 → 재시도
> <img width="1496" height="703" alt="image" src="https://github.com/user-attachments/assets/7dcd128b-b353-47db-b203-4d0db3007a39" />

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
