### PR TITLE
[Feat/#252] 공통 모달컴포넌트 여닫힘 애니메이션 추가

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
@@ -9,6 +9,7 @@ import {
   IcClose,
 } from '@/shared/assets/icons';
 import { ModalOverlay } from '@/shared/components/modal/modal-overlay';
+import { useRequestModalClose } from '@/shared/components/modal/modal-overlay/modal-overlay-close-context';
 import { cn } from '@/shared/utils/cn';
 
 /** `object-contain`으로 그려진 비트맵 영역(레터박스 제외) 안인지 */
@@ -50,6 +51,15 @@ export function ActivityImageLightbox({
   onClose,
   onNavigate,
 }: ActivityImageLightboxProps) {
+  const overlayClose = useRequestModalClose();
+
+  const requestDismiss = useCallback(() => {
+    if (overlayClose) {
+      overlayClose.requestClose();
+      return;
+    }
+    onClose();
+  }, [overlayClose, onClose]);
   const url = urls[index];
   const total = urls.length;
   const canNavigate = total > 1;
@@ -86,9 +96,9 @@ export function ActivityImageLightbox({
         }
       }
 
-      onClose();
+      requestDismiss();
     },
-    [onClose]
+    [requestDismiss]
   );
 
   const handleImageSlotClick = useCallback(
@@ -111,11 +121,11 @@ export function ActivityImageLightbox({
             img
           )
         ) {
-          onClose();
+          requestDismiss();
         }
       }
     },
