### PR TITLE
[Refactor/#85] 공통 Button 컴포넌트 타입 재정의 + 예약 상세카드 하단 여백 조정

### DIFF
--- a/src/app/(main)/components/all-activity-section/index.tsx
+++ b/src/app/(main)/components/all-activity-section/index.tsx
@@ -11,12 +11,12 @@ import { ActivityCardListSkeleton } from '@/app/(main)/components/activity-card-
 import { ActivitySectionStatus } from '@/app/(main)/components/activity-section-status';
 import type { AllActivitySectionProps } from '@/app/(main)/components/all-activity-section/allActivitySection.types';
 import {
-  MAIN_CATEGORIES,
   MAIN_DESKTOP_PAGE_SIZE,
   MAIN_DESKTOP_PAGE_SIZE_MEDIA_QUERY,
   MAIN_PAGE_SIZE,
   MAIN_SORT_OPTIONS,
 } from '@/app/(main)/main.constants';
+import { MAIN_CATEGORIES } from '@/app/(main)/mainCategories.constants';
 import { FilterButton } from '@/shared/components/buttons';
 import { Dropdown } from '@/shared/components/dropdown';
 import { Heading } from '@/shared/components/heading';
@@ -182,7 +182,7 @@ export function AllActivitySection({
             <li key={category.value} className="shrink-0">
               <FilterButton
                 label={category.label}
-                category={category.iconCategory}
+                icon={<category.Icon />}
                 state={
                   selectedCategory === category.apiValue ? 'active' : 'normal'
                 }

--- a/src/app/(main)/main.constants.ts
+++ b/src/app/(main)/main.constants.ts
@@ -1,48 +1,9 @@
-import type { MainCategory, MainSortOption } from '@/app/(main)/main.types';
+import type { MainSortOption } from '@/app/(main)/main.types';
 
 export const MAIN_BANNER = {
   title: 'FIND YOUR EXPERIENCE',
   description: '당신만의 특별한 체험을 발견하세요',
 };
-
-export const MAIN_CATEGORIES: MainCategory[] = [
-  {
-    label: '문화 · 예술',
-    value: 'art',
-    apiValue: '문화 · 예술',
-    iconCategory: 'art',
-  },
-  {
-    label: '식음료',
-    value: 'food',
-    apiValue: '식음료',
-    iconCategory: 'food',
-  },
-  {
-    label: '스포츠',
-    value: 'sport',
-    apiValue: '스포츠',
-    iconCategory: 'sport',
-  },
-  {
-    label: '투어',
-    value: 'tour',
-    apiValue: '투어',
-    iconCategory: 'tour',
-  },
-  {
-    label: '관광',
-    value: 'bus',
-    apiValue: '관광',
-    iconCategory: 'bus',
-  },
-  {
-    label: '웰빙',
-    value: 'wellbeing',
-    apiValue: '웰빙',
-    iconCategory: 'wellbeing',
-  },
-];
 
 export const MAIN_SORT_OPTIONS: MainSortOption[] = [
   { label: '낮은 가격 순', value: 'price_asc' },

--- a/src/app/(main)/main.types.ts
+++ b/src/app/(main)/main.types.ts
@@ -1,5 +1,5 @@
+import type { ComponentType, SVGProps } from 'react';
 import type { ActivityCategory } from '@/app/(main)/activity/apis/activities.types';
-import type { FilterCategory } from '@/shared/components/buttons';
 
 export type MainCategoryValue =
   | 'art'
@@ -15,7 +15,7 @@ export interface MainCategory {
   label: string;
   value: MainCategoryValue;
   apiValue: ActivityCategory;
-  iconCategory: FilterCategory;
+  Icon: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
 export interface MainSortOption {

--- a/src/app/(main)/mainCategories.constants.ts
+++ b/src/app/(main)/mainCategories.constants.ts
@@ -1,0 +1,49 @@
+import type { MainCategory } from '@/app/(main)/main.types';
+import {
+  IcArt,
+  IcBus,
+  IcFood,
+  IcSport,
+  IcTour,
+  IcWellbeing,
+} from '@/shared/assets/icons';
+
+/** 메인 체험 목록 카테고리 필터(아이콘 포함) — 클라이언트 섹션에서만 import */
+export const MAIN_CATEGORIES: MainCategory[] = [
+  {
+    label: '문화 · 예술',
+    value: 'art',
+    apiValue: '문화 · 예술',
+    Icon: IcArt,
+  },
+  {
+    label: '식음료',
+    value: 'food',
+    apiValue: '식음료',
+    Icon: IcFood,
+  },
+  {
+    label: '스포츠',
+    value: 'sport',
+    apiValue: '스포츠',
+    Icon: IcSport,
+  },
+  {
+    label: '투어',
+    value: 'tour',
+    apiValue: '투어',
+    Icon: IcTour,
+  },
+  {
+    label: '관광',
+    value: 'bus',
+    apiValue: '관광',
+    Icon: IcBus,
+  },
+  {
+    label: '웰빙',
+    value: 'wellbeing',
+    apiValue: '웰빙',
+    Icon: IcWellbeing,
+  },
+];

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
@@ -398,7 +398,8 @@
   }
 
   .reservation-detail-sheet {
-    @apply absolute h-auto w-80 max-w-none rounded-3xl pb-5;
+    /* 플로팅 패널은 내용 높이에 맞추고 바텀시트용 min-h-96은 적용x */
+    @apply absolute h-auto min-h-0 w-80 max-w-none rounded-3xl pb-5;
     max-height: calc(100vh - theme(spacing.10));
   }
 
@@ -422,9 +423,9 @@
     @apply mb-5;
   }
 
-  /*  PC 예약 현황 카드 하단 여백 */
+  /* PC: flex-1(바텀시트용)이 남는 높이를 잡아먹지 않도록 확장 제거 */
   .reservation-detail-sheet__section--requests {
-    @apply mb-1;
+    @apply mb-1 flex-none;
   }
 
   .reservation-detail-sheet__section-title {
@@ -468,7 +469,7 @@
   }
 
   .reservation-detail-sheet__request-scroll--fixed {
-    /* 2건 기준 뷰포트 + 하단 여백을 유지해 데스크톱 가독성 확보 */
-    @apply max-h-60.75 pb-5;
+    /* 내용이 적을 때는 높이를 늘리지 않고 길 때만 max-height로 스크롤 */
+    @apply max-h-60.75 min-h-0 pb-1.5;
   }
 }

--- a/src/app/(main)/my/reservations/components/reserve-filter/index.tsx
+++ b/src/app/(main)/my/reservations/components/reserve-filter/index.tsx
@@ -63,7 +63,6 @@ export function ReserveFilter() {
             <li key={label} className="shrink-0">
               <FilterButton
                 label={STATUS_TEXT[label]}
-                showIcon={false}
                 state={isSelected ? 'active' : 'normal'}
                 className="h-10"
                 onClick={() => handleFilterClick(label)}

--- a/src/shared/components/buttons/button/button.types.ts
+++ b/src/shared/components/buttons/button/button.types.ts
@@ -1,26 +1,11 @@
-import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
-import { VariantProps } from 'class-variance-authority';
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+import type { VariantProps } from 'class-variance-authority';
 import { BUTTON_VARIANTS } from '@/shared/components/buttons/button/button.constants';
 
-type CustomButtonProps<T extends ElementType> = {
+type ButtonVariantKeys = keyof VariantProps<typeof BUTTON_VARIANTS>;
+
+export type ButtonProps<T extends ElementType = 'button'> = {
   as?: T;
-  /** 버튼 왼쪽에 표시할 아이콘 */
   icon?: ReactNode;
-} & Omit<VariantProps<typeof BUTTON_VARIANTS>, 'variant'>;
-
-export type BaseButtonProps<T extends ElementType> = CustomButtonProps<T> &
-  Omit<ComponentPropsWithoutRef<T>, keyof CustomButtonProps<T>>;
-
-export type PrimaryButtonProps<T extends ElementType = 'button'> =
-  BaseButtonProps<T> & {
-    variant?: 'primary';
-  };
-
-export type SecondaryButtonProps<T extends ElementType = 'button'> =
-  BaseButtonProps<T> & {
-    variant: 'secondary';
-  };
-
-export type ButtonProps<T extends ElementType = 'button'> =
-  | PrimaryButtonProps<T>
-  | SecondaryButtonProps<T>;
+} & VariantProps<typeof BUTTON_VARIANTS> &
+  Omit<ComponentPropsWithoutRef<T>, 'as' | 'icon' | ButtonVariantKeys>;

--- a/src/shared/components/buttons/button/index.tsx
+++ b/src/shared/components/buttons/button/index.tsx
@@ -5,11 +5,7 @@ import {
   BUTTON_VARIANTS,
   ICON_SIZE_CLASS,
 } from '@/shared/components/buttons/button/button.constants';
-import type {
-  ButtonProps,
-  PrimaryButtonProps,
-  SecondaryButtonProps,
-} from '@/shared/components/buttons/button/button.types';
+import type { ButtonProps } from '@/shared/components/buttons/button/button.types';
 import { cn } from '@/shared/utils/cn';
 
 export type { ButtonProps };
@@ -44,11 +40,18 @@ export type { ButtonProps };
 export function Button<T extends React.ElementType = 'button'>(
   props: ButtonProps<T>
 ) {
-  const { as, variant = 'primary', icon, className, children, ...rest } = props;
-  const Component = as ?? 'button';
+  const {
+    as,
+    variant = 'primary',
+    icon,
+    size,
+    className,
+    children,
+    ...rest
+  } = props;
 
-  const resolvedSize =
-    (rest as PrimaryButtonProps<T> | SecondaryButtonProps<T>).size ?? 'lg';
+  const Component = as ?? 'button';
+  const resolvedSize = size ?? 'lg';
   const iconClass = ICON_SIZE_CLASS[resolvedSize];
 
   const styledIcon =
@@ -66,40 +69,13 @@ export function Button<T extends React.ElementType = 'button'>(
         )
       : icon;
 
-  /* ── Secondary Button ── */
-  if (variant === 'secondary') {
-    const { size, ...buttonRest } = rest as SecondaryButtonProps<T>;
-
-    return (
-      <Component
-        className={cn(
-          BUTTON_VARIANTS({ variant: 'secondary', size }),
-          className
-        )}
-        {...buttonRest}
-      >
-        {styledIcon && (
-          <span
-            className={cn(
-              'flex shrink-0 items-center justify-center',
-              iconClass
-            )}
-          >
-            {styledIcon}
-          </span>
-        )}
-        <span className="truncate">{children}</span>
-      </Component>
-    );
-  }
-
-  /* ── Primary Button ── */ const { size, ...buttonRest } =
-    rest as PrimaryButtonProps<T>;
-
   return (
     <Component
-      className={cn(BUTTON_VARIANTS({ variant: 'primary', size }), className)}
-      {...buttonRest}
+      className={cn(
+        BUTTON_VARIANTS({ variant, size: resolvedSize }),
+        className
+      )}
+      {...rest}
     >
       {styledIcon && (
         <span

--- a/src/shared/components/buttons/filter-button/filterButton.constants.ts
+++ b/src/shared/components/buttons/filter-button/filterButton.constants.ts
@@ -1,24 +1,4 @@
-import type { SVGProps } from 'react';
 import { cva } from 'class-variance-authority';
-import {
-  IcArt,
-  IcBus,
-  IcFood,
-  IcSport,
-  IcTour,
-  IcWellbeing,
-} from '@/shared/assets/icons';
-
-type CategoryIconComponent = React.FC<SVGProps<SVGSVGElement>>;
-
-export const CATEGORY_ICON_MAP = {
-  art: IcArt,
-  food: IcFood,
-  bus: IcBus,
-  sport: IcSport,
-  tour: IcTour,
-  wellbeing: IcWellbeing,
-} satisfies Record<string, CategoryIconComponent>;
 
 /**
  * 아이콘 크기 Tailwind 클래스

--- a/src/shared/components/buttons/filter-button/filterButton.stories.tsx
+++ b/src/shared/components/buttons/filter-button/filterButton.stories.tsx
@@ -1,4 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import {
+  IcArt,
+  IcBus,
+  IcFood,
+  IcSport,
+  IcTour,
+  IcWellbeing,
+} from '@/shared/assets/icons';
 import { FilterButton } from '@/shared/components/buttons/filter-button';
 
 const meta: Meta<typeof FilterButton> = {
@@ -8,10 +16,9 @@ const meta: Meta<typeof FilterButton> = {
     layout: 'centered',
   },
   args: {
-    label: '아트',
-    category: 'art',
+    label: '문화 · 예술',
+    icon: <IcArt />,
     state: 'normal',
-    showIcon: true,
   },
 };
 
@@ -29,20 +36,19 @@ export const Active: Story = {
 export const NoIcon: Story = {
   args: {
     label: '전체',
-    showIcon: false,
-    category: undefined,
+    icon: undefined,
   },
 };
 
 export const categories: Story = {
   render: () => (
     <div className="flex flex-wrap gap-3">
-      <FilterButton label="아트" category="art" />
-      <FilterButton label="음식" category="food" />
-      <FilterButton label="버스" category="bus" />
-      <FilterButton label="스포츠" category="sport" />
-      <FilterButton label="투어" category="tour" />
-      <FilterButton label="웰빙" category="wellbeing" />
+      <FilterButton label="문화 · 예술" icon={<IcArt />} />
+      <FilterButton label="식음료" icon={<IcFood />} />
+      <FilterButton label="관광" icon={<IcBus />} />
+      <FilterButton label="스포츠" icon={<IcSport />} />
+      <FilterButton label="투어" icon={<IcTour />} />
+      <FilterButton label="웰빙" icon={<IcWellbeing />} />
     </div>
   ),
 };

--- a/src/shared/components/buttons/filter-button/filterButton.types.ts
+++ b/src/shared/components/buttons/filter-button/filterButton.types.ts
@@ -1,32 +1,9 @@
-import { ButtonHTMLAttributes } from 'react';
-import { VariantProps } from 'class-variance-authority';
-import {
-  CATEGORY_ICON_MAP,
-  filterButtonVariants,
-} from '@/shared/components/buttons/filter-button/filterButton.constants';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { VariantProps } from 'class-variance-authority';
+import { filterButtonVariants } from '@/shared/components/buttons/filter-button/filterButton.constants';
 
-/** 카테고리 필터 버튼에 사용 가능한 카테고리 종류 */
-export type FilterCategory = keyof typeof CATEGORY_ICON_MAP;
-
-export interface FilterButtonProps
-  extends
-    ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof filterButtonVariants> {
-  /** 버튼에 표시할 텍스트 레이블 */
-  label: string;
-  /**
-   * 카테고리 종류
-   * - `'art'` : 아트/문화
-   * - `'food'` : 음식/음료
-   * - `'bus'` : 버스/투어
-   * - `'sport'` : 스포츠
-   * - `'tour'` : 관광
-   * - `'wellbeing'` : 웰빙
-   */
-  category?: FilterCategory;
-  /**
-   * 아이콘 표시 여부
-   * @defaultValue `true`
-   */
-  showIcon?: boolean;
-}
+export type FilterButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof filterButtonVariants> & {
+    label: string;
+    icon?: ReactNode;
+  };

--- a/src/shared/components/buttons/filter-button/index.tsx
+++ b/src/shared/components/buttons/filter-button/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cloneElement, isValidElement } from 'react';
+import { cloneElement, isValidElement, useMemo } from 'react';
 import {
   FILTER_ICON_CLASS,
   filterButtonVariants,
@@ -38,19 +38,17 @@ export function FilterButton({
   className,
   ...rest
 }: FilterButtonProps) {
-  const styledIcon =
-    icon && isValidElement(icon)
-      ? cloneElement(
-          icon as React.ReactElement<React.SVGProps<SVGSVGElement>>,
-          {
-            className: cn(
-              (icon as React.ReactElement<React.SVGProps<SVGSVGElement>>).props
-                .className,
-              FILTER_ICON_CLASS
-            ),
-          }
-        )
-      : icon;
+  const styledIcon = useMemo(() => {
+    if (!icon || !isValidElement(icon)) {
+      return icon;
+    }
+
+    const iconElement = icon as React.ReactElement<{ className?: string }>;
+
+    return cloneElement(iconElement, {
+      className: cn(iconElement.props.className, FILTER_ICON_CLASS),
+    });
+  }, [icon]);
 
   return (
     <button

--- a/src/shared/components/buttons/filter-button/index.tsx
+++ b/src/shared/components/buttons/filter-button/index.tsx
@@ -1,49 +1,56 @@
 'use client';
 
-import { IcArt } from '@/shared/assets/icons';
+import { cloneElement, isValidElement } from 'react';
 import {
-  CATEGORY_ICON_MAP,
   FILTER_ICON_CLASS,
   filterButtonVariants,
 } from '@/shared/components/buttons/filter-button/filterButton.constants';
 import type { FilterButtonProps } from '@/shared/components/buttons/filter-button/filterButton.types';
 import { cn } from '@/shared/utils/cn';
 
-export type { FilterCategory } from '@/shared/components/buttons/filter-button/filterButton.types';
+export type { FilterButtonProps } from '@/shared/components/buttons/filter-button/filterButton.types';
 
 /**
- * 홈 화면 카테고리 필터링에 사용하는 pill 형태 버튼
+ * pill 형태의 필터·토글용 버튼
  *
  * - `state="normal"` : 흰 배경 + 회색 테두리
  * - `state="active"` : 검정 배경 + 흰 텍스트
  * - 반응형 크기: 모바일 h-[37px] → PC/TB h-11 (md: 기준)
  *
  * @example
- * <FilterButton label="아트" category="art" state="normal" />
+ * <FilterButton label="문화 · 예술" icon={<IcArt />} state="normal" />
  *
  * @example
- * <FilterButton label="음식" category="food" state="active" />
- *
- * @example
- * <FilterButton label="전체" showIcon={false} state="normal" />
+ * <FilterButton label="예약 완료" state="active" />
  *
  * @example
  * <FilterButton
  *   label="스포츠"
- *   category="sport"
- *   state={selected === 'sport' ? 'active' : 'normal'}
- *   onClick={() => setSelected('sport')}
+ *   icon={<IcSport />}
+ *   state={selected ? 'active' : 'normal'}
+ *   onClick={handleClick}
  * />
  */
 export function FilterButton({
   label,
-  category,
-  showIcon = true,
+  icon,
   state = 'normal',
   className,
   ...rest
 }: FilterButtonProps) {
-  const IconComponent = category ? CATEGORY_ICON_MAP[category] : IcArt;
+  const styledIcon =
+    icon && isValidElement(icon)
+      ? cloneElement(
+          icon as React.ReactElement<React.SVGProps<SVGSVGElement>>,
+          {
+            className: cn(
+              (icon as React.ReactElement<React.SVGProps<SVGSVGElement>>).props
+                .className,
+              FILTER_ICON_CLASS
+            ),
+          }
+        )
+      : icon;
 
   return (
     <button
@@ -51,7 +58,7 @@ export function FilterButton({
       className={cn(filterButtonVariants({ state }), className)}
       {...rest}
     >
-      {showIcon && <IconComponent className={FILTER_ICON_CLASS} />}
+      {styledIcon}
       <span>{label}</span>
     </button>
   );

--- a/src/shared/components/buttons/index.ts
+++ b/src/shared/components/buttons/index.ts
@@ -4,5 +4,5 @@ export type { ArrowButtonProps } from '@/shared/components/buttons/arrow-button'
 export { ArrowButton } from '@/shared/components/buttons/arrow-button';
 export type { ButtonProps } from '@/shared/components/buttons/button';
 export { Button } from '@/shared/components/buttons/button';
-export type { FilterCategory } from '@/shared/components/buttons/filter-button';
+export type { FilterButtonProps } from '@/shared/components/buttons/filter-button';
 export { FilterButton } from '@/shared/components/buttons/filter-button';


### PR DESCRIPTION
## 🔗 관련 이슈

- close #85 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

이전: `CustomButtonProps` → `BaseButtonProps` → `PrimaryButtonProps | SecondaryButtonProps` 구분용 유니온

이후: `VariantProps<typeof BUTTON_VARIANTS>`와 `as·icon`을 합친 단일 `ButtonProps<T>`로 통합
CVA의 `variant·size`와 네이티브 `props`가 겹치지 않도록 Omit에 `ButtonVariantKeys` 사용

구현: `primary`/`secondary` 분기 제거 후 `BUTTON_VARIANTS({ variant, size: resolvedSize })` 한 경로로 렌더링

FilterButton
`category` + `CATEGORY_ICON_MAP` + 기본 `IcArt` 제거 → 호출부에서 넘기는 `icon?: ReactNode`만 사용

아이콘 클래스는 `Button`과 같이 `cloneElement`로 `FILTER_ICON_CLASS`를 합침

`showIcon` 제거 → 아이콘이 없으면 렌더x (`ReserveFilter`는 `icon` 미전달)
`FilterCategory` 타입 삭제 → 공용 버튼 레이어에서 도메인 문자열 키 제거
`filterButton.constants.ts`: CVA·아이콘 클래스만 유지

