### PR TITLE
[Fix/#217] filter버튼 애니메이션 로직 수정

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -195,3 +195,22 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
+
+/* FilterButton: 탭 투 클릭·초 단축 클릭에서도 눌림이 보이도록 짧은 키프레임(상태 클래스는 JS에서 토글) */
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes filter-button-press {
+    0% {
+      transform: translate3d(0, 1px, 0) scale(0.96);
+    }
+    50% {
+      transform: translate3d(0, 1px, 0) scale(0.96);
+    }
+    100% {
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  .filter-button-press-animate {
+    animation: filter-button-press 0.14s ease-out both;
+  }
+}

--- a/src/shared/components/buttons/filter-button/filterButton.constants.ts
+++ b/src/shared/components/buttons/filter-button/filterButton.constants.ts
@@ -17,10 +17,10 @@ export const FILTER_BUTTON_PRESS_ANIMATE_CLASS = 'filter-button-press-animate';
  */
 export const filterButtonVariants = cva(
   [
-    'text-md px-em inline-flex h-9.25 cursor-pointer items-center justify-center gap-1 rounded-full',
+    'typo-md px-em inline-flex h-9.25 cursor-pointer items-center justify-center gap-1 rounded-full',
     'border font-medium text-gray-950',
     'transition-[background-color,border-color,color] duration-200 ease-out',
-    'md:h-11 md:gap-1.5 md:text-lg',
+    'md:typo-lg md:h-11 md:gap-1.5',
   ].join(' '),
   {
     variants: {

--- a/src/shared/components/buttons/filter-button/filterButton.constants.ts
+++ b/src/shared/components/buttons/filter-button/filterButton.constants.ts
@@ -6,6 +6,9 @@ import { cva } from 'class-variance-authority';
  */
 export const FILTER_ICON_CLASS = 'block shrink-0 w-4 h-4 md:w-6 md:h-6';
 
+/** globals.css의 @keyframes filter-button-press / .filter-button-press-animate 와 이름을 맞출 것 */
+export const FILTER_BUTTON_PRESS_ANIMATE_CLASS = 'filter-button-press-animate';
+
 /**
  * size variant 없이 반응형 단일 클래스로 처리
  * - 모바일(기본): h-[37px] gap-1 px-em text-md
@@ -13,13 +16,19 @@ export const FILTER_ICON_CLASS = 'block shrink-0 w-4 h-4 md:w-6 md:h-6';
  * - px-em: 폰트 크기에 비례한 좌우 패딩, py 불필요 (items-center 수직 정렬)
  */
 export const filterButtonVariants = cva(
-  'text-md px-em inline-flex h-9.25 cursor-pointer items-center justify-center gap-1 rounded-full transition-all duration-200 md:h-11 md:gap-1.5 md:text-lg',
+  [
+    'text-md px-em inline-flex h-9.25 cursor-pointer items-center justify-center gap-1 rounded-full',
+    'border font-medium text-gray-950',
+    'transition-[background-color,border-color,color] duration-200 ease-out',
+    'md:h-11 md:gap-1.5 md:text-lg',
+  ].join(' '),
   {
     variants: {
       state: {
         normal:
-          'border border-[#D8D8D8] bg-white font-medium text-gray-950 hover:border-transparent hover:bg-[#333333] hover:font-bold hover:text-white',
-        active: 'bg-[#333333] font-bold text-white',
+          'border-[#D8D8D8] bg-white hover:border-transparent hover:bg-[#333333] hover:text-white',
+        // normal과 동일한 1px 테두리 유지(배경과 같은 색) → 선택/해제 시 가로 폭이 변하지 않음
+        active: 'border-[#333333] bg-[#333333] text-white',
       },
     },
     defaultVariants: {

--- a/src/shared/components/buttons/filter-button/index.tsx
+++ b/src/shared/components/buttons/filter-button/index.tsx
@@ -28,7 +28,7 @@ const PRESS_ANIM_DEBOUNCE_MS = 55;
  * - `state="active"` : 검정 배경 + 흰 텍스트(테두리는 배경색과 동일하게 유지해 폭이 바뀌지 않음)
  * - 반응형 크기: 모바일 h-[37px] → PC/TB h-11 (md: 기준)
  * - 눌림 피드백은 짧은 CSS 키프레임으로 처리한다. 클래스는 React `className`에 포함해 부모 리렌더 후에도 유지되며,
- *   맥 탭 투 클릭 대비로 `mousedown`/`pointerdown`/`click`에서 모두 트리거
+ *   포인터 입력은 `onPointerDown`에서만, 키보드(스페이스/엔터) 활성화는 `onClick`에서만 트리거해 중복 실행 방어
  *
  * @example
  * <FilterButton label="문화 · 예술" icon={<IcArt />} state="normal" />
@@ -51,13 +51,15 @@ export function FilterButton({
   className,
   disabled,
   onClick,
-  onMouseDown,
   onPointerDown,
+  onPointerUp,
+  onPointerLeave,
   onAnimationEnd,
   ...rest
 }: FilterButtonProps) {
   const rootRef = useRef<HTMLButtonElement>(null);
   const lastPressAnimAt = useRef(0);
+  const suppressNextClickBumpRef = useRef(false);
   const [pressToken, setPressToken] = useState(0);
 
   const styledIcon = useMemo(() => {
@@ -105,16 +107,6 @@ export function FilterButton({
     el.classList.add(FILTER_BUTTON_PRESS_ANIMATE_CLASS);
   }, [pressToken]);
 
-  const handlePressGesture = useCallback(
-    (e: React.MouseEvent | React.PointerEvent) => {
-      if (disabled || e.button !== 0) {
-        return;
-      }
-      bumpPressAnimation();
-    },
-    [disabled, bumpPressAnimation]
-  );
-
   return (
     <button
       {...rest}
@@ -128,21 +120,32 @@ export function FilterButton({
       )}
       onPointerDown={(e) => {
         onPointerDown?.(e);
-        if (e.defaultPrevented) {
+        if (e.defaultPrevented || disabled || e.button !== 0) {
           return;
         }
-        handlePressGesture(e);
+        suppressNextClickBumpRef.current = true;
+        bumpPressAnimation();
       }}
-      onMouseDown={(e) => {
-        onMouseDown?.(e);
-        if (e.defaultPrevented) {
-          return;
-        }
-        handlePressGesture(e);
+      onPointerUp={(e) => {
+        onPointerUp?.(e);
+        window.setTimeout(() => {
+          if (suppressNextClickBumpRef.current) {
+            suppressNextClickBumpRef.current = false;
+          }
+        }, 0);
+      }}
+      onPointerLeave={(e) => {
+        onPointerLeave?.(e);
+        suppressNextClickBumpRef.current = false;
       }}
       onClick={(e) => {
         onClick?.(e);
         if (e.defaultPrevented || disabled) {
+          suppressNextClickBumpRef.current = false;
+          return;
+        }
+        if (suppressNextClickBumpRef.current) {
+          suppressNextClickBumpRef.current = false;
           return;
         }
         bumpPressAnimation();

--- a/src/shared/components/buttons/filter-button/index.tsx
+++ b/src/shared/components/buttons/filter-button/index.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import { cloneElement, isValidElement, useMemo } from 'react';
 import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  FILTER_BUTTON_PRESS_ANIMATE_CLASS,
   FILTER_ICON_CLASS,
   filterButtonVariants,
 } from '@/shared/components/buttons/filter-button/filterButton.constants';
@@ -10,12 +19,16 @@ import { cn } from '@/shared/utils/cn';
 
 export type { FilterButtonProps } from '@/shared/components/buttons/filter-button/filterButton.types';
 
+const PRESS_ANIM_DEBOUNCE_MS = 55;
+
 /**
  * pill 형태의 필터·토글용 버튼
  *
  * - `state="normal"` : 흰 배경 + 회색 테두리
- * - `state="active"` : 검정 배경 + 흰 텍스트
+ * - `state="active"` : 검정 배경 + 흰 텍스트(테두리는 배경색과 동일하게 유지해 폭이 바뀌지 않음)
  * - 반응형 크기: 모바일 h-[37px] → PC/TB h-11 (md: 기준)
+ * - 눌림 피드백은 짧은 CSS 키프레임으로 처리한다. 클래스는 React `className`에 포함해 부모 리렌더 후에도 유지되며,
+ *   맥 탭 투 클릭 대비로 `mousedown`/`pointerdown`/`click`에서 모두 트리거한다.
  *
  * @example
  * <FilterButton label="문화 · 예술" icon={<IcArt />} state="normal" />
@@ -36,8 +49,17 @@ export function FilterButton({
   icon,
   state = 'normal',
   className,
+  disabled,
+  onClick,
+  onMouseDown,
+  onPointerDown,
+  onAnimationEnd,
   ...rest
 }: FilterButtonProps) {
+  const rootRef = useRef<HTMLButtonElement>(null);
+  const lastPressAnimAt = useRef(0);
+  const [pressToken, setPressToken] = useState(0);
+
   const styledIcon = useMemo(() => {
     if (!icon || !isValidElement(icon)) {
       return icon;
@@ -50,11 +72,87 @@ export function FilterButton({
     });
   }, [icon]);
 
+  const bumpPressAnimation = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    const now = performance.now();
+    if (now - lastPressAnimAt.current < PRESS_ANIM_DEBOUNCE_MS) {
+      return;
+    }
+    lastPressAnimAt.current = now;
+
+    setPressToken((t) => t + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (pressToken === 0) {
+      return;
+    }
+
+    const el = rootRef.current;
+    if (!el) {
+      return;
+    }
+
+    el.classList.remove(FILTER_BUTTON_PRESS_ANIMATE_CLASS);
+    void el.offsetWidth;
+    el.classList.add(FILTER_BUTTON_PRESS_ANIMATE_CLASS);
+  }, [pressToken]);
+
+  const handlePressGesture = useCallback(
+    (e: React.MouseEvent | React.PointerEvent) => {
+      if (disabled || e.button !== 0) {
+        return;
+      }
+      bumpPressAnimation();
+    },
+    [disabled, bumpPressAnimation]
+  );
+
   return (
     <button
-      type="button"
-      className={cn(filterButtonVariants({ state }), className)}
       {...rest}
+      ref={rootRef}
+      type="button"
+      disabled={disabled}
+      className={cn(
+        filterButtonVariants({ state }),
+        pressToken > 0 && FILTER_BUTTON_PRESS_ANIMATE_CLASS,
+        className
+      )}
+      onPointerDown={(e) => {
+        onPointerDown?.(e);
+        if (e.defaultPrevented) {
+          return;
+        }
+        handlePressGesture(e);
+      }}
+      onMouseDown={(e) => {
+        onMouseDown?.(e);
+        if (e.defaultPrevented) {
+          return;
+        }
+        handlePressGesture(e);
+      }}
+      onClick={(e) => {
+        onClick?.(e);
+        if (e.defaultPrevented || disabled) {
+          return;
+        }
+        bumpPressAnimation();
+      }}
+      onAnimationEnd={(e) => {
+        if (e.animationName === 'filter-button-press') {
+          setPressToken(0);
+        }
+        onAnimationEnd?.(e);
+      }}
     >
       {styledIcon}
       <span>{label}</span>

--- a/src/shared/components/buttons/filter-button/index.tsx
+++ b/src/shared/components/buttons/filter-button/index.tsx
@@ -4,7 +4,7 @@ import {
   cloneElement,
   isValidElement,
   useCallback,
-  useLayoutEffect,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -28,7 +28,7 @@ const PRESS_ANIM_DEBOUNCE_MS = 55;
  * - `state="active"` : 검정 배경 + 흰 텍스트(테두리는 배경색과 동일하게 유지해 폭이 바뀌지 않음)
  * - 반응형 크기: 모바일 h-[37px] → PC/TB h-11 (md: 기준)
  * - 눌림 피드백은 짧은 CSS 키프레임으로 처리한다. 클래스는 React `className`에 포함해 부모 리렌더 후에도 유지되며,
- *   맥 탭 투 클릭 대비로 `mousedown`/`pointerdown`/`click`에서 모두 트리거한다.
+ *   맥 탭 투 클릭 대비로 `mousedown`/`pointerdown`/`click`에서 모두 트리거
  *
  * @example
  * <FilterButton label="문화 · 예술" icon={<IcArt />} state="normal" />
@@ -90,7 +90,7 @@ export function FilterButton({
     setPressToken((t) => t + 1);
   }, []);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (pressToken === 0) {
       return;
     }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #271 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

메인 카테고리 필터(`FilterButton`) 선택·해제 시 가로로 밀리던 현상을 줄이기 위해
`normal` / `active` 모두 `1px` 테두리 유지, 글자 굵기·호버 시 `bold`로 인한 폭 변화 제거
`transition-all` 대신 배경·테두리·글자색만 전환하도록 조정

맥 탭 투 클릭처럼 눌림이 거의 보이지 않던 경우 발생, 짧은 키프레임 눌림 애니메이션 추가,
`pointerdown` / `mousedown` / `click`에서 트리거

애니메이션 클래스를 `React className`에 포함해 카테고리 변경 등 부모 리렌더 후에도 유지되도록 처리
`useLayoutEffect`로 키프레임이 매번 재생되도록 처리
`prefers-reduced-motion: reduce`일 때는 눌림 키프레임 적용x

## 💬 리뷰 포인트

브랜치 번호를 271로 했어야 했는데 217로 생성했습니당 ..ㅎ....
