### PR TITLE
[Feat/#270] 메인 - 인기체험 버튼 컴포넌트 적용, 슬라이드/카드 호버 애니메이션 적용

### DIFF
--- a/src/app/(main)/components/activity-card/index.tsx
+++ b/src/app/(main)/components/activity-card/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import type { ActivityCardProps } from '@/app/(main)/components/activity-card/activityCard.types';
 import { IcStar } from '@/shared/assets/icons';
 import { Heading } from '@/shared/components/heading';
+import { cn } from '@/shared/utils/cn';
 
 /**
  * 메인 페이지 체험 카드 컴포넌트
@@ -20,19 +21,36 @@ export function ActivityCard({ activity }: ActivityCardProps) {
   return (
     <Link
       href={`/activity/${activity.id}`}
-      className="block h-full"
+      className={cn(
+        'group block h-full',
+        'motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-out',
+        'hover:-translate-y-1',
+        'active:scale-[0.98]',
+        'motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100'
+      )}
       aria-label={`${activity.title} 상세 페이지로 이동`}
       draggable={false}
     >
-      <article className="shadow-card h-full w-full overflow-hidden rounded-3xl bg-white">
-        <div className="relative aspect-square w-full bg-gray-200">
+      <article
+        className={cn(
+          'shadow-card h-full w-full overflow-hidden rounded-3xl bg-white',
+          'motion-safe:transition-shadow motion-safe:duration-200',
+          'group-hover:shadow-lg'
+        )}
+      >
+        <div className="relative aspect-square w-full overflow-hidden bg-gray-200">
           {bannerImageUrl && (
             <Image
               src={bannerImageUrl}
               alt={`${activity.title} 대표 이미지`}
               fill
               sizes="(min-width: 1536px) 262px, (min-width: 768px) 33vw, 50vw"
-              className="object-cover"
+              className={cn(
+                'object-cover',
+                'motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out',
+                'group-hover:scale-105',
+                'motion-reduce:group-hover:scale-100'
+              )}
               draggable={false}
             />
           )}

--- a/src/app/(main)/components/popular-activity-section/index.tsx
+++ b/src/app/(main)/components/popular-activity-section/index.tsx
@@ -109,21 +109,22 @@ export function PopularActivitySection() {
 
   const activities = isDesktopLayout ? desktopActivities : allActivities;
 
-  const canLoadNextPage =
-    Boolean(hasNextPage) && !isFetchingNextPage && !hasLoadedAllActivities;
+  const hasMorePopularToLoad = Boolean(hasNextPage) && !hasLoadedAllActivities;
+
+  const canFetchNextPage = hasMorePopularToLoad && !isFetchingNextPage;
 
   const canMovePreviousDesktopPage =
     isDesktopLayout && safeDesktopPageIndex > 0;
 
   const canMoveNextDesktopPage =
     isDesktopLayout &&
-    (safeDesktopPageIndex < desktopPages.length - 1 || canLoadNextPage);
+    (safeDesktopPageIndex < desktopPages.length - 1 || hasMorePopularToLoad);
 
   const shouldShowPreviousButton = canMovePreviousDesktopPage;
   const shouldShowNextButton = canMoveNextDesktopPage;
 
   const loadNextPage = useCallback(async () => {
-    if (!canLoadNextPage || isLoadNextPageLockedRef.current) return null;
+    if (!canFetchNextPage || isLoadNextPageLockedRef.current) return null;
 
     isLoadNextPageLockedRef.current = true;
 
@@ -132,7 +133,7 @@ export function PopularActivitySection() {
     } finally {
       isLoadNextPageLockedRef.current = false;
     }
-  }, [canLoadNextPage, fetchNextPage]);
+  }, [canFetchNextPage, fetchNextPage]);
 
   const handlePreviousButtonClick = () => {
     setDesktopPageIndex((prev) => Math.max(prev - 1, 0));
@@ -218,13 +219,9 @@ export function PopularActivitySection() {
                   transform: `translateX(-${safeDesktopPageIndex * desktopCarouselSlideFraction}%)`,
                 }}
               >
-                {desktopPages.map((page, pageIdx) => (
+                {desktopPages.map((page) => (
                   <ul
-                    key={
-                      page.activities[0]
-                        ? `popular-desktop-${page.activities[0].id}`
-                        : `popular-desktop-${pageIdx}`
-                    }
+                    key={`popular-desktop-${page.activities[0].id}`}
                     className="grid shrink-0 grid-cols-4 gap-6"
                     style={{ width: `${desktopCarouselSlideFraction}%` }}
                   >
@@ -256,12 +253,12 @@ export function PopularActivitySection() {
           {shouldShowPreviousButton && (
             <ArrowButton
               direction="left"
+              size="lg"
               onClick={handlePreviousButtonClick}
               aria-label="이전 인기 체험 보기"
               className={cn(
-                'shadow-card absolute top-1/2 left-0 hidden h-13.5 w-13.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
+                'shadow-card absolute top-1/2 left-0 hidden -translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
                 'hover:text-gray-800 disabled:hover:text-gray-300',
-                '[&_svg]:h-7 [&_svg]:w-7',
                 '2xl:flex'
               )}
             />
@@ -270,14 +267,14 @@ export function PopularActivitySection() {
           {shouldShowNextButton && (
             <ArrowButton
               direction="right"
+              size="lg"
               onClick={() => {
                 void handleNextButtonClick();
               }}
               aria-label="인기 체험 더 불러오기"
               className={cn(
-                'shadow-card absolute top-1/2 right-0 hidden h-13.5 w-13.5 translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
+                'shadow-card absolute top-1/2 right-0 hidden translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
                 'hover:text-gray-800 disabled:hover:text-gray-300',
-                '[&_svg]:h-7 [&_svg]:w-7',
                 '2xl:flex'
               )}
             />

--- a/src/app/(main)/components/popular-activity-section/index.tsx
+++ b/src/app/(main)/components/popular-activity-section/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  type CSSProperties,
   type UIEvent,
   useCallback,
   useRef,
@@ -35,6 +36,13 @@ const POPULAR_ACTIVITY_LIST_CLASS_NAME = cn(
 );
 
 const SCROLL_LOAD_THRESHOLD = 80;
+
+/** 데스크톱 인기 체험 캐러셀 — Style Guide: 동적 값은 CSS 변수로만 전달 */
+const POPULAR_DESKTOP_CAROUSEL_CSS_VARS = {
+  trackWidth: '--popular-desktop-carousel-track-w',
+  translateX: '--popular-desktop-carousel-translate-x',
+  slideWidth: '--popular-desktop-carousel-slide-w',
+} as const;
 
 const subscribeDesktopLayout = (onStoreChange: () => void) => {
   if (typeof window === 'undefined') {
@@ -176,6 +184,12 @@ export function PopularActivitySection() {
   const desktopCarouselPageCount = Math.max(desktopPages.length, 1);
   const desktopCarouselSlideFraction = 100 / desktopCarouselPageCount;
 
+  const popularDesktopCarouselTrackStyle = {
+    [POPULAR_DESKTOP_CAROUSEL_CSS_VARS.trackWidth]: `${desktopCarouselPageCount * 100}%`,
+    [POPULAR_DESKTOP_CAROUSEL_CSS_VARS.translateX]: `-${safeDesktopPageIndex * desktopCarouselSlideFraction}%`,
+    [POPULAR_DESKTOP_CAROUSEL_CSS_VARS.slideWidth]: `${desktopCarouselSlideFraction}%`,
+  } as CSSProperties;
+
   return (
     <section>
       <Heading
@@ -208,22 +222,19 @@ export function PopularActivitySection() {
       {!isPending && !isError && activities.length > 0 && (
         <div className="relative">
           {isDesktopLayout ? (
-            <div className="w-full overflow-hidden pb-4">
+            <div className="w-full overflow-hidden pt-2 pb-4">
               <div
                 className={cn(
-                  'flex motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out',
+                  'flex w-(--popular-desktop-carousel-track-w) translate-x-(--popular-desktop-carousel-translate-x)',
+                  'motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out',
                   'motion-reduce:transition-none'
                 )}
-                style={{
-                  width: `${desktopCarouselPageCount * 100}%`,
-                  transform: `translateX(-${safeDesktopPageIndex * desktopCarouselSlideFraction}%)`,
-                }}
+                style={popularDesktopCarouselTrackStyle}
               >
                 {desktopPages.map((page) => (
                   <ul
-                    key={`popular-desktop-${page.activities[0].id}`}
-                    className="grid shrink-0 grid-cols-4 gap-6"
-                    style={{ width: `${desktopCarouselSlideFraction}%` }}
+                    key={'popular-desktop-' + page.activities[0].id}
+                    className="grid w-(--popular-desktop-carousel-slide-w) shrink-0 grid-cols-4 gap-6"
                   >
                     {page.activities.map((activity) => (
                       <li key={activity.id} className="min-w-0">
@@ -258,7 +269,7 @@ export function PopularActivitySection() {
               aria-label="이전 인기 체험 보기"
               className={cn(
                 'shadow-card absolute top-1/2 left-0 hidden -translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
-                'hover:text-gray-800 disabled:hover:text-gray-300',
+                'hover:text-gray-800',
                 '2xl:flex'
               )}
             />
@@ -274,7 +285,7 @@ export function PopularActivitySection() {
               aria-label="인기 체험 더 불러오기"
               className={cn(
                 'shadow-card absolute top-1/2 right-0 hidden translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
-                'hover:text-gray-800 disabled:hover:text-gray-300',
+                'hover:text-gray-800',
                 '2xl:flex'
               )}
             />

--- a/src/app/(main)/components/popular-activity-section/index.tsx
+++ b/src/app/(main)/components/popular-activity-section/index.tsx
@@ -15,20 +15,26 @@ import {
   MAIN_DESKTOP_PAGE_SIZE_MEDIA_QUERY,
   POPULAR_ACTIVITY_PAGE_SIZE,
 } from '@/app/(main)/main.constants';
+import { ArrowButton } from '@/shared/components/buttons';
 import { Heading } from '@/shared/components/heading';
 import { useDragScroll } from '@/shared/hooks/useDragScroll';
 import { cn } from '@/shared/utils/cn';
 
-const SCROLL_LOAD_THRESHOLD = 80;
-
-const POPULAR_ACTIVITY_LIST_CLASS_NAME = cn(
+const POPULAR_ACTIVITY_MOBILE_LIST_CLASS_NAME = cn(
   'scrollbar-hide grid grid-flow-col overflow-x-auto pb-4 select-none',
-  'cursor-grab active:cursor-grabbing 2xl:cursor-auto 2xl:active:cursor-auto',
+  'cursor-grab active:cursor-grabbing',
   '-mx-6 auto-cols-[calc((100%-1rem)/1.15)] gap-4 px-6',
   'xs:auto-cols-[calc((100%-1rem)/2.1)]',
-  'md:-mr-7.5 md:ml-0 md:auto-cols-[calc((100%-3rem)/3)] md:gap-6 md:pr-7.5 md:pl-0',
+  'md:-mr-7.5 md:ml-0 md:auto-cols-[calc((100%-3rem)/3)] md:gap-6 md:pr-7.5 md:pl-0'
+);
+
+const POPULAR_ACTIVITY_LIST_CLASS_NAME = cn(
+  POPULAR_ACTIVITY_MOBILE_LIST_CLASS_NAME,
+  '2xl:cursor-auto 2xl:active:cursor-auto',
   '2xl:mx-0 2xl:auto-cols-auto 2xl:grid-flow-row 2xl:grid-cols-4 2xl:overflow-visible 2xl:px-0'
 );
+
+const SCROLL_LOAD_THRESHOLD = 80;
 
 const subscribeDesktopLayout = (onStoreChange: () => void) => {
   if (typeof window === 'undefined') {
@@ -166,6 +172,9 @@ export function PopularActivitySection() {
     }
   };
 
+  const desktopCarouselPageCount = Math.max(desktopPages.length, 1);
+  const desktopCarouselSlideFraction = 100 / desktopCarouselPageCount;
+
   return (
     <section>
       <Heading
@@ -197,46 +206,81 @@ export function PopularActivitySection() {
 
       {!isPending && !isError && activities.length > 0 && (
         <div className="relative">
-          <ul
-            ref={scrollRef}
-            onScroll={handleHorizontalScroll}
-            {...(!isDesktopLayout && events)}
-            className={POPULAR_ACTIVITY_LIST_CLASS_NAME}
-            onDragStart={(event) => event.preventDefault()}
-          >
-            {activities.map((activity) => (
-              <li key={activity.id} className="w-full">
-                <ActivityCard activity={activity} />
-              </li>
-            ))}
-          </ul>
+          {isDesktopLayout ? (
+            <div className="w-full overflow-hidden pb-4">
+              <div
+                className={cn(
+                  'flex motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out',
+                  'motion-reduce:transition-none'
+                )}
+                style={{
+                  width: `${desktopCarouselPageCount * 100}%`,
+                  transform: `translateX(-${safeDesktopPageIndex * desktopCarouselSlideFraction}%)`,
+                }}
+              >
+                {desktopPages.map((page, pageIdx) => (
+                  <ul
+                    key={
+                      page.activities[0]
+                        ? `popular-desktop-${page.activities[0].id}`
+                        : `popular-desktop-${pageIdx}`
+                    }
+                    className="grid shrink-0 grid-cols-4 gap-6"
+                    style={{ width: `${desktopCarouselSlideFraction}%` }}
+                  >
+                    {page.activities.map((activity) => (
+                      <li key={activity.id} className="min-w-0">
+                        <ActivityCard activity={activity} />
+                      </li>
+                    ))}
+                  </ul>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <ul
+              ref={scrollRef}
+              onScroll={handleHorizontalScroll}
+              {...events}
+              className={POPULAR_ACTIVITY_MOBILE_LIST_CLASS_NAME}
+              onDragStart={(event) => event.preventDefault()}
+            >
+              {activities.map((activity) => (
+                <li key={activity.id} className="w-full">
+                  <ActivityCard activity={activity} />
+                </li>
+              ))}
+            </ul>
+          )}
 
           {shouldShowPreviousButton && (
-            <button
-              type="button"
+            <ArrowButton
+              direction="left"
               onClick={handlePreviousButtonClick}
               aria-label="이전 인기 체험 보기"
-              className="shadow-card absolute top-1/2 left-0 hidden h-13.5 w-13.5 -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-white 2xl:flex"
-            >
-              <span
-                aria-hidden="true"
-                className="h-3 w-3 rotate-45 border-b-2 border-l-2 border-gray-950"
-              />
-            </button>
+              className={cn(
+                'shadow-card absolute top-1/2 left-0 hidden h-13.5 w-13.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
+                'hover:text-gray-800 disabled:hover:text-gray-300',
+                '[&_svg]:h-7 [&_svg]:w-7',
+                '2xl:flex'
+              )}
+            />
           )}
 
           {shouldShowNextButton && (
-            <button
-              type="button"
-              onClick={handleNextButtonClick}
+            <ArrowButton
+              direction="right"
+              onClick={() => {
+                void handleNextButtonClick();
+              }}
               aria-label="인기 체험 더 불러오기"
-              className="shadow-card absolute top-1/2 right-0 hidden h-13.5 w-13.5 translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-white 2xl:flex"
-            >
-              <span
-                aria-hidden="true"
-                className="h-3 w-3 rotate-45 border-t-2 border-r-2 border-gray-950"
-              />
-            </button>
+              className={cn(
+                'shadow-card absolute top-1/2 right-0 hidden h-13.5 w-13.5 translate-x-1/2 -translate-y-1/2 rounded-full bg-white text-gray-950',
+                'hover:text-gray-800 disabled:hover:text-gray-300',
+                '[&_svg]:h-7 [&_svg]:w-7',
+                '2xl:flex'
+              )}
+            />
           )}
         </div>
       )}

--- a/src/shared/components/buttons/arrow-button/index.tsx
+++ b/src/shared/components/buttons/arrow-button/index.tsx
@@ -15,6 +15,11 @@ export interface ArrowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement
    * - `'arrow_navigation'`: 40×40 페이지네이션용
    */
   variant?: 'arrow' | 'arrow_navigation';
+  /**
+   * - 미지정: `variant`에 따른 기본 크기(화살표 32px / 내비 40px)
+   * - `'lg'`: 54×54 버튼 + 28px 아이콘(메인 인기 체험 캐러셀 등)
+   */
+  size?: 'lg';
   /** 화살표 방향 */
   direction: 'left' | 'right';
 }
@@ -24,6 +29,7 @@ export interface ArrowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement
  *
  * - `variant="arrow"` (기본값): 32×32 슬라이더·캐러셀용 (IcArrow)
  * - `variant="arrow_navigation"`: 40×40 페이지네이션용 (IcArrowNavi)
+ * - `size="lg"`: 54×54 버튼 + 28px 아이콘(큰 원형 캐러셀 등)
  * - 비활성 상태는 `disabled` 속성으로 제어
  *
  * @example
@@ -31,14 +37,17 @@ export interface ArrowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement
  * <ArrowButton direction="right" disabled={!hasNext} onClick={goNext} />
  * <ArrowButton variant="arrow_navigation" direction="left" disabled={page <= 1} onClick={prevPage} />
  * <ArrowButton variant="arrow_navigation" direction="right" disabled={page >= totalPages} onClick={nextPage} />
+ * <ArrowButton direction="left" size="lg" aria-label="이전 묶음 보기" />
  */
 export function ArrowButton({
   variant = 'arrow',
+  size,
   direction,
   className,
   ...rest
 }: ArrowButtonProps) {
   const isNavigation = variant === 'arrow_navigation';
+  const isLarge = size === 'lg';
   const Icon = isNavigation
     ? direction === 'left'
       ? IcArrowNaviLeft
@@ -55,13 +64,16 @@ export function ArrowButton({
         'inline-flex cursor-pointer items-center justify-center transition-colors duration-200',
         'text-gray-800 hover:text-gray-600',
         'disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:text-gray-300',
-        isNavigation ? 'h-10 w-10' : 'h-8 w-8',
+        isLarge ? 'h-13.5 w-13.5' : isNavigation ? 'h-10 w-10' : 'h-8 w-8',
         className
       )}
       {...rest}
     >
       <Icon
-        className={cn('block shrink-0', isNavigation ? 'h-10 w-10' : 'h-8 w-8')}
+        className={cn(
+          'block shrink-0',
+          isLarge ? 'h-7 w-7' : isNavigation ? 'h-10 w-10' : 'h-8 w-8'
+        )}
       />
     </button>
   );


### PR DESCRIPTION
## 🔗 관련 이슈

- close #270 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

인기 체험 영역에서 데스크탑 내 좌·우 이동 시 카드 묶음이 가로 슬라이드로 전환 적용
모바일·태블릿: 가로 스크롤·드래그 유지

인기 체험 이전/다음 컨트롤에 `ArrowButton` 적용

체험 카드(`ActivityCard`)에 호버 시 살짝 떠오름·이미지 확대·그림자 추가
클릭 시 살짝 눌리는 애니메이션 적용
`prefers-reduced-motion`일 때는 모션을 줄임