### PR TITLE
[Refactor/#243] 프로필 이미지 영역 리팩토링(hover 인터랙션 추가)

### DIFF
--- a/src/shared/components/sidebar/index.tsx
+++ b/src/shared/components/sidebar/index.tsx
@@ -21,8 +21,9 @@ import { validateImageFile } from '@/shared/utils/validateImageFile';
  * 마이페이지에서 공용으로 사용하는 사이드바 컴포넌트.
  *
  * - 현재 경로에 해당하는 메뉴를 자동으로 활성화한다.
- * - 프로필 이미지 변경/제거를 자체적으로 처리한다.
- * - 로그아웃 시 인증 쿠키 삭제, 캐시 클리어, 메인 페이지로 이동을 모두 처리한다.
+ * - 프로필 이미지 영역에 마우스 호버 또는 키보드 포커스 시 오버레이로 수정 아이콘이 표시된다.
+ * - 사용자가 업로드한 이미지가 있을 때만 우상단에 삭제 버튼이 노출되며, 호버 시 시각 정리를 위해 숨겨진다.
+ * - 로그아웃 시 인증 쿠키 삭제, 캐시 클리어, 메인 페이지 이동을 모두 처리한다.
  * - variant에 따라 데스크탑 사이드바와 모바일 드로어 내부 메뉴로 재사용한다.
  */
 export function Sidebar({
@@ -69,7 +70,7 @@ export function Sidebar({
   };
 
   const handleLogout = () => {
-    onNavigate?.(); // 드로어 모드일 경우 드로어 먼저 닫기
+    onNavigate?.();
     logout();
     onLogout?.();
   };
@@ -90,9 +91,14 @@ export function Sidebar({
           isDrawer ? 'mb-6' : 'mb-3 2xl:mb-6'
         )}
       >
-        <div
+        {/* 이미지 원 = 버튼 (peer 추가) */}
+        <button
+          type="button"
+          onClick={handleProfileEdit}
+          disabled={isProfileImageMutating}
+          aria-label="프로필 이미지 수정"
           className={cn(
-            'relative aspect-square overflow-hidden rounded-full bg-blue-50',
+            'group peer relative block aspect-square cursor-pointer overflow-hidden rounded-full bg-blue-50 disabled:cursor-not-allowed',
             isDrawer ? 'w-24' : 'w-17.5 2xl:w-28'
           )}
         >
@@ -109,21 +115,26 @@ export function Sidebar({
               <IcProfile className="h-full w-full" aria-hidden="true" />
             </div>
           )}
-        </div>
 
-        <button
-          type="button"
-          onClick={handleProfileEdit}
-          disabled={isProfileImageMutating}
-          aria-label="프로필 이미지 수정"
-          className={cn(
-            'absolute right-1 bottom-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1.75 text-white transition-colors hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
-            isDrawer ? 'h-7.5 w-7.5' : 'h-6 w-6 2xl:h-7.5 2xl:w-7.5'
-          )}
-        >
-          <IcEdit className="h-full w-full" aria-hidden="true" />
+          {/* 호버/포커스 시 나타나는 오버레이 + 수정 아이콘 */}
+          <div
+            className={cn(
+              'absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200',
+              'group-hover:opacity-100 group-focus-visible:opacity-100',
+              'group-disabled:opacity-0'
+            )}
+            aria-hidden="true"
+          >
+            <IcEdit
+              className={cn(
+                'text-white',
+                isDrawer ? 'h-8 w-8' : 'h-6 w-6 2xl:h-8 2xl:w-8'
+              )}
+            />
+          </div>
         </button>
 
+        {/* 이미지 삭제 버튼 (사용자 업로드 이미지가 있을 때만, 호버/포커스 시 숨김) */}
         {hasProfileImage && (
           <button
             type="button"
@@ -131,7 +142,9 @@ export function Sidebar({
             disabled={isProfileImageMutating}
             aria-label="프로필 이미지 삭제"
             className={cn(
-              'absolute -top-1 -right-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1 text-white transition-colors hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
+              'absolute -top-1 -right-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-400 p-1 text-white transition-opacity duration-200 hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-60',
+              'peer-hover:pointer-events-none peer-hover:opacity-0',
+              'peer-focus-visible:pointer-events-none peer-focus-visible:opacity-0',
               isDrawer ? 'h-6 w-6' : 'h-5 w-5 2xl:h-6 2xl:w-6'
             )}
           >


### PR DESCRIPTION
## 🔗 관련 이슈

- close #243 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

- 항시 표시되던 프로필 이미지 편집 버튼을 -> 마우스 오버시에만 표시되도록 변경
- 프로필 이미지 삭제 버튼은 우측 상단에 고정되어 있지만 -> 마우스 오버시(프로필 편집 버튼이 떴을때)에만 잠시 사라지도록 변경

### 스크린샷 (선택)

- <img width="178" height="99" alt="image" src="https://github.com/user-attachments/assets/aa61c32d-3fac-4bb2-8555-7d5822cd90b2" />

- <img width="130" height="81" alt="image" src="https://github.com/user-attachments/assets/69c161d2-df88-4736-a7da-b7762f1f814d" />

- <img width="487" height="368" alt="image" src="https://github.com/user-attachments/assets/46f17112-033b-4b8d-9beb-f246248ff795" />

- <img width="492" height="412" alt="image" src="https://github.com/user-attachments/assets/2dc151a1-cf8f-451e-bd85-f2c3e67e64b8" />



### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
