### PR TITLE
[Fix/#209] 내정보 페이지에서 프로필 이미지, 닉네임 수정 시 헤더 영역에 즉시 반영되도록 수정

### DIFF
--- a/src/app/(main)/components/main-header-with-drawer/index.tsx
+++ b/src/app/(main)/components/main-header-with-drawer/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useMyInfo } from '@/app/(main)/my/profile/hooks/useMyInfo';
 import { Header } from '@/shared/components/header';
 import type { HeaderUser } from '@/shared/components/header/header.types';
 import { SideDrawer } from '@/shared/components/side-drawer';
@@ -19,16 +20,33 @@ interface MainHeaderWithDrawerProps {
  *
  * - Header의 모바일 프로필 버튼 클릭 시 마이페이지 드로어를 연다.
  * - 메뉴 이동, 로그아웃 버튼 클릭, md 이상 화면 전환 시 드로어를 닫는다.
+ * - 서버에서 prefetch한 initialUser를 기본으로 표시하되,
+ *   React Query 캐시(useMyInfo)에 더 신선한 데이터가 있으면 그것을 우선한다.
+ *   이를 통해 마이페이지에서 프로필 변경 시 헤더도 자동 동기화된다.
  *
  * @example
  * <MainHeaderWithDrawer user={user} />
  */
 export function MainHeaderWithDrawer({
-  user,
+  user: initialUser,
   hasNotification = false,
   onNotificationClick,
 }: MainHeaderWithDrawerProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  // 비로그인 상태에서는 useMyInfo 호출 시 401이 발생하므로,
+  // 서버에서 user가 확인된 경우(initialUser 존재)에만 클라이언트 캐시 조회를 활성화한다.
+  const { data: queryUser } = useMyInfo({
+    enabled: Boolean(initialUser),
+  });
+
+  // 클라이언트 캐시 데이터가 있으면 그것을, 없으면 서버에서 받은 초기값을 사용한다.
+  const user: HeaderUser | undefined = queryUser
+    ? {
+        nickname: queryUser.nickname,
+        profileImageUrl: queryUser.profileImageUrl,
+      }
+    : initialUser;
 
   const openDrawer = useCallback(() => {
     setIsDrawerOpen(true);

--- a/src/app/(main)/components/main-header-with-drawer/index.tsx
+++ b/src/app/(main)/components/main-header-with-drawer/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMyInfo } from '@/app/(main)/my/profile/hooks/useMyInfo';
 import { Header } from '@/shared/components/header';
 import type { HeaderUser } from '@/shared/components/header/header.types';
@@ -41,12 +41,14 @@ export function MainHeaderWithDrawer({
   });
 
   // 클라이언트 캐시 데이터가 있으면 그것을, 없으면 서버에서 받은 초기값을 사용한다.
-  const user: HeaderUser | undefined = queryUser
-    ? {
-        nickname: queryUser.nickname,
-        profileImageUrl: queryUser.profileImageUrl,
-      }
-    : initialUser;
+  const user = useMemo<HeaderUser | undefined>(() => {
+    return queryUser
+      ? {
+          nickname: queryUser.nickname,
+          profileImageUrl: queryUser.profileImageUrl,
+        }
+      : initialUser;
+  }, [queryUser, initialUser]);
 
   const openDrawer = useCallback(() => {
     setIsDrawerOpen(true);

--- a/src/app/(main)/my/profile/hooks/useMyInfo.ts
+++ b/src/app/(main)/my/profile/hooks/useMyInfo.ts
@@ -1,3 +1,4 @@
+// src/app/(main)/my/profile/hooks/useMyInfo.ts
 import { useQuery } from '@tanstack/react-query';
 import { fetchMyInfo } from '@/app/(main)/my/profile/apis/myInfo';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
@@ -13,11 +14,20 @@ export const myInfoOptions = () => ({
 /**
  * 내 정보 페이지에서 사용하는 커스텀 훅
  *
+ * @param options 쿼리 옵션 (enabled 등)
+ *
  * @example
  * ```ts
- * const { data: user, isLoading, isError } = useMyInfo();
+ * // 기본 사용
+ * const { data: user } = useMyInfo();
+ *
+ * // 조건부 호출 (비로그인 상태 회피 등)
+ * const { data: user } = useMyInfo({ enabled: Boolean(initialUser) });
  * ```
  */
-export const useMyInfo = () => {
-  return useQuery(myInfoOptions());
+export const useMyInfo = (options?: { enabled?: boolean }) => {
+  return useQuery({
+    ...myInfoOptions(),
+    ...options,
+  });
 };

--- a/src/app/(main)/my/profile/hooks/useMyInfo.ts
+++ b/src/app/(main)/my/profile/hooks/useMyInfo.ts
@@ -1,4 +1,3 @@
-// src/app/(main)/my/profile/hooks/useMyInfo.ts
 import { useQuery } from '@tanstack/react-query';
 import { fetchMyInfo } from '@/app/(main)/my/profile/apis/myInfo';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
@@ -12,7 +11,7 @@ export const myInfoOptions = () => ({
 });
 
 /**
- * 내 정보 페이지에서 사용하는 커스텀 훅
+ * 내 정보를 가져오는 커스텀 훅
  *
  * @param options 쿼리 옵션 (enabled 등)
  *


### PR DESCRIPTION
## 🔗 관련 이슈

- close #209 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 마이페이지에서 프로필 이미지/닉네임 변경 시 헤더가 자동으로 갱신되지 않던 문제 해결. 

## 구현된 기능

- [x] 마이페이지에서 프로필 이미지 변경 → 헤더 즉시 갱신
- [x] 마이페이지에서 프로필 이미지 제거 → 헤더 즉시 기본 아이콘으로 전환
- [x] 비로그인 사용자에게는 useMyInfo를 호출하지 않아 401 콘솔 경고 발생 안 함

## 검증 시나리오

- [x] 데스크탑: 마이페이지에서 이미지 변경 → 헤더 즉시 갱신
- [x] 데스크탑: 마이페이지에서 이미지 제거 → 헤더 즉시 기본 아이콘
- [x] 비로그인 사용자: 콘솔 401 경고 없음
- [x] 페이지 이동 시에도 정상 표시 (initialUser fallback)

## 변경 파일

- `src/app/(main)/components/main-header-with-drawer.tsx` (useMyInfo 호출 추가, finalUser 계산)
- `src/app/(main)/my/profile/hooks/useMyInfo.ts` (옵션 받는 시그니처 추가)


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
