### PR TITLE
[Fix/#285] 체험 상세 - 체험 수정 시 후기 사라지는 문제 해결

### DIFF
--- a/src/app/(main)/activity/[id]/edit/utils/getActivityUpdatePayload.ts
+++ b/src/app/(main)/activity/[id]/edit/utils/getActivityUpdatePayload.ts
@@ -1,7 +1,7 @@
 import { ActivityFormValues } from '@/app/(main)/activity/components/activity-form/activityForm.schema';
 import { ActivityDetailResponse } from '@/shared/types/activityDetail.types';
 
-const normalizeTime = (time: string) => time.slice(0, 5);
+const normalizeTime = (time?: string | null) => (time ? time.slice(0, 5) : '');
 
 /**
  * 체험 수정 폼 데이터를 API 요청 규격(Payload)에 맞게 변환하는 유틸 함수

--- a/src/app/(main)/activity/[id]/edit/utils/getActivityUpdatePayload.ts
+++ b/src/app/(main)/activity/[id]/edit/utils/getActivityUpdatePayload.ts
@@ -1,6 +1,8 @@
 import { ActivityFormValues } from '@/app/(main)/activity/components/activity-form/activityForm.schema';
 import { ActivityDetailResponse } from '@/shared/types/activityDetail.types';
 
+const normalizeTime = (time: string) => time.slice(0, 5);
+
 /**
  * 체험 수정 폼 데이터를 API 요청 규격(Payload)에 맞게 변환하는 유틸 함수
  *
@@ -50,8 +52,8 @@ export const getActivityUpdatePayload = (
     return (
       original &&
       (original.date !== final.date ||
-        original.startTime !== final.startTime ||
-        original.endTime !== final.endTime)
+        normalizeTime(original.startTime) !== normalizeTime(final.startTime) ||
+        normalizeTime(original.endTime) !== normalizeTime(final.endTime))
     );
   });
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #285 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 기존 스케줄 ID가 삭제되면 예약/후기 연결 데이터가 끊길 수 있어 사용자 입장에서 체험 수정 후 후기가 사라지는 것으로 보이는 문제 발생
- 스케줄의 실질 변경 여부만 감지하도록 개선 (데이터 연속성 유지)

- 원인
  - 수정 `payload` 생성 과정에서 스케줄 변경 감지 시 시간 포맷(`HH:mm:ss` | `HH:mm`)이 달라 실제 변경이 없어도 스케줄이 변경된 것으로 인지되고 있었음

- 해결
  - 시간 비교를 `HH:mm` 기준으로 정규화, 동일 스케줄이 불필요하게 삭제되지 않도록 개선

## 파일 변화
- `getActivityUpdatePayload`에 시간 정규화 로직 추가
- 스케줄 변경 감지 비교식에서 정규화된 시간값으로 비교하도록 수정
- 결과적으로 변경 없는 스케줄이 `scheduleIdsToRemove`에 포함되지 않도록 개선