### PR TITLE
[Feat/#206-new] from query 파라미터 전달

### DIFF
--- a/src/app/(auth)/components/auth-footer/index.tsx
+++ b/src/app/(auth)/components/auth-footer/index.tsx
@@ -52,12 +52,15 @@ const MODE_TO_KAKAO_INTENT: Record<AuthFooterMode, KakaoAuthIntent> = {
 /**
  * 인증 페이지(로그인/회원가입) 공용 푸터.
  *
+ * @remarks
  * SNS 구분선, 카카오 인증 버튼, 반대 페이지 이동 링크를 제공한다.
  * `mode` prop에 따라 모든 텍스트와 링크가 자동 결정된다.
  *
  * 카카오 버튼 클릭 시 인가 URL을 생성하고 카카오 인증 페이지로 리다이렉트한다.
  * URL의 `from` query가 있으면 sessionStorage에 보존하여 카카오 흐름 후
  * 해당 경로로 redirect할 수 있도록 한다.
+ * 반대 페이지 이동 링크(회원가입↔로그인 전환)에도 from을 전달하여
+ * 인증 페이지 간 이동 시에도 목적지 정보가 유지된다.
  * 인가 URL 생성 실패(환경변수 누락, sessionStorage 접근 불가 등) 시
  * 토스트로 안내한다.
  *
@@ -69,12 +72,17 @@ export function AuthFooter({ mode }: AuthFooterProps) {
   const texts = FOOTER_TEXTS[mode];
   const showToast = useShowToast();
   const searchParams = useSearchParams();
+  const from = searchParams.get('from');
+
+  // 반대 페이지 이동 링크에도 from 전달 (signin ↔ signup 전환 시 목적지 보존)
+  const linkHref = from
+    ? `${texts.linkHref}?from=${encodeURIComponent(from)}`
+    : texts.linkHref;
 
   const handleKakaoClick = () => {
     try {
       // URL의 from query를 sessionStorage에 보존 (카카오 흐름 후 redirect용)
       // from이 없으면 기존 값 정리 (이전 카카오 흐름의 잔여 데이터 방지)
-      const from = searchParams.get('from');
       if (from) {
         setKakaoFrom(from);
       } else {
@@ -108,10 +116,10 @@ export function AuthFooter({ mode }: AuthFooterProps) {
         {texts.kakao}
       </KakaoAuthButton>
 
-      {/* 반대 페이지 이동 링크 */}
+      {/* 반대 페이지 이동 링크 — from 전달로 목적지 보존 */}
       <p className="mt-8 text-sm text-gray-400">
         {texts.linkPrefix}{' '}
-        <Link href={texts.linkHref} className="text-gray-700 underline">
+        <Link href={linkHref} className="text-gray-700 underline">
           {texts.linkLabel}
         </Link>
       </p>

--- a/src/app/(auth)/components/auth-footer/index.tsx
+++ b/src/app/(auth)/components/auth-footer/index.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { KakaoAuthButton } from '@/app/(auth)/components/kakao-auth-button';
 import {
   buildKakaoAuthUrl,
+  consumeKakaoFrom,
   type KakaoAuthIntent,
+  setKakaoFrom,
 } from '@/shared/apis/auth/kakao';
 import { useShowToast } from '@/shared/store/useToastStore';
 
@@ -41,7 +44,6 @@ const FOOTER_TEXTS: Record<
   },
 };
 
