### PR TITLE
[Fix/#215] 체험 삭제에 isPending 가드 추가

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-detail-page-client/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-page-client/index.tsx
@@ -31,6 +31,7 @@ export function ActivityDetailPageClient({
 
   const {
     isOpen,
+    isDeleting,
     handleEdit,
     handleDeleteRequest,
     handleDeleteCancel,
@@ -106,6 +107,7 @@ export function ActivityDetailPageClient({
             confirmText="삭제"
             onCancel={handleDeleteCancel}
             onConfirm={handleDeleteConfirm}
+            isPending={isDeleting}
           />
         </ModalOverlay>
       ) : null}

--- a/src/app/(main)/activity/hooks/useActivityActions.ts
+++ b/src/app/(main)/activity/hooks/useActivityActions.ts
@@ -80,11 +80,9 @@ export const useActivityActions = ({
   });
 
   const handleDeleteConfirm = () => {
-    if (isDeleting) return;
+    if (isDeleting || selectedId === null) return;
 
-    if (selectedId) {
-      confirmDelete(selectedId);
-    }
+    confirmDelete(selectedId);
   };
 
   return {

--- a/src/app/(main)/activity/hooks/useActivityActions.ts
+++ b/src/app/(main)/activity/hooks/useActivityActions.ts
@@ -80,6 +80,8 @@ export const useActivityActions = ({
   });
 
   const handleDeleteConfirm = () => {
+    if (isDeleting) return;
+
     if (selectedId) {
       confirmDelete(selectedId);
     }

--- a/src/app/(main)/my/activities/components/my-activities-list/index.tsx
+++ b/src/app/(main)/my/activities/components/my-activities-list/index.tsx
@@ -84,6 +84,7 @@ export function MyActivitiesList() {
                 confirmText="삭제"
                 onCancel={handleDeleteCancel}
                 onConfirm={handleDeleteConfirm}
+                isPending={isDeleting}
               />
             </ModalOverlay>
           )}

--- a/src/shared/components/modal/TwoButtonModal.tsx
+++ b/src/shared/components/modal/TwoButtonModal.tsx
@@ -22,6 +22,7 @@ interface TwoButtonModalProps {
   confirmText?: string;
   onCancel?: () => void;
   onConfirm?: () => void;
+  isPending?: boolean;
 }
 
 export function TwoButtonModal({
@@ -30,6 +31,7 @@ export function TwoButtonModal({
   confirmText = '확인',
   onCancel,
   onConfirm,
+  isPending = false,
 }: TwoButtonModalProps) {
   return (
     <ModalBase
@@ -44,6 +46,7 @@ export function TwoButtonModal({
             size="lg"
             onClick={onCancel}
             className="w-full max-w-31.5"
+            disabled={isPending}
           >
             {cancelText}
           </Button>
@@ -53,6 +56,7 @@ export function TwoButtonModal({
             size="lg"
             onClick={onConfirm}
             className="w-full max-w-31.5"
+            disabled={isPending}
           >
             {confirmText}
           </Button>

--- a/src/shared/components/modal/TwoButtonModal.tsx
+++ b/src/shared/components/modal/TwoButtonModal.tsx
@@ -15,6 +15,7 @@
  */
 import { Button } from '@/shared/components/buttons/button';
 import { ModalBase } from '@/shared/components/modal/ModalBase';
+import { Spinner } from '@/shared/components/spinner';
 
 interface TwoButtonModalProps {
   message: string;
@@ -26,7 +27,7 @@ interface TwoButtonModalProps {
 }
 
 export function TwoButtonModal({
-  message: title,
+  message,
   cancelText = '아니오',
   confirmText = '확인',
   onCancel,
@@ -58,12 +59,12 @@ export function TwoButtonModal({
             className="w-full max-w-31.5"
             disabled={isPending}
           >
-            {confirmText}
+            {isPending ? <Spinner /> : confirmText}
           </Button>
         </div>
       }
     >
-      <p className="typo-2lg-bold text-center text-gray-950">{title}</p>
+      <p className="typo-2lg-bold text-center text-gray-950">{message}</p>
     </ModalBase>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #215 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- TwoButtonModal에 `isPending` prop 추가
- 체험 삭제 버튼들에 `isPending` 상태 적용

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
