### PR TITLE
[Fix/#266] 체험 상세 - 오늘날짜 자동선택로직 수정

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -92,11 +92,11 @@ export const useActivityReservationCardState = ({
       cancelAnimationFrame(frameId);
     };
     /**
-     * 예약 성공 후 `setSelectedDateKey(null)`로 초기화되면, 가용 날짜 시그니처가
+     * 예약 성공 후 setSelectedDateKey(null)로 초기화되면 가용 날짜 시그니처가
      * 그대로인 경우 effect가 재실행되지 않아 오늘 자동선택이 복구되지 않는다.
-     * `selectedDateKey`를 함께 구독해 null로 돌아온 뒤에도 동일 규칙으로 다시 잡는다.
+     * selectedDateKey를 함께 구독해 null로 돌아온 뒤에도 동일 규칙으로 적용
      */
-  }, [availableDateKeysSignature, selectedDateKey]);
+  }, [availableDateKeys, selectedDateKey]);
   const effectiveSelectedDateKey = selectedDateKey;
 
   const parsedSelectedDate = useMemo(() => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -91,7 +91,12 @@ export const useActivityReservationCardState = ({
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [availableDateKeysSignature]);
+    /**
+     * 예약 성공 후 `setSelectedDateKey(null)`로 초기화되면, 가용 날짜 시그니처가
+     * 그대로인 경우 effect가 재실행되지 않아 오늘 자동선택이 복구되지 않는다.
+     * `selectedDateKey`를 함께 구독해 null로 돌아온 뒤에도 동일 규칙으로 다시 잡는다.
+     */
+  }, [availableDateKeysSignature, selectedDateKey]);
   const effectiveSelectedDateKey = selectedDateKey;
 
   const parsedSelectedDate = useMemo(() => {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #266 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

체험 상세에서 예약 가능한 가장 빠른 날이 오늘일 때 자동으로 오늘을 고르는 로직이
예약 성공 후 `selectedDateKey`가 `null`로 초기화될 때는 다시 실행되지 않던 문제 해결

오늘 자동선택 `useEffect`의 의존성에 `selectedDateKey`를 포함해 예약 완료, 모달 확인 후에도 `가장 빠른 날이 오늘이면 오늘 선택` 규칙이 다시 적용되도록 수정
