### PR TITLE
[Feat/#268] 공통 드롭다운 열림 애니메이션 추가

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -108,6 +108,18 @@
       transform: translate3d(0, 0, 0);
     }
   }
+
+  /* 공통 드롭다운: transform 없이 opacity만 (fieldInput 결합 테두리·ring 정렬 유지) */
+  --animate-dropdown-menu-in: dropdown-menu-in 0.2s ease-out forwards;
+
+  @keyframes dropdown-menu-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 }
 
 @layer base {

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -206,8 +206,8 @@ export function Dropdown({
         {isOpen && (
           <div
             className={cn(
-              'z-dropdown absolute inset-x-0 top-full',
-              !isFieldVariant && 'min-w-0'
+              'z-dropdown absolute top-full',
+              isFieldVariant ? 'inset-x-0' : 'left-0'
             )}
           >
             <div className="animate-dropdown-menu-in motion-reduce:animate-none">

--- a/src/shared/components/dropdown/index.tsx
+++ b/src/shared/components/dropdown/index.tsx
@@ -204,55 +204,62 @@ export function Dropdown({
         </button>
 
         {isOpen && (
-          <ul
-            id={listboxId}
-            role="listbox"
-            ref={listboxRef}
+          <div
             className={cn(
-              // 공통 필수 속성 및 비활성화 상태
-              'z-dropdown absolute top-full left-0 overflow-y-auto border bg-white',
-              // 상수 파일의 디자인 및 커스텀 클래스
-              MENU_VARIANT_CLASS[variant],
-              menuClassName,
-              // 추가 상태
-              errorMessage &&
-                variant === 'fieldInput' &&
-                FIELD_INPUT_ERROR_FOCUS_CLASS
+              'z-dropdown absolute inset-x-0 top-full',
+              !isFieldVariant && 'min-w-0'
             )}
-            style={{ maxHeight: menuMaxHeight }}
           >
-            {options.map((option, index) => {
-              const isSelected = option.value === value;
-              const isOptionDisabled = option.disabled;
+            <div className="animate-dropdown-menu-in motion-reduce:animate-none">
+              <ul
+                id={listboxId}
+                role="listbox"
+                ref={listboxRef}
+                className={cn(
+                  'm-0 list-none overflow-y-auto border bg-white p-0 text-left',
+                  MENU_VARIANT_CLASS[variant],
+                  menuClassName,
+                  errorMessage &&
+                    variant === 'fieldInput' &&
+                    FIELD_INPUT_ERROR_FOCUS_CLASS
+                )}
+                style={{ maxHeight: menuMaxHeight }}
+              >
+                {options.map((option, index) => {
+                  const isSelected = option.value === value;
+                  const isOptionDisabled = option.disabled;
 
-              return (
-                <li key={option.value}>
-                  <button
-                    id={`${listboxId}-option-${index}`}
-                    type="button"
-                    role="option"
-                    disabled={isOptionDisabled}
-                    aria-selected={isSelected}
-                    className={cn(
-                      'typo-lg-medium flex w-full cursor-pointer items-center px-5 text-left text-gray-950 transition-colors',
-                      isSelected && 'bg-primary-100 text-primary-500',
-                      isOptionDisabled && 'cursor-not-allowed text-gray-400',
-                      index === focusedIndex &&
-                        !isOptionDisabled &&
-                        'bg-primary-100 text-primary-500'
-                    )}
-                    style={{ height: optionHeight }}
-                    onPointerEnter={() =>
-                      !isOptionDisabled && setFocusedIndex(index)
-                    }
-                    onClick={() => handleOptionClick(option)}
-                  >
-                    <span className="truncate">{option.label}</span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+                  return (
+                    <li key={option.value}>
+                      <button
+                        id={`${listboxId}-option-${index}`}
+                        type="button"
+                        role="option"
+                        disabled={isOptionDisabled}
+                        aria-selected={isSelected}
+                        className={cn(
+                          'typo-lg-medium flex w-full cursor-pointer items-center px-5 text-left text-gray-950 transition-colors',
+                          isSelected && 'bg-primary-100 text-primary-500',
+                          isOptionDisabled &&
+                            'cursor-not-allowed text-gray-400',
+                          index === focusedIndex &&
+                            !isOptionDisabled &&
+                            'bg-primary-100 text-primary-500'
+                        )}
+                        style={{ height: optionHeight }}
+                        onPointerEnter={() =>
+                          !isOptionDisabled && setFocusedIndex(index)
+                        }
+                        onClick={() => handleOptionClick(option)}
+                      >
+                        <span className="truncate">{option.label}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </div>
         )}
       </div>
       {errorMessage && (


### PR DESCRIPTION
## 🔗 관련 이슈

- close #268 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

공통 `Dropdown` 메뉴가 열릴 때 짧은 `opacity` 페이드 인 애니메이션을 적용 (`@theme의 dropdown-menu-in` 토큰)

`fieldInput` 등 트리거와 패널 테두리가 어긋나지 않도록 메뉴를 `absolute` 래퍼(`inset-x-0`)로 두고
애니메이션은 `ul` 바깥 내부 래퍼에만 걸어 `transform`이 리스트 박스에 닿지 않게 처리

`prefers-reduced-motion` 사용자를 위해 `motion-reduce:animate-none` 유지