-/** AuthFooter의 mode를 카카오 OAuth intent로 매핑 */
 const MODE_TO_KAKAO_INTENT: Record<AuthFooterMode, KakaoAuthIntent> = {
   signin: 'signin',
   signup: 'signup',
@@ -54,6 +56,8 @@ const MODE_TO_KAKAO_INTENT: Record<AuthFooterMode, KakaoAuthIntent> = {
  * `mode` prop에 따라 모든 텍스트와 링크가 자동 결정된다.
  *
  * 카카오 버튼 클릭 시 인가 URL을 생성하고 카카오 인증 페이지로 리다이렉트한다.
+ * URL의 `from` query가 있으면 sessionStorage에 보존하여 카카오 흐름 후
+ * 해당 경로로 redirect할 수 있도록 한다.
  * 인가 URL 생성 실패(환경변수 누락, sessionStorage 접근 불가 등) 시
  * 토스트로 안내한다.
  *
@@ -64,9 +68,19 @@ const MODE_TO_KAKAO_INTENT: Record<AuthFooterMode, KakaoAuthIntent> = {
 export function AuthFooter({ mode }: AuthFooterProps) {
   const texts = FOOTER_TEXTS[mode];
   const showToast = useShowToast();
+  const searchParams = useSearchParams();
 
   const handleKakaoClick = () => {
     try {
+      // URL의 from query를 sessionStorage에 보존 (카카오 흐름 후 redirect용)
+      // from이 없으면 기존 값 정리 (이전 카카오 흐름의 잔여 데이터 방지)
+      const from = searchParams.get('from');
+      if (from) {
+        setKakaoFrom(from);
+      } else {
+        consumeKakaoFrom();
+      }
+
       const intent = MODE_TO_KAKAO_INTENT[mode];
       const authUrl = buildKakaoAuthUrl(intent);
       window.location.href = authUrl;

--- a/src/app/(auth)/login/hooks/useLoginMutation.ts
+++ b/src/app/(auth)/login/hooks/useLoginMutation.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { login } from '@/shared/apis/auth/login';
+import { getSafeRedirectPath } from '@/shared/utils/getSafeRedirectPath';
 
 /**
  * 로그인 mutation hook.
@@ -11,17 +12,23 @@ import { login } from '@/shared/apis/auth/login';
  * 토큰은 Route Handler 가 httpOnly 쿠키로 자동 저장하므로,
  * 클라이언트 코드는 토큰을 직접 다루지 않는다.
  *
- * 성공 시 메인 페이지로 리다이렉트한다.
+ * 성공 시 URL의 `from` query를 검증하여 해당 경로로, 없으면 메인 페이지로 리다이렉트한다.
+ * (예: 비로그인 상태로 /my/profile 진입 → /login?from=/my/profile → 로그인 → /my/profile)
+ *
+ * `from` 값은 getSafeRedirectPath로 검증하여 open redirect 취약점을 방어한다.
+ *
  * 에러 케이스별 처리는 호출부에서 mutate 의 onError 옵션으로.
  */
 export const useLoginMutation = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   return useMutation({
     mutationFn: login,
     onSuccess: () => {
       // 토큰은 Route Handler 가 httpOnly 쿠키로 저장 — 여기서 처리 X
-      router.push('/');
+      const from = searchParams.get('from');
+      router.push(getSafeRedirectPath(from));
     },
   });
 };

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { LoginForm } from '@/app/(auth)/login/components/login-form';
 
@@ -11,7 +12,15 @@ export const metadata: Metadata = {
  *
  * metadata 정의를 위해 서버 컴포넌트로 유지하고,
  * 폼 상호작용은 클라이언트 컴포넌트인 LoginForm에서 처리한다.
+ *
+ * LoginForm 내부의 useLoginMutation이 `useSearchParams()`를 사용하므로
+ * dynamic 렌더링이 필요하며, Suspense로 감싸 빌드 시 prerender 에러를 방지한다.
+ * (?from=원래경로 query를 받아 로그인 후 해당 경로로 redirect하기 위함)
  */
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/src/app/(auth)/signup/hooks/useSignupMutation.ts
+++ b/src/app/(auth)/signup/hooks/useSignupMutation.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
+import { LOGIN_PATH } from '@/shared/apis/auth/auth.constants';
 import { signup } from '@/shared/apis/auth/signup';
 import { useShowToast } from '@/shared/store/useToastStore';
+import { getSafeRedirectPath } from '@/shared/utils/getSafeRedirectPath';
 
 /**
  * 회원가입 mutation hook.
@@ -13,31 +15,42 @@ import { useShowToast } from '@/shared/store/useToastStore';
  * 토큰을 httpOnly 쿠키로 자동 저장하므로,
  * 클라이언트 코드는 토큰을 직접 다루지 않는다.
  *
- * 성공 시 메인 페이지로 리다이렉트한다.
  * 응답 케이스:
- * - 정상 (user 있음): 메인 페이지로 이동
- * - 부분 실패 (message 만 있음): 사용자 알림 + 로그인 페이지로 유도
+ * - 정상 (user 있음): URL의 from query를 검증하여 해당 경로로,
+ *                      없으면 메인 페이지로 이동
+ * - 부분 실패 (message 만 있음): 사용자 알림 + 로그인 페이지로 유도,
+ *                                  from query 보존하여 로그인 후 원래 경로로 갈 수 있도록 함
+ *
+ * `from` 값은 getSafeRedirectPath로 검증하여 open redirect 취약점을 방어한다.
+ *
  * 에러 케이스별 처리는 호출부에서 mutate 의 onError 옵션으로.
  */
 export const useSignupMutation = () => {
   const showToast = useShowToast();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   return useMutation({
     mutationFn: signup,
     onSuccess: (data) => {
+      const from = searchParams.get('from');
+
       // 부분 실패 — 회원가입은 성공했지만 자동 로그인 실패
+      // from 보존하여 로그인 페이지로 보냄 (로그인 후 원래 경로로 갈 수 있도록)
       if (!data.user && data.message) {
         showToast({
           theme: 'warning',
           message: data.message,
         });
-        router.push('/login');
+        const loginPath = from
+          ? `${LOGIN_PATH}?from=${encodeURIComponent(from)}`
+          : LOGIN_PATH;
+        router.push(loginPath);
         return;
       }
 
-      // 정상
-      router.push('/');
+      // 정상 — 자동 로그인까지 됐으므로 from 경로(있으면)로 바로 redirect
+      router.push(getSafeRedirectPath(from));
     },
   });
 };

--- a/src/app/(auth)/signup/kakao/hooks/useKakaoSignupMutation.ts
+++ b/src/app/(auth)/signup/kakao/hooks/useKakaoSignupMutation.ts
@@ -2,8 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
+import { consumeKakaoFrom } from '@/shared/apis/auth/kakao';
 import { kakaoSignup } from '@/shared/apis/auth/kakaoSignup';
 import { useShowToast } from '@/shared/store/useToastStore';
+import { getSafeRedirectPath } from '@/shared/utils/getSafeRedirectPath';
 
 /**
  * 카카오 간편 회원가입 mutation hook.
@@ -16,7 +18,9 @@ import { useShowToast } from '@/shared/store/useToastStore';
  * 일반 회원가입과 달리 백엔드 단일 호출로 회원가입+로그인이 완료되므로
  * 부분 실패 시나리오는 없다.
  *
- * 성공 시 토스트 안내 + 메인 페이지로 리다이렉트한다.
+ * 성공 시 토스트 안내 + sessionStorage에 보존된 from 경로(AuthFooter에서 저장)를
+ * 검증하여 해당 경로로, 없으면 메인 페이지로 리다이렉트한다.
+ *
  * 에러 케이스별 처리는 호출부에서 mutate 의 onError 옵션으로.
  */
 export const useKakaoSignupMutation = () => {
@@ -30,7 +34,10 @@ export const useKakaoSignupMutation = () => {
         theme: 'success',
         message: '카카오 회원가입이 완료되었습니다.',
       });
-      router.replace('/');
+
+      // 카카오 흐름 진입 시 보존한 from 경로를 꺼내 검증 후 redirect
+      const from = consumeKakaoFrom();
+      router.replace(getSafeRedirectPath(from));
     },
   });
 };

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { SignupForm } from '@/app/(auth)/signup/components/signup-form';
 
@@ -11,7 +12,15 @@ export const metadata: Metadata = {
  *
  * metadata 정의를 위해 서버 컴포넌트로 유지하고,
  * 폼 상호작용은 클라이언트 컴포넌트인 SignupForm에서 처리한다.
+ *
+ * SignupForm 내부의 AuthFooter가 `useSearchParams()`를 사용하므로
+ * dynamic 렌더링이 필요하며, Suspense로 감싸 빌드 시 prerender 에러를 방지한다.
+ * (?from=원래경로 query를 받아 카카오 OAuth 흐름에 보존하기 위함)
  */
 export default function SignupPage() {
-  return <SignupForm />;
+  return (
+    <Suspense fallback={null}>
+      <SignupForm />
+    </Suspense>
+  );
 }

--- a/src/app/oauth/kakao/hooks/useKakaoSigninMutation.ts
+++ b/src/app/oauth/kakao/hooks/useKakaoSigninMutation.ts
@@ -2,8 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
+import { consumeKakaoFrom } from '@/shared/apis/auth/kakao';
 import { kakaoSignin } from '@/shared/apis/auth/kakaoSignin';
 import { useShowToast } from '@/shared/store/useToastStore';
+import { getSafeRedirectPath } from '@/shared/utils/getSafeRedirectPath';
 
 /**
  * 카카오 간편 로그인 mutation hook.
@@ -13,7 +15,8 @@ import { useShowToast } from '@/shared/store/useToastStore';
  * 토큰을 httpOnly 쿠키로 자동 저장하므로,
  * 클라이언트 코드는 토큰을 직접 다루지 않는다.
  *
- * 성공 시 토스트 안내 + 메인 페이지로 리다이렉트한다.
+ * 성공 시 sessionStorage에 보존된 from 경로(AuthFooter에서 저장)를 검증하여
+ * 해당 경로로, 없으면 메인 페이지로 리다이렉트한다.
  *
  * 에러 케이스(404 미가입 사용자 안내 등)는 호출부에서 mutate 의 onError 옵션으로 처리.
  */
@@ -28,7 +31,10 @@ export const useKakaoSigninMutation = () => {
         theme: 'success',
         message: '카카오 로그인이 완료되었습니다.',
       });
-      router.replace('/');
+
+      // 카카오 흐름 진입 시 보존한 from 경로를 꺼내 검증 후 redirect
+      const from = consumeKakaoFrom();
+      router.replace(getSafeRedirectPath(from));
     },
   });
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -120,7 +120,10 @@ export const proxy = async (request: NextRequest) => {
   // 인증 실패 시 redirect할 로그인 URL.
   // 사용자가 원래 가려던 경로를 from query로 보존하여 로그인 후 그 경로로 돌아갈 수 있도록 한다.
   const loginUrl = new URL(LOGIN_PATH, request.url);
-  loginUrl.searchParams.set('from', request.nextUrl.pathname);
+  loginUrl.searchParams.set(
+    'from',
+    request.nextUrl.pathname + request.nextUrl.search
+  );
 
   if (!refreshToken) {
     return NextResponse.redirect(loginUrl);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -116,7 +116,11 @@ export const proxy = async (request: NextRequest) => {
   }
 
   const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME);
+
+  // 인증 실패 시 redirect할 로그인 URL.
+  // 사용자가 원래 가려던 경로를 from query로 보존하여 로그인 후 그 경로로 돌아갈 수 있도록 한다.
   const loginUrl = new URL(LOGIN_PATH, request.url);
+  loginUrl.searchParams.set('from', request.nextUrl.pathname);
 
   if (!refreshToken) {
     return NextResponse.redirect(loginUrl);

--- a/src/shared/apis/auth/auth.constants.ts
+++ b/src/shared/apis/auth/auth.constants.ts
@@ -62,3 +62,18 @@ export const KAKAO_SIGNUP_NICKNAME_PATH = '/signup/kakao';
  * redirect(`${LOGIN_PATH}?from=/activity/${activityId}/edit`);
  */
 export const LOGIN_PATH = '/login';
+
+/**
+ * 회원가입 페이지 경로.
+ *
+ * 카카오 로그인 시도한 미가입 사용자 안내, 로그인 페이지의 회원가입 링크 등에 사용.
+ */
+export const SIGNUP_PATH = '/signup';
+
+/**
+ * 메인 페이지(홈) 경로.
+ *
+ * 로그인/회원가입 성공 후 기본 진입 경로, "홈으로" 버튼 등에 사용.
+ * from query 등으로 redirect 대상이 지정된 경우 그 경로가 우선한다.
+ */
+export const MAIN_PATH = '/';

--- a/src/shared/apis/auth/kakao.ts
+++ b/src/shared/apis/auth/kakao.ts
@@ -148,3 +148,46 @@ export const peekKakaoPendingSignup = (): KakaoPendingSignup | null => {
     return null;
   }
 };
+
+/**
+ * 카카오 OAuth 흐름에서 from 경로 임시 저장 키.
+ *
+ * 사용자가 /login?from=... 등으로 진입 후 카카오 로그인 버튼을 누르면
+ * 외부 사이트(카카오)로 이동하므로 React state로는 from을 보존할 수 없다.
+ * sessionStorage에 임시 저장하여 콜백 후 onSuccess 시점에 활용한다.
+ */
+const KAKAO_OAUTH_FROM_KEY = 'kakao_oauth_from';
+
+/**
+ * 카카오 OAuth 흐름의 from 경로를 sessionStorage에 저장한다.
+ * 카카오 인증 URL로 이동하기 직전에 호출.
+ *
+ * from 로그인/가입 성공 후 redirect할 경로
+ */
+export const setKakaoFrom = (from: string): void => {
+  sessionStorage.setItem(KAKAO_OAUTH_FROM_KEY, from);
+};
+
+/**
+ * 카카오 OAuth 흐름의 from 경로를 읽기만 한다 (삭제하지 않음).
+ *
+ * 재시도 가능성(예: 닉네임 중복으로 가입 실패 후 재시도)을 고려하여
+ * 즉시 삭제하지 않고, 실제 로그인/가입이 성공한 시점에 `consumeKakaoFrom`으로 삭제한다.
+ *
+ * 저장된 from 경로, 없으면 null
+ */
+export const peekKakaoFrom = (): string | null => {
+  return sessionStorage.getItem(KAKAO_OAUTH_FROM_KEY);
+};
+
+/**
+ * 카카오 OAuth 흐름의 from 경로를 읽고 즉시 삭제한다.
+ * 로그인/가입 성공 후 redirect 시점에 호출.
+ *
+ * 저장된 from 경로, 없으면 null
+ */
+export const consumeKakaoFrom = (): string | null => {
+  const from = sessionStorage.getItem(KAKAO_OAUTH_FROM_KEY);
+  if (from) sessionStorage.removeItem(KAKAO_OAUTH_FROM_KEY);
+  return from;
+};

--- a/src/shared/apis/fetchInstance.client.ts
+++ b/src/shared/apis/fetchInstance.client.ts
@@ -11,6 +11,7 @@
  */
 
 import { ApiError } from '@/shared/apis/apiError';
+import { LOGIN_PATH } from '@/shared/apis/auth/auth.constants';
 import {
   fetchInstance,
   type FetchInstanceOptions,
@@ -86,7 +87,10 @@ const handleSessionExpired = () => {
     theme: 'warning',
     message: '세션이 만료되었습니다. 다시 로그인해 주세요.',
   });
-  window.location.href = '/login';
+
+  // 사용자가 작업 중이던 경로를 from query로 보존
+  const from = window.location.pathname;
+  window.location.href = `${LOGIN_PATH}?from=${encodeURIComponent(from)}`;
 };
 
 /**

--- a/src/shared/apis/fetchInstance.client.ts
+++ b/src/shared/apis/fetchInstance.client.ts
@@ -89,7 +89,7 @@ const handleSessionExpired = () => {
   });
 
   // 사용자가 작업 중이던 경로를 from query로 보존
-  const from = window.location.pathname;
+  const from = window.location.pathname + window.location.search;
   window.location.href = `${LOGIN_PATH}?from=${encodeURIComponent(from)}`;
 };
 

--- a/src/shared/utils/getSafeRedirectPath.ts
+++ b/src/shared/utils/getSafeRedirectPath.ts
@@ -12,7 +12,10 @@ import { MAIN_PATH } from '@/shared/apis/auth/auth.constants';
  * - null/undefined/빈 문자열: 메인 페이지로 fallback
  * - `/`로 시작하지 않음 (상대 경로): 차단
  * - `//`로 시작 (protocol-relative URL): 차단 (//evil.com 형식)
- * - URL 디코딩 후 protocol 포함 (`javascript:`, `http:` 등): 차단
+ * - `/\`로 시작 (백슬래시 우회): 차단 (일부 브라우저가 \를 /로 정규화하여
+ *    /\evil.com → //evil.com 으로 해석할 수 있음)
+ * - URL 디코딩 후 위 패턴이 나타나는 경우: 차단 (인코딩 우회 방어)
+ * - 디코딩 후 protocol 포함 (`javascript:`, `http:` 등): 차단
  *
  * from 검증할 경로 (보통 searchParams.get('from')의 결과)
  * 안전한 경로. 검증 실패 시 MAIN_PATH(메인 페이지) 반환.
@@ -21,7 +24,10 @@ import { MAIN_PATH } from '@/shared/apis/auth/auth.constants';
  * getSafeRedirectPath('/my/profile')           // → '/my/profile'
  * getSafeRedirectPath('https://evil.com')      // → '/'
  * getSafeRedirectPath('//evil.com')            // → '/'
+ * getSafeRedirectPath('/\\evil.com')           // → '/' (백슬래시 우회)
  * getSafeRedirectPath('javascript:alert(1)')   // → '/'
+ * getSafeRedirectPath('%2F%2Fevil.com')        // → '/' (인코딩 우회)
+ * getSafeRedirectPath('%2F%5Cevil.com')        // → '/' (인코딩된 백슬래시)
  * getSafeRedirectPath(null)                    // → '/'
  */
 export const getSafeRedirectPath = (
@@ -32,14 +38,16 @@ export const getSafeRedirectPath = (
   // 1. '/'로 시작해야 내부 경로
   if (!from.startsWith('/')) return MAIN_PATH;
 
-  // 2. '//'로 시작하면 protocol-relative URL (외부 사이트 가능)
-  if (from.startsWith('//')) return MAIN_PATH;
+  // 2. '//' 또는 '/\'로 시작하면 protocol-relative URL (외부 사이트 가능)
+  //    일부 브라우저는 \를 /로 정규화하여 /\evil.com을 //evil.com 처럼 해석
+  if (from.startsWith('//') || from.startsWith('/\\')) return MAIN_PATH;
 
   // 3. URL 디코딩 후 검증 (인코딩 우회 방어)
-  //    예: %2F%2Fevil.com → //evil.com
+  //    예: %2F%2Fevil.com → //evil.com, %2F%5Cevil.com → /\evil.com
   try {
     const decoded = decodeURIComponent(from);
-    if (decoded.startsWith('//')) return MAIN_PATH;
+    if (decoded.startsWith('//') || decoded.startsWith('/\\')) return MAIN_PATH;
+
     // protocol 문자 (`:`)가 첫 '/' 이전에 있으면 위험
     // 예: javascript:..., http:..., //evil.com 등
     const firstSlashIndex = decoded.indexOf('/');

--- a/src/shared/utils/getSafeRedirectPath.ts
+++ b/src/shared/utils/getSafeRedirectPath.ts
@@ -1,0 +1,56 @@
+import { MAIN_PATH } from '@/shared/apis/auth/auth.constants';
+
+/**
+ * 외부에서 받은 redirect 경로가 안전한지 검증하고, 안전한 경로를 반환한다.
+ *
+ * Open Redirect 취약점 방어:
+ * 사용자에게 보낸 링크에 `?from=https://evil.com` 같이 외부 URL을 박으면
+ * 사용자가 로그인 후 피싱 사이트로 유도될 수 있다.
+ * 내부 경로만 허용하여 이러한 공격을 차단한다.
+ *
+ * 검증 규칙:
+ * - null/undefined/빈 문자열: 메인 페이지로 fallback
+ * - `/`로 시작하지 않음 (상대 경로): 차단
+ * - `//`로 시작 (protocol-relative URL): 차단 (//evil.com 형식)
+ * - URL 디코딩 후 protocol 포함 (`javascript:`, `http:` 등): 차단
+ *
+ * from 검증할 경로 (보통 searchParams.get('from')의 결과)
+ * 안전한 경로. 검증 실패 시 MAIN_PATH(메인 페이지) 반환.
+ *
+ * @example
+ * getSafeRedirectPath('/my/profile')           // → '/my/profile'
+ * getSafeRedirectPath('https://evil.com')      // → '/'
+ * getSafeRedirectPath('//evil.com')            // → '/'
+ * getSafeRedirectPath('javascript:alert(1)')   // → '/'
+ * getSafeRedirectPath(null)                    // → '/'
+ */
+export const getSafeRedirectPath = (
+  from: string | null | undefined
+): string => {
+  if (!from) return MAIN_PATH;
+
+  // 1. '/'로 시작해야 내부 경로
+  if (!from.startsWith('/')) return MAIN_PATH;
+
+  // 2. '//'로 시작하면 protocol-relative URL (외부 사이트 가능)
+  if (from.startsWith('//')) return MAIN_PATH;
+
+  // 3. URL 디코딩 후 검증 (인코딩 우회 방어)
+  //    예: %2F%2Fevil.com → //evil.com
+  try {
+    const decoded = decodeURIComponent(from);
+    if (decoded.startsWith('//')) return MAIN_PATH;
+    // protocol 문자 (`:`)가 첫 '/' 이전에 있으면 위험
+    // 예: javascript:..., http:..., //evil.com 등
+    const firstSlashIndex = decoded.indexOf('/');
+    const firstColonIndex = decoded.indexOf(':');
+    if (firstColonIndex !== -1 && firstColonIndex < firstSlashIndex) {
+      return MAIN_PATH;
+    }
+  } catch {
+    // 디코딩 실패는 잘못된 형식 — fallback
+    return MAIN_PATH;
+  }
+
+  return from;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #206 

## 📌 작업 내용
**인증 흐름에 from query 처리 추가**

### 배경
- 미들웨어 가드, 세션 만료 등으로 로그인 페이지로 redirect되는 사용자가 원래 가려던 페이지 정보를 잃어 로그인 후 항상 메인으로 가는 UX 문제 존재

### 개선
인증 흐름 전반에 `?from=원래경로` query를 추가:
1. **redirect 시점**: 미들웨어, 세션 만료 시 from 자동 보존
2. **인증 후**: 일반/카카오 로그인, 일반/카카오 회원가입 성공 시 from 경로로 리다이렉트
3. **카카오 OAuth**: 외부 사이트 경유 흐름 대응을 위해 sessionStorage 활용

### 신규 파일
- `src/shared/utils/getSafeRedirectPath.ts` — Open Redirect 방어 헬퍼
- `src/shared/apis/auth/auth.constants.ts` — SIGNUP_PATH, MAIN_PATH 추가
- `src/shared/apis/auth/kakao.ts` — setKakaoFrom, peekKakaoFrom, consumeKakaoFrom

### 수정 파일
- `src/proxy.ts` — 인증 실패 시 from query 추가
- `src/shared/apis/fetchInstance.client.ts` — 세션 만료 시 from 보존
- 인증 페이지들 (Suspense 추가)
- 인증 mutation 훅들 (onSuccess에서 from 처리)
- AuthFooter (카카오 흐름 진입 시 sessionStorage에 from 저장)

### 보안 — Open Redirect 방어
사용자에게 보낸 링크에 외부 URL을 박는 공격을 차단:
- `/`로 시작하지 않는 경로 차단
- `//`로 시작하는 protocol-relative URL 차단
- URL 디코딩 후 재검증 (인코딩 우회 방어)
- protocol 문자(`javascript:` 등) 차단

검증 케이스:
- `/my/profile` → `/my/profile` ✅
- `https://evil.com` → `/` ✅ 차단
- `//evil.com` → `/` ✅ 차단
- `%2F%2Fevil.com` → `/` ✅ 차단 (인코딩 우회)
- `javascript:alert(1)` → `/` ✅ 차단

### 결정한 것
- **카카오 OAuth는 sessionStorage**: 외부 사이트 경유로 URL/state 보존 불가
- **peek vs consume**: 성공 시점에만 sessionStorage 정리 (회원가입 nickname 패턴과 일관되도록 함)
- **사용 시점 검증**: from 입력때보다 redirect 직전 검증이 안전
- **잔여 데이터 정리**: AuthFooter에서 from 없을 때 기존 sessionStorage 정리하여 이전 흐름의 잔여 데이터가 다음 카카오 로그인에 영향 주는 것을 방지.

### 테스트 시나리오
[일반 사용자 시나리오]
✅ 비로그인 + /my/profile 진입 → /login?from=/my/profile → 로그인 → /my/profile
✅ 비로그인 + /my/profile 진입 → /login?from=/my/profile → 카카오 로그인 → /my/profile
✅ /signup?from=/my/profile → 일반 회원가입 → /my/profile (자동 로그인)
✅ /signup?from=/my/profile → 일반 회원가입 (부분 실패) → /login?from=/my/profile

[세션 만료 시나리오]
✅ 작업 중 세션 만료 → 토스트 + /login?from=현재경로 → 로그인 → 원래 페이지로

[보안 시나리오]
✅ /login?from=https://evil.com → 로그인 → / (메인) ✅ 차단
✅ /signup?from=https://evil.com → 가입 → / (메인) ✅ 차단
✅ /login?from=%2F%2Fevil.com (인코딩 우회) → / (메인) ✅ 차단

[정리 시나리오]
✅ 이전 카카오 흐름의 잔여 from 데이터 → 새 카카오 클릭 시 정리됨


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
