### PR TITLE
[Fix/#284] 체험 상세 - 체험 후기 작성일 오늘 날짜로 표시

### DIFF
--- a/src/shared/utils/formatDate.ts
+++ b/src/shared/utils/formatDate.ts
@@ -7,6 +7,12 @@ const pad2 = (value: number) => String(value).padStart(2, '0');
  * formatDate('2026-05-04T12:00:00Z') // "2026. 05. 04"
  */
 export const formatDate = (isoDate: string) => {
+  const dateOnlyMatch = isoDate.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    return `${year}. ${month}. ${day}`;
+  }
+
   const date = new Date(isoDate);
 
   if (Number.isNaN(date.getTime())) return '-';

--- a/src/shared/utils/formatDate.ts
+++ b/src/shared/utils/formatDate.ts
@@ -7,17 +7,24 @@ const pad2 = (value: number) => String(value).padStart(2, '0');
  * formatDate('2026-05-04T12:00:00Z') // "2026. 05. 04"
  */
 export const formatDate = (isoDate: string) => {
+  const parsedDate = new Date(isoDate);
+  if (Number.isNaN(parsedDate.getTime())) return '-';
+
   const dateOnlyMatch = isoDate.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (dateOnlyMatch) {
     const [, year, month, day] = dateOnlyMatch;
+    const utcDate = new Date(`${year}-${month}-${day}T00:00:00Z`);
+    const isValidDate =
+      utcDate.getUTCFullYear() === Number(year) &&
+      utcDate.getUTCMonth() + 1 === Number(month) &&
+      utcDate.getUTCDate() === Number(day);
+
+    if (!isValidDate) return '-';
+
     return `${year}. ${month}. ${day}`;
   }
 
-  const date = new Date(isoDate);
-
-  if (Number.isNaN(date.getTime())) return '-';
-
-  return `${date.getFullYear()}. ${pad2(date.getMonth() + 1)}. ${pad2(date.getDate())}`;
+  return `${parsedDate.getFullYear()}. ${pad2(parsedDate.getMonth() + 1)}. ${pad2(parsedDate.getDate())}`;
 };
 
 /**


### PR DESCRIPTION
## 🔗 관련 이슈

- close #284 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 체험 상세 페이지 후기 작성 후 날짜가 실제 작성일보다 하루 다르게 보이는 문제 해결
- 원인
  - UTC 기반 `createdAt` 문자열을 `Date`로 파싱하는 과정에서 로컬 타임존이 적용되며 날짜가 변경되고 있었음

- 날짜 표시는 ISO 문자열의 `YYYY-MM-DD`를 우선 사용하도록 처리해 타임존 영향 없이 작성일이 정확히 노출되게 처리
