### PR TITLE
[Feat/#251] 예약 현황 - 예약 상세카드 모달, 바텀시트 여닫힘 애니메이션 + 체험 상세 바텀시트 닫힘 애니메이션 구현

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
@@ -95,6 +95,18 @@ export function MobileReservationSheet({
     };
   }, []);
 
+  useEffect(() => {
+    isClosingRef.current = false;
+    if (!isOpen && closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    // effect 본문에서 동기 setState는 React Compiler 경고 대상 → 다음 마이크로태스크로 미룸
+    queueMicrotask(() => {
+      setIsClosing(false);
+    });
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   CalendarValue,
   MobileSheetStep,
@@ -9,6 +10,16 @@ import { TimeSlotButton } from '@/app/(main)/activity/[id]/components/time-slot-
 import { IcArrowLeft, IcMinus, IcPlus } from '@/shared/assets/icons';
 import { Button } from '@/shared/components/buttons/button';
 import { Heading } from '@/shared/components/heading';
+import { cn } from '@/shared/utils/cn';
+
+const MOBILE_RESERVATION_SHEET_CLOSE_MS = 320;
+
+function getMobileReservationSheetCloseMs() {
+  if (typeof window === 'undefined') return MOBILE_RESERVATION_SHEET_CLOSE_MS;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 0
+    : MOBILE_RESERVATION_SHEET_CLOSE_MS;
+}
 
 interface MobileReservationSheetProps {
   isOpen: boolean;
@@ -64,15 +75,45 @@ export function MobileReservationSheet({
   onSubmitReservation,
   tileDisabled,
 }: MobileReservationSheetProps) {
+  const isClosingRef = useRef(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const requestClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    isClosingRef.current = true;
+    setIsClosing(true);
+    const durationMs = getMobileReservationSheetCloseMs();
+    closeTimerRef.current = setTimeout(() => {
+      onClose();
+    }, durationMs);
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
   if (!isOpen) return null;
 
   return (
     <div
-      className="z-modal-backdrop animate-reservation-sheet-backdrop-in fixed inset-0 bg-black/60 2xl:hidden"
-      onClick={onClose}
+      className={cn(
+        'z-modal-backdrop fixed inset-0 bg-black/60 2xl:hidden',
+        isClosing
+          ? 'animate-reservation-sheet-backdrop-out'
+          : 'animate-reservation-sheet-backdrop-in'
+      )}
+      onClick={requestClose}
     >
       <section
-        className="animate-reservation-sheet-in shadow-review-card absolute right-0 bottom-0 left-0 max-h-dvh w-full overflow-y-auto overscroll-contain rounded-t-2xl bg-white px-5 pt-14 pb-5 md:pt-7 md:pb-5"
+        className={cn(
+          'shadow-review-card absolute right-0 bottom-0 left-0 max-h-dvh w-full overflow-y-auto overscroll-contain rounded-t-2xl bg-white px-5 pt-14 pb-5 md:pt-7 md:pb-5',
+          isClosing
+            ? 'animate-reservation-sheet-out'
+            : 'animate-reservation-sheet-in'
+        )}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="mx-auto w-full max-w-186">

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
@@ -73,6 +73,11 @@ export function ActivityReservationCard({
         onOpenDateSheet={handleOpenDateSheet}
       />
       <MobileReservationSheet
+        key={
+          isDateSheetOpen
+            ? 'mobile-reservation-sheet-open'
+            : 'mobile-reservation-sheet-closed'
+        }
         isOpen={isDateSheetOpen}
         mobileSheetStep={mobileSheetStep}
         hasSelectableDate={hasSelectableDate}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
@@ -73,11 +73,6 @@ export function ActivityReservationCard({
         onOpenDateSheet={handleOpenDateSheet}
       />
       <MobileReservationSheet
-        key={
-          isDateSheetOpen
-            ? 'mobile-reservation-sheet-open'
-            : 'mobile-reservation-sheet-closed'
-        }
         isOpen={isDateSheetOpen}
         mobileSheetStep={mobileSheetStep}
         hasSelectableDate={hasSelectableDate}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/reservation-calendar.css
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/reservation-calendar.css
@@ -265,3 +265,56 @@
 .animate-reservation-sheet-in {
   animation: reservation-sheet-in 220ms ease-out;
 }
+
+/**
+ * @description
+ * 바텀시트 닫힘: 딤 페이드 아웃
+ */
+@keyframes reservation-sheet-backdrop-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+/**
+ * @description
+ * 바텀시트 닫힘: 패널을 화면 아래로 슬라이드
+ */
+@keyframes reservation-sheet-out {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, 100%, 0);
+  }
+}
+
+.animate-reservation-sheet-backdrop-out {
+  animation: reservation-sheet-backdrop-out 320ms ease-in forwards;
+}
+
+.animate-reservation-sheet-out {
+  animation: reservation-sheet-out 320ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-reservation-sheet-backdrop-in,
+  .animate-reservation-sheet-in,
+  .animate-reservation-sheet-backdrop-out,
+  .animate-reservation-sheet-out {
+    animation: none;
+  }
+
+  .animate-reservation-sheet-backdrop-out {
+    opacity: 0;
+  }
+
+  .animate-reservation-sheet-out {
+    transform: translate3d(0, 100%, 0);
+  }
+}

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.tsx
@@ -73,6 +73,18 @@ export function ReservationDetailSheet({
     };
   }, []);
 
+  useEffect(() => {
+    isClosingRef.current = false;
+    if (!isOpen && closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    // effect 본문에서 동기 setState는 React Compiler 경고 대상 → 다음 마이크로태스크로 미룸
+    queueMicrotask(() => {
+      setIsClosing(false);
+    });
+  }, [isOpen]);
+
   const {
     activeTab,
     requests,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { formatDetailDate } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.constants';
 import { ReservationDetailSheetRequestList } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetRequestList';
 import { ReservationDetailSheetTabs } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetTabs';
@@ -9,6 +10,16 @@ import { Heading } from '@/shared/components/heading';
 import { OneButtonModal, TwoButtonModal } from '@/shared/components/modal';
 import { ModalOverlay } from '@/shared/components/modal/modal-overlay';
 import { cn } from '@/shared/utils/cn';
+
+/** 닫힘 전용 키프레임 길이와 맞춤 (모바일 바텀시트·배경 320ms, 2xl 플로팅 300ms 중 긴 쪽) */
+const DETAIL_SHEET_CLOSE_MS = 320;
+
+function getDetailSheetCloseDurationMs() {
+  if (typeof window === 'undefined') return DETAIL_SHEET_CLOSE_MS;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 0
+    : DETAIL_SHEET_CLOSE_MS;
+}
 
 interface ReservationDetailSheetProps {
   activityId: number;
@@ -42,6 +53,26 @@ export function ReservationDetailSheet({
   desktopPosition,
   onClose,
 }: ReservationDetailSheetProps) {
+  const isClosingRef = useRef(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const requestClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    isClosingRef.current = true;
+    setIsClosing(true);
+    const durationMs = getDetailSheetCloseDurationMs();
+    closeTimerRef.current = setTimeout(() => {
+      onClose();
+    }, durationMs);
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
   const {
     activeTab,
     requests,
@@ -72,7 +103,7 @@ export function ReservationDetailSheet({
     isOpen,
     selectedDate,
     detailData,
-    onClose,
+    onClose: requestClose,
   });
   const timeSlotOptions = detailData?.timeSlots.length
     ? detailData.timeSlots.map((timeSlot) => ({
@@ -85,15 +116,21 @@ export function ReservationDetailSheet({
 
   return (
     <div
-      className="reservation-detail-sheet__backdrop"
+      className={cn(
+        'reservation-detail-sheet__backdrop',
+        isClosing && 'reservation-detail-sheet__backdrop--closing'
+      )}
       role="dialog"
       aria-modal="true"
       aria-label="예약 상세"
-      onClick={onClose}
+      onClick={requestClose}
     >
       <section
         ref={sheetRef}
-        className="reservation-detail-sheet"
+        className={cn(
+          'reservation-detail-sheet',
+          isClosing && 'reservation-detail-sheet--closing'
+        )}
         style={desktopPosition ?? undefined}
         onClick={(event) => event.stopPropagation()}
       >
@@ -106,7 +143,7 @@ export function ReservationDetailSheet({
               type="button"
               className="reservation-detail-sheet__close"
               aria-label="예약 상세 닫기"
-              onClick={onClose}
+              onClick={requestClose}
             >
               <IcClose className="h-5 w-5" />
             </button>

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetTabs.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetTabs.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import {
   DETAIL_TABS,
   ReservationTab,
@@ -19,8 +20,17 @@ export function ReservationDetailSheetTabs({
   tabCount,
   onChangeTab,
 }: ReservationDetailSheetTabsProps) {
+  const activeIndex = DETAIL_TABS.indexOf(activeTab);
+  const tabNavStyle = {
+    ['--reservation-detail-tab-index' as string]: activeIndex,
+  } as CSSProperties;
+
   return (
-    <nav className="reservation-detail-sheet__tabs">
+    <nav
+      className="reservation-detail-sheet__tabs"
+      style={tabNavStyle}
+      aria-label="예약 상태 탭"
+    >
       {DETAIL_TABS.map((tabKey) => (
         <button
           key={tabKey}
@@ -34,6 +44,7 @@ export function ReservationDetailSheetTabs({
           {TAB_LABEL[tabKey]} {tabCount[tabKey]}
         </button>
       ))}
+      <span className="reservation-detail-sheet__tab-indicator" aria-hidden />
     </nav>
   );
 }

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetTabs.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheetTabs.tsx
@@ -22,7 +22,7 @@ export function ReservationDetailSheetTabs({
 }: ReservationDetailSheetTabsProps) {
   const activeIndex = DETAIL_TABS.indexOf(activeTab);
   const tabNavStyle = {
-    ['--reservation-detail-tab-index' as string]: activeIndex,
+    '--reservation-detail-tab-index': activeIndex,
   } as CSSProperties;
 
   return (

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservation-calendar.css
@@ -1,5 +1,69 @@
 @reference "../../../../../styles/globals.css";
 
+@keyframes reservation-detail-backdrop-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes reservation-detail-sheet-mobile-in {
+  from {
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes reservation-detail-sheet-desktop-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 10px, 0) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes reservation-detail-backdrop-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes reservation-detail-sheet-mobile-out {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, 100%, 0);
+  }
+}
+
+@keyframes reservation-detail-sheet-desktop-out {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(0, 14px, 0) scale(0.94);
+  }
+}
+
 /* ===== 예약 캘린더 기본 프레임/헤더 ===== */
 .reservation-status-calendar {
   @apply w-full rounded-3xl border-0 bg-white px-6;
@@ -131,10 +195,24 @@
 /* ===== 예약 상세 레이어(모바일: 바텀시트) ===== */
 .reservation-detail-sheet__backdrop {
   @apply z-modal-backdrop fixed inset-0 flex items-end justify-center bg-black/40;
+  animation: reservation-detail-backdrop-in 280ms ease-out both;
+}
+
+.reservation-detail-sheet__backdrop--closing {
+  animation: reservation-detail-backdrop-out 320ms ease-in forwards;
 }
 
 .reservation-detail-sheet {
   @apply shadow-card h-auto min-h-96 w-full max-w-none rounded-t-2xl bg-white pb-6;
+  animation: reservation-detail-sheet-mobile-in 280ms
+    cubic-bezier(0.32, 0.72, 0, 1) both;
+  will-change: transform;
+}
+
+.reservation-detail-sheet--closing {
+  animation: reservation-detail-sheet-mobile-out 320ms
+    cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  will-change: transform;
 }
 
 .reservation-detail-sheet__inner {
@@ -154,20 +232,25 @@
 }
 
 .reservation-detail-sheet__tabs {
-  @apply mb-3 grid h-10 grid-cols-3 border-b border-gray-100;
+  @apply relative mb-3 grid h-10 grid-cols-3 border-b border-gray-100;
+}
+
+.reservation-detail-sheet__tab-indicator {
+  @apply bg-primary-500 pointer-events-none absolute bottom-0 left-0 h-0.5 w-1/3 rounded-full;
+  transform: translate3d(
+    calc(100% * var(--reservation-detail-tab-index, 0)),
+    0,
+    0
+  );
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .reservation-detail-sheet__tab {
-  @apply typo-lg-medium relative flex h-10 items-center justify-center pb-2 text-gray-500;
+  @apply typo-lg-medium relative z-10 flex h-10 items-center justify-center pb-2 text-gray-500;
 }
 
 .reservation-detail-sheet__tab--active {
   @apply text-primary-500;
-}
-
-.reservation-detail-sheet__tab--active::after {
-  content: '';
-  @apply bg-primary-500 absolute -bottom-px left-0 h-0.5 w-full;
 }
 
 .reservation-detail-sheet__content {
@@ -395,12 +478,28 @@
   .reservation-detail-sheet__backdrop {
     /* 대형 화면에서는 전체 오버레이 대신 달력 내부 레이어처럼 동작 */
     @apply absolute inset-0 items-start justify-start bg-transparent p-0;
+    animation: none;
+    opacity: 1;
+  }
+
+  .reservation-detail-sheet__backdrop--closing {
+    animation: none;
+    opacity: 1;
   }
 
   .reservation-detail-sheet {
     /* 플로팅 패널은 내용 높이에 맞추고 바텀시트용 min-h-96은 적용x */
     @apply absolute h-auto min-h-0 w-80 max-w-none rounded-3xl pb-5;
     max-height: calc(100vh - theme(spacing.10));
+    animation: reservation-detail-sheet-desktop-in 260ms
+      cubic-bezier(0.32, 0.72, 0, 1) both;
+    will-change: transform, opacity;
+  }
+
+  .reservation-detail-sheet--closing {
+    animation: reservation-detail-sheet-desktop-out 300ms
+      cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    will-change: transform, opacity;
   }
 
   .reservation-detail-sheet__inner {
@@ -471,5 +570,38 @@
   .reservation-detail-sheet__request-scroll--fixed {
     /* 내용이 적을 때는 높이를 늘리지 않고 길 때만 max-height로 스크롤 */
     @apply max-h-60.75 min-h-0 pb-1.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reservation-detail-sheet__backdrop,
+  .reservation-detail-sheet {
+    animation: none;
+  }
+
+  .reservation-detail-sheet__backdrop--closing {
+    animation: none;
+    opacity: 0;
+  }
+
+  .reservation-detail-sheet--closing {
+    animation: none;
+    opacity: 0;
+    transform: translate3d(0, 100%, 0);
+  }
+
+  .reservation-detail-sheet__tab-indicator {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) and (min-width: theme(screens.2xl)) {
+  .reservation-detail-sheet {
+    animation: none;
+  }
+
+  .reservation-detail-sheet--closing {
+    opacity: 0;
+    transform: none;
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #251 
- close #250 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

예약 현황:
날짜 선택 시 상세 패널(`데스크톱 플로팅 카드` / `모바일·태블릿 바텀시트`)의 열림·닫힘을 키프레임 애니메이션으로 정리
닫힘: `transition`만 쓰지 않고 전용 `out 키프레임`으로 처리해 닫힐 때도 자연스럽게 보이도록 처리
`신청` / `승인` / `거절` 탭 아래 강조선: 한 줄 인디케이터가 슬라이드하도록 변경

체험 상세(모바일·태블릿):
예약 바텀시트 닫힘에 `배경 페이드 아웃` + `패널 슬라이드 다운`을 추가
시트 닫힌 후 날짜 선택하기가 막히던 문제: `key`로 시트 인스턴스를 분리해 닫힘 상태가 다음 오픈에 남지 않도록 처리

`prefers-reduced-motion`이 켜진 환경에서는 애니메이션·닫힘 지연을 줄이거나 생략하도록 맞춰 처리