-    [onClose]
+    [requestDismiss]
   );
 
   useEffect(() => {
@@ -157,7 +167,7 @@ export function ActivityImageLightbox({
   if (!url) return null;
 
   const navButtonClass =
-    'inline-flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-full leading-none text-white transition-colors hover:bg-white/15 active:bg-white/25 md:size-12';
+    'inline-flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-full leading-none text-white transition-colors duration-200 ease-out hover:bg-white/15 active:bg-white/25 motion-safe:active:scale-95 md:size-12';
 
   const navIconClass = 'block h-10 w-10 shrink-0';
 
@@ -167,14 +177,14 @@ export function ActivityImageLightbox({
       className="px-3 py-6 sm:px-6 md:px-10 md:py-10"
     >
       <div
-        className="flex w-full max-w-7xl flex-col lg:max-w-[min(100%,88rem)]"
+        className="mx-auto flex w-full max-w-7xl flex-col lg:max-w-screen-2xl"
         onPointerDown={handlePanelPointerDown}
       >
         <div className="mb-2 flex shrink-0 justify-end md:mb-3">
           <button
             type="button"
             aria-label="닫기"
-            onClick={onClose}
+            onClick={requestDismiss}
             className={navButtonClass}
           >
             <IcClose aria-hidden className="block size-6 shrink-0" />
@@ -201,7 +211,7 @@ export function ActivityImageLightbox({
           <div
             ref={imageSlotRef}
             data-lightbox-image-slot
-            className="relative isolate h-[min(78vh,720px)] min-h-[12rem] min-w-0 flex-1 basis-0 md:min-h-[16rem]"
+            className="relative isolate aspect-video max-h-dvh min-h-48 w-full max-w-full min-w-0 flex-1 basis-0 md:min-h-64"
             onClick={handleImageSlotClick}
           >
             <div

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
@@ -211,7 +211,7 @@ export function ActivityImageLightbox({
           <div
             ref={imageSlotRef}
             data-lightbox-image-slot
-            className="relative isolate aspect-video max-h-dvh min-h-48 w-full max-w-full min-w-0 flex-1 basis-0 md:min-h-64"
+            className="relative isolate h-[min(78vh,720px)] min-h-48 w-full max-w-full min-w-0 flex-1 basis-0 md:min-h-64"
             onClick={handleImageSlotClick}
           >
             <div

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
@@ -280,7 +280,7 @@
 }
 
 .reservation-detail-sheet__confirm-modal {
-  @apply w-full max-w-lg;
+  @apply mx-auto flex w-full max-w-lg justify-center;
 }
 
 .reservation-detail-sheet__confirm-modal .max-w-100 {

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -48,6 +48,66 @@
       transform: translateY(0);
     }
   }
+
+  /* 공통 모달: 오버레이·패널 */
+  --animate-modal-backdrop-in: modal-backdrop-in 0.22s ease-out forwards;
+  --animate-modal-backdrop-out: modal-backdrop-out 0.2s ease-in forwards;
+  --animate-modal-content-in: modal-content-in 0.32s
+    cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  --animate-modal-content-out: modal-content-out 0.2s ease-in forwards;
+  --animate-modal-footer-button-in: modal-footer-button-in 0.28s
+    cubic-bezier(0.16, 1, 0.3, 1) forwards;
+
+  @keyframes modal-backdrop-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes modal-backdrop-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes modal-content-in {
+    from {
+      opacity: 0;
+      transform: translate3d(0, 0.5rem, 0) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  @keyframes modal-content-out {
+    from {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translate3d(0, 0.35rem, 0) scale(0.985);
+    }
+  }
+
+  @keyframes modal-footer-button-in {
+    from {
+      opacity: 0;
+      transform: translate3d(0, 0.35rem, 0);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
 }
 
 @layer base {

--- a/src/shared/components/modal/ModalBase.tsx
+++ b/src/shared/components/modal/ModalBase.tsx
@@ -21,6 +21,7 @@ import type { ReactNode } from 'react';
 import { useId } from 'react';
 import { IcClose } from '@/shared/assets/icons';
 import { Heading } from '@/shared/components/heading';
+import { useRequestModalClose } from '@/shared/components/modal/modal-overlay/modal-overlay-close-context';
 import { cn } from '@/shared/utils/cn';
 
 interface ModalBaseProps {
@@ -46,13 +47,22 @@ export function ModalBase({
 }: ModalBaseProps) {
   const titleId = useId();
   const isHeaderVisible = Boolean(title || onClose);
+  const overlayClose = useRequestModalClose();
+
+  const handleHeaderClose = () => {
+    if (overlayClose) {
+      overlayClose.requestClose();
+      return;
+    }
+    onClose?.();
+  };
 
   return (
     <div
       role={role}
       aria-modal="true"
       aria-labelledby={title ? titleId : undefined}
-      className={cn('w-full max-w-135 rounded-3xl bg-white', className)}
+      className={cn('mx-auto w-full max-w-135 rounded-3xl bg-white', className)}
     >
       {isHeaderVisible && (
         <div className="relative px-7 pt-7">
@@ -65,8 +75,8 @@ export function ModalBase({
             <button
               type="button"
               aria-label="닫기"
-              onClick={onClose}
-              className="absolute top-7 right-7 flex h-8 w-8 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100"
+              onClick={handleHeaderClose}
+              className="absolute top-7 right-7 flex h-8 w-8 items-center justify-center rounded-full text-gray-500 transition-colors duration-200 ease-out hover:bg-gray-100 motion-safe:active:scale-90"
             >
               <IcClose aria-hidden="true" className="h-5 w-5" />
             </button>
@@ -88,6 +98,8 @@ export function ModalBase({
         <div
           className={cn(
             'flex items-center justify-center gap-3 px-7 pb-7',
+            'motion-safe:[&_button]:animate-modal-footer-button-in',
+            'motion-safe:[&_button:nth-of-type(2)]:delay-75',
             footerClassName
           )}
         >

--- a/src/shared/components/modal/OneButtonModal.tsx
+++ b/src/shared/components/modal/OneButtonModal.tsx
@@ -12,6 +12,8 @@
  *   onConfirm={handleClose}
  * />
  */
+'use client';
+
 import { Button } from '@/shared/components/buttons/button';
 import { ModalBase } from '@/shared/components/modal/ModalBase';
 

--- a/src/shared/components/modal/ReviewModal.tsx
+++ b/src/shared/components/modal/ReviewModal.tsx
@@ -116,7 +116,7 @@ export function ReviewModal({
             variant="primary"
             size="lg"
             onClick={onSubmit}
-            className="w-full"
+            className="motion-safe:animate-modal-footer-button-in w-full motion-safe:delay-100"
             disabled={isPending}
           >
             {isPending ? '리뷰 작성 중...' : '작성하기'}

--- a/src/shared/components/modal/TwoButtonModal.tsx
+++ b/src/shared/components/modal/TwoButtonModal.tsx
@@ -13,7 +13,10 @@
  *   onConfirm={handleConfirm}
  * />
  */
+'use client';
+
 import { Button } from '@/shared/components/buttons/button';
+import { useRequestModalClose } from '@/shared/components/modal/modal-overlay/modal-overlay-close-context';
 import { ModalBase } from '@/shared/components/modal/ModalBase';
 import { Spinner } from '@/shared/components/spinner';
 
@@ -34,6 +37,16 @@ export function TwoButtonModal({
   onConfirm,
   isPending = false,
 }: TwoButtonModalProps) {
+  const overlayClose = useRequestModalClose();
+
+  const handleCancel = () => {
+    if (overlayClose) {
+      overlayClose.requestClose();
+      return;
+    }
+    onCancel?.();
+  };
+
   return (
     <ModalBase
       role="alertdialog"
@@ -45,7 +58,7 @@ export function TwoButtonModal({
           <Button
             variant="secondary"
             size="lg"
-            onClick={onCancel}
+            onClick={handleCancel}
             className="w-full max-w-31.5"
             disabled={isPending}
           >

--- a/src/shared/components/modal/modal-overlay/index.tsx
+++ b/src/shared/components/modal/modal-overlay/index.tsx
@@ -48,17 +48,27 @@ export function ModalOverlay({
       : document.getElementById('modal-root');
 
   const [isExiting, setIsExiting] = useState(false);
-  const [reduceMotion, setReduceMotion] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  });
+  /** SSR과 첫 클라이언트 렌더를 맞추기 위해 초기값은 false, 마운트 후 rAF로 동기화 */
+  const [reduceMotion, setReduceMotion] = useState(false);
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const onChange = () => setReduceMotion(mq.matches);
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
+
+    const syncFromMedia = () => {
+      setReduceMotion(mq.matches);
+    };
+
+    const rafId = requestAnimationFrame(() => {
+      syncFromMedia();
+    });
+
+    mq.addEventListener('change', syncFromMedia);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      mq.removeEventListener('change', syncFromMedia);
+    };
   }, []);
 
   const clearExitTimer = useCallback(() => {
@@ -161,8 +171,8 @@ export function ModalOverlay({
           onMouseDown={handleBackdropMouseDown}
         />
 
-        <div className="pointer-events-none relative z-10 flex min-h-dvh w-full min-w-0 flex-col items-center justify-center px-5 py-8 md:px-8">
-          <div className="box-border w-full max-w-full shrink-0">
+        <div className="pointer-events-none relative z-10 flex min-h-dvh w-full min-w-0 flex-col items-center px-5 py-8 md:px-8">
+          <div className="my-auto box-border w-full max-w-full shrink-0">
             <div
               data-modal-content
               className={cn(

--- a/src/shared/components/modal/modal-overlay/index.tsx
+++ b/src/shared/components/modal/modal-overlay/index.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import type { MouseEvent, ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { ModalOverlayCloseContext } from '@/shared/components/modal/modal-overlay/modal-overlay-close-context';
 import { cn } from '@/shared/utils/cn';
+
+const MODAL_EXIT_MS = 220;
 
 interface ModalOverlayProps {
   children: ReactNode;
@@ -20,6 +23,8 @@ interface ModalOverlayProps {
  * - 오버레이 바깥 영역 클릭 시 모달 닫기 가능
  * - ESC 키 입력 시 모달 닫기 가능
  * - 모달이 열려 있는 동안 body 스크롤을 잠금
+ * - 열림/닫힘 시 배경·패널 전환 애니메이션 (`requestClose`로 닫을 때 동일)
+ * - `min-h-dvh` + 세로 플렉스로 뷰포트·모바일 주소창 변화에도 패널을 화면 중앙에 맞춤
  *
  * ※ ModalBase를 감싸서 사용하며, 중첩 모달에서는 사용하지 않음
  *
@@ -42,6 +47,55 @@ export function ModalOverlay({
       ? null
       : document.getElementById('modal-root');
 
+  const [isExiting, setIsExiting] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setReduceMotion(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  const clearExitTimer = useCallback(() => {
+    if (exitTimerRef.current !== null) {
+      clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+  }, []);
+
+  const runOnClose = useCallback(() => {
+    clearExitTimer();
+    onClose();
+  }, [clearExitTimer, onClose]);
+
+  const requestClose = useCallback(() => {
+    if (isExiting) return;
+
+    if (reduceMotion) {
+      runOnClose();
+      return;
+    }
+
+    setIsExiting(true);
+    exitTimerRef.current = setTimeout(() => {
+      exitTimerRef.current = null;
+      runOnClose();
+    }, MODAL_EXIT_MS);
+  }, [isExiting, reduceMotion, runOnClose]);
+
+  const overlayCloseContext = useMemo(() => ({ requestClose }), [requestClose]);
+
+  useEffect(() => {
+    return () => {
+      clearExitTimer();
+    };
+  }, [clearExitTimer]);
+
   // 모달이 열린 동안 배경 페이지가 스크롤되지 않도록 잠그고, unmount 시 원래 상태로 복구합니다.
   useEffect(() => {
     document.body.classList.add('overflow-hidden');
@@ -58,7 +112,7 @@ export function ModalOverlay({
     const handleEscapeKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
 
-      onClose();
+      requestClose();
     };
 
     window.addEventListener('keydown', handleEscapeKeyDown);
@@ -66,29 +120,62 @@ export function ModalOverlay({
     return () => {
       window.removeEventListener('keydown', handleEscapeKeyDown);
     };
-  }, [closeOnEscape, onClose]);
+  }, [closeOnEscape, requestClose]);
 
-  const handleOverlayMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+  const handleBackdropMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     if (!closeOnOverlayClick) return;
-
-    // 모달 내부 클릭은 무시하고, 오버레이 배경 자체를 클릭한 경우에만 닫습니다.
     if (event.target !== event.currentTarget) return;
 
-    onClose();
+    requestClose();
   };
 
   if (!portalRoot) return null;
 
+  const backdropAnimClass = reduceMotion
+    ? undefined
+    : isExiting
+      ? 'motion-safe:animate-modal-backdrop-out'
+      : 'motion-safe:animate-modal-backdrop-in';
+
+  const panelAnimClass = reduceMotion
+    ? undefined
+    : isExiting
+      ? 'motion-safe:animate-modal-content-out'
+      : 'motion-safe:animate-modal-content-in';
+
   return createPortal(
-    <div
-      className={cn(
-        'z-modal-backdrop fixed inset-0 flex items-center justify-center bg-black/70 px-5 md:px-8',
-        className
-      )}
-      onMouseDown={handleOverlayMouseDown}
-    >
-      {children}
-    </div>,
+    <ModalOverlayCloseContext.Provider value={overlayCloseContext}>
+      <div
+        className={cn(
+          'z-modal-backdrop pointer-events-auto fixed inset-0 overflow-y-auto',
+          className
+        )}
+      >
+        <div
+          data-modal-backdrop
+          aria-hidden
+          className={cn(
+            'pointer-events-auto fixed inset-0 z-0 bg-black/70',
+            backdropAnimClass
+          )}
+          onMouseDown={handleBackdropMouseDown}
+        />
+
+        <div className="pointer-events-none relative z-10 flex min-h-dvh w-full min-w-0 flex-col items-center justify-center px-5 py-8 md:px-8">
+          <div className="box-border w-full max-w-full shrink-0">
+            <div
+              data-modal-content
+              className={cn(
+                'pointer-events-auto mx-auto box-border w-full max-w-full min-w-0 origin-center',
+                panelAnimClass
+              )}
+            >
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalOverlayCloseContext.Provider>,
     portalRoot
   );
 }

--- a/src/shared/components/modal/modal-overlay/modal-overlay-close-context.tsx
+++ b/src/shared/components/modal/modal-overlay/modal-overlay-close-context.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export type ModalOverlayCloseContextValue = {
+  /** 닫기 애니메이션 후 부모 `onClose`를 호출합니다. `ModalOverlay` 바깥에서는 no-op입니다. */
+  requestClose: () => void;
+};
+
+export const ModalOverlayCloseContext =
+  createContext<ModalOverlayCloseContextValue | null>(null);
+
+export function useRequestModalClose(): ModalOverlayCloseContextValue | null {
+  return useContext(ModalOverlayCloseContext);
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #252 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

공통 `ModalOverlay`에 배경·패널 열림/닫힘 애니메이션과 `requestClose` 기반 닫기 흐름을 추가

뷰포트 기준으로 모달이 가운데 오도록 레이아웃(`min-h-dvh`, `딤 fixed`, `포인터 이벤트 분리`) 정리

`ModalBase` 푸터 버튼 등장 애니메이션·닫기 버튼 피드백 추가, `TwoButtonModal` 취소는 애니메이션 닫기,
확인은 기존처럼 `onConfirm`만 호출해 비동기 삭제/예약 취소 등이 깨지지 않게 처리

`OneButtonModal`은 확인 시 항상 `onConfirm`을 호출하도록 되돌려 비로그인 시 `로그인하기`→ `/login` 리다이렉트 동작하도록 수정
