### PR TITLE
[Fix/#263] 예약 현황 - 체험 시간 경과 대기예약 자동거절 뱃지 표시 로직 수정

### DIFF
--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -69,7 +69,7 @@ export const useReservationCalendarData = ({
     return (
       now.getFullYear() === currentYear && now.getMonth() + 1 === currentMonth
     );
-  }, [currentYear, currentMonth]);
+  }, [currentYear, currentMonth, todayDateKey]);
 
   const fetchTodayScheduleInBackground =
     isTodayInVisibleMonth &&

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -26,9 +26,9 @@ const ACTIVITY_RESERVATION_CACHE_ROOTS = [
 
 const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
   schedules.some((schedule) => {
-    const pending = Math.max(schedule.count.pending ?? 0, 0);
-    const confirmed = Math.max(schedule.count.confirmed ?? 0, 0);
-    const declined = Math.max(schedule.count.declined ?? 0, 0);
+    const pending = Math.max(schedule.count.pending, 0);
+    const confirmed = Math.max(schedule.count.confirmed, 0);
+    const declined = Math.max(schedule.count.declined, 0);
     return pending + confirmed + declined > 0;
   });
 
@@ -165,7 +165,7 @@ export const useReservationCalendarData = ({
 
     for (const { dateKey, schedules } of scheduleLoads) {
       for (const schedule of schedules) {
-        if (Math.max(schedule.count.pending ?? 0, 0) <= 0) continue;
+        if (Math.max(schedule.count.pending, 0) <= 0) continue;
         if (!isScheduleStartReached(dateKey, schedule.startTime, now)) continue;
         if (autoDeclineAttemptedScheduleIdsRef.current.has(schedule.scheduleId))
           continue;

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -24,6 +24,14 @@ const ACTIVITY_RESERVATION_CACHE_ROOTS = [
   QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD[0],
 ] as const;
 
+const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
+  schedules.some((schedule) => {
+    const pending = Math.max(schedule.count.pending ?? 0, 0);
+    const confirmed = Math.max(schedule.count.confirmed ?? 0, 0);
+    const declined = Math.max(schedule.count.declined ?? 0, 0);
+    return pending + confirmed + declined > 0;
+  });
+
 interface UseReservationCalendarDataProps {
   activityId: number | null;
   currentYear: number;
@@ -34,8 +42,9 @@ interface UseReservationCalendarDataProps {
 /**
  * 예약 캘린더 화면에서 필요한 조회 데이터를 한 번에 조합
  *
- * 월간 `reservation-dashboard`로 달력 배지·알림 도트를 구성하고, 상세 패널이 연 선택일에 한해
- * `reserved-schedule`을 조회해 배지 집계를 스케줄 단위로 보정
+ * 월간 `reservation-dashboard`로 달력 배지·알림 도트를 구성하고, URL로 연 선택일·그리고
+ * 현재 보이는 달에 포함된 오늘 날짜에 대해 `reserved-schedule`을 조회해 배지 집계를 스케줄 단위로 보정
+ * (오늘만 선택하지 않아도 지난 슬롯의 pending이 대시보드에 남는 문제를 막기 위함)
  * 대시보드에 없는 날을 URL로만 열었을 때의 도트는 선택일 스케줄 응답으로만 보강
  *
  * 선택한 날짜의 스케줄을 조회한 뒤 체험 시작 시각이 지난 슬롯의 대기(pending) 예약을 클라이언트에서 자동 거절
@@ -54,6 +63,19 @@ export const useReservationCalendarData = ({
   /** 선택일·체험이 바뀌기 전까지 자동 거절을 이미 시도한 `scheduleId` (무한 invalidate 루프 방지) */
   const autoDeclineAttemptedScheduleIdsRef = useRef<Set<number>>(new Set());
 
+  const todayDateKey = formatDateKey(new Date());
+  const isTodayInVisibleMonth = useMemo(() => {
+    const now = new Date();
+    return (
+      now.getFullYear() === currentYear && now.getMonth() + 1 === currentMonth
+    );
+  }, [currentYear, currentMonth]);
+
+  const fetchTodayScheduleInBackground =
+    isTodayInVisibleMonth &&
+    (reservedScheduleDateKey === null ||
+      reservedScheduleDateKey !== todayDateKey);
+
   const { data: reservationDashboard = [] } = useQuery({
     queryKey: [
       ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
@@ -71,7 +93,7 @@ export const useReservationCalendarData = ({
     refetchInterval: activityId !== null ? 60_000 : false,
   });
 
-  const { data: reservedSchedules = [] } = useQuery({
+  const { data: reservedSchedulesSelected = [] } = useQuery({
     queryKey: [
       ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
       activityId,
@@ -87,26 +109,71 @@ export const useReservationCalendarData = ({
       activityId !== null && Boolean(reservedScheduleDateKey) ? 60_000 : false,
   });
 
+  const { data: reservedSchedulesToday = [] } = useQuery({
+    queryKey: [
+      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
+      activityId,
+      todayDateKey,
+    ],
+    queryFn: () =>
+      fetchReservedSchedule({
+        activityId: activityId as number,
+        date: todayDateKey,
+      }),
+    enabled: activityId !== null && fetchTodayScheduleInBackground,
+    refetchInterval:
+      activityId !== null && fetchTodayScheduleInBackground ? 60_000 : false,
+  });
+
   useEffect(() => {
     autoDeclineAttemptedScheduleIdsRef.current.clear();
-  }, [activityId, reservedScheduleDateKey]);
+  }, [activityId, reservedScheduleDateKey, todayDateKey]);
 
   useEffect(() => {
-    if (activityId === null || reservedScheduleDateKey === null) return;
-    if (reservedSchedules.length === 0) return;
+    if (activityId === null) return;
+
+    const scheduleLoads: {
+      dateKey: string;
+      schedules: ReservedScheduleItem[];
+    }[] = [];
+
+    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
+      scheduleLoads.push({
+        dateKey: reservedScheduleDateKey,
+        schedules: reservedSchedulesSelected,
+      });
+    }
+
+    if (
+      fetchTodayScheduleInBackground &&
+      reservedSchedulesToday.length > 0 &&
+      !scheduleLoads.some((entry) => entry.dateKey === todayDateKey)
+    ) {
+      scheduleLoads.push({
+        dateKey: todayDateKey,
+        schedules: reservedSchedulesToday,
+      });
+    }
+
+    if (scheduleLoads.length === 0) return;
 
     const now = new Date();
-    const startPassedWithPending = reservedSchedules.filter(
-      (schedule) =>
-        Math.max(schedule.count.pending ?? 0, 0) > 0 &&
-        isScheduleStartReached(reservedScheduleDateKey, schedule.startTime, now)
-    );
+    const candidatesByScheduleId = new Map<
+      number,
+      { dateKey: string; schedule: ReservedScheduleItem }
+    >();
 
-    const candidates = startPassedWithPending.filter(
-      (schedule) =>
-        !autoDeclineAttemptedScheduleIdsRef.current.has(schedule.scheduleId)
-    );
+    for (const { dateKey, schedules } of scheduleLoads) {
+      for (const schedule of schedules) {
+        if (Math.max(schedule.count.pending ?? 0, 0) <= 0) continue;
+        if (!isScheduleStartReached(dateKey, schedule.startTime, now)) continue;
+        if (autoDeclineAttemptedScheduleIdsRef.current.has(schedule.scheduleId))
+          continue;
+        candidatesByScheduleId.set(schedule.scheduleId, { dateKey, schedule });
+      }
+    }
 
+    const candidates = [...candidatesByScheduleId.values()];
     if (candidates.length === 0) return;
 
     let cancelled = false;
@@ -114,7 +181,7 @@ export const useReservationCalendarData = ({
     void (async () => {
       let declinedAny = false;
 
-      for (const schedule of candidates) {
+      for (const { schedule } of candidates) {
         if (cancelled) return;
 
         try {
@@ -149,10 +216,18 @@ export const useReservationCalendarData = ({
     return () => {
       cancelled = true;
     };
-  }, [activityId, queryClient, reservedScheduleDateKey, reservedSchedules]);
+  }, [
+    activityId,
+    fetchTodayScheduleInBackground,
+    queryClient,
+    reservedScheduleDateKey,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+    todayDateKey,
+  ]);
 
   const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
-    const todayDateKey = formatDateKey(new Date());
+    const todayKey = formatDateKey(new Date());
     const notificationDotByDate: Record<string, boolean> = {};
 
     const eventCounts = reservationDashboard.reduce<
@@ -163,17 +238,18 @@ export const useReservationCalendarData = ({
       const confirmed = Math.max(r.confirmed ?? 0, 0);
       const pending = Math.max(r.pending ?? 0, 0);
       const declined = Math.max(r.declined ?? 0, 0);
-      const rawTotal = pending + confirmed + completed + declined;
+      const isPastDate = item.date < todayKey;
+      const pendingForDisplay = isPastDate ? 0 : pending;
+      const rawTotal = pendingForDisplay + confirmed + completed + declined;
       if (rawTotal > 0) {
         notificationDotByDate[item.date] = true;
       }
 
-      const isPastDate = item.date < todayDateKey;
       const shiftedCompleted = isPastDate ? completed + confirmed : completed;
       const shiftedConfirmed = isPastDate ? 0 : confirmed;
 
       const dailyEventCounts: ReservationEventCounts = {};
-      if (pending > 0) dailyEventCounts.pending = pending;
+      if (pendingForDisplay > 0) dailyEventCounts.pending = pendingForDisplay;
       if (shiftedConfirmed > 0) dailyEventCounts.confirmed = shiftedConfirmed;
       if (shiftedCompleted > 0) dailyEventCounts.completed = shiftedCompleted;
 
@@ -184,21 +260,33 @@ export const useReservationCalendarData = ({
       return accumulator;
     }, {});
 
-    if (reservedScheduleDateKey) {
-      const hasSelectedDaySlotActivity = reservedSchedules.some((schedule) => {
-        const pending = Math.max(schedule.count.pending ?? 0, 0);
-        const confirmed = Math.max(schedule.count.confirmed ?? 0, 0);
-        const declined = Math.max(schedule.count.declined ?? 0, 0);
-        return pending + confirmed + declined > 0;
-      });
-      if (hasSelectedDaySlotActivity) {
-        notificationDotByDate[reservedScheduleDateKey] = true;
-      }
+    if (
+      reservedScheduleDateKey &&
+      hasReservedSlotActivity(reservedSchedulesSelected)
+    ) {
+      notificationDotByDate[reservedScheduleDateKey] = true;
+    }
+
+    if (
+      fetchTodayScheduleInBackground &&
+      hasReservedSlotActivity(reservedSchedulesToday)
+    ) {
+      notificationDotByDate[todayKey] = true;
     }
 
     const scheduleDataByDate = new Map<string, ReservedScheduleItem[]>();
-    if (reservedScheduleDateKey) {
-      scheduleDataByDate.set(reservedScheduleDateKey, reservedSchedules);
+    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
+      scheduleDataByDate.set(
+        reservedScheduleDateKey,
+        reservedSchedulesSelected
+      );
+    }
+    if (
+      fetchTodayScheduleInBackground &&
+      reservedSchedulesToday.length > 0 &&
+      todayKey !== reservedScheduleDateKey
+    ) {
+      scheduleDataByDate.set(todayKey, reservedSchedulesToday);
     }
 
     const nowForSchedules = new Date();
@@ -215,13 +303,19 @@ export const useReservationCalendarData = ({
     });
 
     return { eventCountsByDate: eventCounts, notificationDotByDate };
-  }, [reservationDashboard, reservedScheduleDateKey, reservedSchedules]);
+  }, [
+    fetchTodayScheduleInBackground,
+    reservationDashboard,
+    reservedScheduleDateKey,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+  ]);
 
   const detailData = useMemo<ReservationDetailData>(() => {
     return buildReservationDetailData({
-      reservedSchedules,
+      reservedSchedules: reservedSchedulesSelected,
     });
-  }, [reservedSchedules]);
+  }, [reservedSchedulesSelected]);
 
   return {
     detailData,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -227,7 +227,6 @@ export const useReservationCalendarData = ({
   ]);
 
   const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
-    const todayKey = formatDateKey(new Date());
     const notificationDotByDate: Record<string, boolean> = {};
 
     const eventCounts = reservationDashboard.reduce<
@@ -238,7 +237,7 @@ export const useReservationCalendarData = ({
       const confirmed = Math.max(r.confirmed ?? 0, 0);
       const pending = Math.max(r.pending ?? 0, 0);
       const declined = Math.max(r.declined ?? 0, 0);
-      const isPastDate = item.date < todayKey;
+      const isPastDate = item.date < todayDateKey;
       const pendingForDisplay = isPastDate ? 0 : pending;
       const rawTotal = pendingForDisplay + confirmed + completed + declined;
       if (rawTotal > 0) {
@@ -271,7 +270,7 @@ export const useReservationCalendarData = ({
       fetchTodayScheduleInBackground &&
       hasReservedSlotActivity(reservedSchedulesToday)
     ) {
-      notificationDotByDate[todayKey] = true;
+      notificationDotByDate[todayDateKey] = true;
     }
 
     const scheduleDataByDate = new Map<string, ReservedScheduleItem[]>();
@@ -284,9 +283,9 @@ export const useReservationCalendarData = ({
     if (
       fetchTodayScheduleInBackground &&
       reservedSchedulesToday.length > 0 &&
-      todayKey !== reservedScheduleDateKey
+      todayDateKey !== reservedScheduleDateKey
     ) {
-      scheduleDataByDate.set(todayKey, reservedSchedulesToday);
+      scheduleDataByDate.set(todayDateKey, reservedSchedulesToday);
     }
 
     const nowForSchedules = new Date();
@@ -309,6 +308,7 @@ export const useReservationCalendarData = ({
     reservedScheduleDateKey,
     reservedSchedulesSelected,
     reservedSchedulesToday,
+    todayDateKey,
   ]);
 
   const detailData = useMemo<ReservationDetailData>(() => {

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -42,8 +42,8 @@ interface UseReservationCalendarDataProps {
 /**
  * 예약 캘린더 화면에서 필요한 조회 데이터를 한 번에 조합
  *
- * 월간 `reservation-dashboard`로 달력 배지·알림 도트를 구성하고, URL로 연 선택일·그리고
- * 현재 보이는 달에 포함된 오늘 날짜에 대해 `reserved-schedule`을 조회해 배지 집계를 스케줄 단위로 보정
+ * 월간 reservation-dashboard로 달력 배지·알림 도트를 구성
+ * URL로 연 선택일,현재 보이는 달에 포함된 오늘 날짜에 대해 reserved-schedule을 조회해 배지 집계를 스케줄 단위로 보정
  * (오늘만 선택하지 않아도 지난 슬롯의 pending이 대시보드에 남는 문제를 막기 위함)
  * 대시보드에 없는 날을 URL로만 열었을 때의 도트는 선택일 스케줄 응답으로만 보강
  *


### PR DESCRIPTION
## 🔗 관련 이슈

- close #263 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

예약 현황 달력에서 체험 시작 시각이 지나 자동 거절된 승인 대기 예약이 뱃지에 반영되지 않고,
해당 날짜를 클릭해 reserved-schedule이 로드될 때만 뱃지·알림 도트가 사라지던 문제 해결

현재 보이는 달에 오늘이 포함될 때 URL에 date가 없어도 오늘 스케줄을 추가 조회해 스케줄 단위 `집계`·`자동 거절`·`캐시 무효화`가 오늘에도 동작하도록 구현
캘린더상 이미 지난 날짜(오늘 이전)은 일 단위 대시보드의 `pending`을 `도트`에 쓰지 않아, 지난 일자에 남는 stale 표시 줄임
