### PR TITLE
[Fix/#218] 체험 등록/수정 접근 제한

### DIFF
--- a/src/app/(main)/activity/[id]/edit/page.tsx
+++ b/src/app/(main)/activity/[id]/edit/page.tsx
@@ -1,12 +1,15 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { ActivityEditForm } from '@/app/(main)/activity/[id]/edit/components/activity-edit-form';
 import { ActivityEditPageProps } from '@/app/(main)/activity/[id]/edit/edit.types';
 import { ActivityFormSkeleton } from '@/app/(main)/activity/components/activity-form-skeleton';
+import { ApiError } from '@/shared/apis/apiError';
+import type { User } from '@/shared/apis/auth/auth.types';
 import { fetchInstanceServer } from '@/shared/apis/fetchInstance.server';
 import { Heading } from '@/shared/components/heading';
-import { ActivityDetailResponse } from '@/shared/types/activityDetail.types';
+import { URL_QUERY_ERRORS } from '@/shared/constants/queryKeys.constants';
+import type { ActivityDetailResponse } from '@/shared/types/activityDetail.types';
 
 /**
  * 동적 메타데이터 생성
@@ -34,6 +37,27 @@ export default async function ActivityEditPage({
 
   if (!Number.isFinite(activityId)) {
     notFound();
+  }
+
+  const [meResult, activityResult] = await Promise.allSettled([
+    fetchInstanceServer<User>('/users/me', { cache: 'no-store' }),
+    fetchInstanceServer<ActivityDetailResponse>(`/activities/${activityId}`),
+  ]);
+
+  const me = meResult.status === 'fulfilled' ? meResult.value : null;
+
+  if (activityResult.status === 'rejected') {
+    const error = activityResult.reason;
+    if (error instanceof ApiError && error.status === 404) {
+      notFound();
+    }
+    throw error;
+  }
+
+  const activity = activityResult.value;
+
+  if (!me || activity.userId !== me.id) {
+    redirect(`/activity/${activityId}?error=${URL_QUERY_ERRORS.UNAUTHORIZED}`);
   }
 
   return (

--- a/src/app/(main)/activity/[id]/edit/page.tsx
+++ b/src/app/(main)/activity/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { ActivityEditForm } from '@/app/(main)/activity/[id]/edit/components/act
 import { ActivityEditPageProps } from '@/app/(main)/activity/[id]/edit/edit.types';
 import { ActivityFormSkeleton } from '@/app/(main)/activity/components/activity-form-skeleton';
 import { ApiError } from '@/shared/apis/apiError';
+import { LOGIN_PATH } from '@/shared/apis/auth/auth.constants';
 import type { User } from '@/shared/apis/auth/auth.types';
 import { fetchInstanceServer } from '@/shared/apis/fetchInstance.server';
 import { Heading } from '@/shared/components/heading';
@@ -41,7 +42,9 @@ export default async function ActivityEditPage({
 
   const [meResult, activityResult] = await Promise.allSettled([
     fetchInstanceServer<User>('/users/me', { cache: 'no-store' }),
-    fetchInstanceServer<ActivityDetailResponse>(`/activities/${activityId}`),
+    fetchInstanceServer<ActivityDetailResponse>(`/activities/${activityId}`, {
+      cache: 'no-store',
+    }),
   ]);
 
   const me = meResult.status === 'fulfilled' ? meResult.value : null;
@@ -56,7 +59,11 @@ export default async function ActivityEditPage({
 
   const activity = activityResult.value;
 
-  if (!me || activity.userId !== me.id) {
+  if (!me) {
+    redirect(`${LOGIN_PATH}?from=/activity/${activityId}/edit`);
+  }
+
+  if (activity.userId !== me.id) {
     redirect(`/activity/${activityId}?error=${URL_QUERY_ERRORS.UNAUTHORIZED}`);
   }
 

--- a/src/app/(main)/components/global-query-toast/index.tsx
+++ b/src/app/(main)/components/global-query-toast/index.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { URL_QUERY_ERRORS } from '@/shared/constants/queryKeys.constants';
+import { useShowToast } from '@/shared/store/useToastStore';
+
+/**
+ * 전역 URL 쿼리 에러를 감지하여 토스트 알림을 띄우는 숨김 컴포넌트
+ *
+ * @example
+ * // URL에 ?error=unauthorized 가 포함되어 있으면 토스트를 띄우고 쿼리를 제거함
+ * <GlobalQueryToast />
+ */
+export function GlobalQueryToast() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const showToast = useShowToast();
+
+  const error = searchParams.get('error');
+
+  useEffect(() => {
+    if (!error) return;
+
+    if (error === URL_QUERY_ERRORS.UNAUTHORIZED) {
+      showToast({
+        theme: 'warning',
+        message: '본인의 체험만 수정할 수 있습니다.',
+      });
+
+      const newSearchParams = new URLSearchParams(searchParams.toString());
+      newSearchParams.delete('error');
+
+      const newUrl = newSearchParams.toString()
+        ? `${pathname}?${newSearchParams.toString()}`
+        : pathname;
+
+      router.replace(newUrl, { scroll: false });
+    }
+  }, [error, pathname, router, searchParams, showToast]);
+
+  return null;
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+import { GlobalQueryToast } from '@/app/(main)/components/global-query-toast';
 import { MainHeaderWithDrawer } from '@/app/(main)/components/main-header-with-drawer';
 import { MainLayoutWrapper } from '@/app/(main)/components/main-layout-wrapper';
 import { ApiError } from '@/shared/apis/apiError';
@@ -35,6 +37,11 @@ export default async function MainLayout({ children }: MainLayoutProps) {
   return (
     <>
       <MainHeaderWithDrawer user={user} />
+
+      {/* 백그라운드에서 URL을 감지하고 토스트를 띄우는 역할 */}
+      <Suspense fallback={null}>
+        <GlobalQueryToast />
+      </Suspense>
 
       <MainLayoutWrapper>{children}</MainLayoutWrapper>
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -132,5 +132,5 @@ export const middleware = async (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: ['/my', '/my/:path*'],
+  matcher: ['/my', '/my/:path*', '/activity/add', '/activity/:id/edit'],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -108,7 +108,7 @@ const tryRefreshTokens = async (
  *
  * @see fetchInstance.client.ts — API 호출 시점의 토큰 갱신 (이 미들웨어와 별개 흐름)
  */
-export const middleware = async (request: NextRequest) => {
+export const proxy = async (request: NextRequest) => {
   const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME);
 
   if (accessToken) {

--- a/src/shared/apis/auth/auth.constants.ts
+++ b/src/shared/apis/auth/auth.constants.ts
@@ -54,3 +54,11 @@ export const REFRESH_TOKEN_COOKIE_OPTIONS = {
  * 콜백 페이지에서 이 경로로 redirect한다.
  */
 export const KAKAO_SIGNUP_NICKNAME_PATH = '/signup/kakao';
+
+/**
+ * 인증 실패 및 비로그인 상태 시 리다이렉트할 기본 로그인 페이지 경로.
+ *
+ * @example
+ * redirect(`${LOGIN_PATH}?from=/activity/${activityId}/edit`);
+ */
+export const LOGIN_PATH = '/login';

--- a/src/shared/constants/queryKeys.constants.ts
+++ b/src/shared/constants/queryKeys.constants.ts
@@ -11,3 +11,7 @@ export const QUERY_KEYS = {
   MY_ACTIVITY_RESERVATIONS: ['myActivityReservations'],
   MY_INFO: ['myInfo'],
 } as const;
+
+export const URL_QUERY_ERRORS = {
+  UNAUTHORIZED: 'unauthorized',
+} as const;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #218 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

- 비 로그인 상태에서 체험 `등록 페이지` 접근 시 : `로그인 페이지`로 리다이렉트
- 비 로그인 상태에서 체험 `수정 페이지` 접근 시 : `로그인 페이지`로 리다이렉트
- 로그인 상태에서 남의 체험 `수정 페이지` 접근 시 : `해당 체험 상세 페이지`로 리다이렉트 + 토스트 알람

> 이번 PR에서 작업한 내용을 작성해주세요.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
