### PR TITLE
[Feat/#289] 메인페이지- 검색 뒤로가기와 인기 체험 상태 유지

### DIFF
--- a/src/app/(main)/components/main-interactive-content/index.tsx
+++ b/src/app/(main)/components/main-interactive-content/index.tsx
@@ -62,7 +62,9 @@ export function MainInteractiveContent() {
         onSearch={handleSearch}
       />
 
-      <PopularActivitySection />
+      <div className={isSearchMode ? 'hidden' : undefined}>
+        <PopularActivitySection />
+      </div>
 
       <AllActivitySection
         keyword={keyword}

--- a/src/app/(main)/components/main-interactive-content/index.tsx
+++ b/src/app/(main)/components/main-interactive-content/index.tsx
@@ -12,7 +12,7 @@ import { useUpdateSearchParams } from '@/app/(main)/hooks/useUpdateSearchParams'
  *
  * - 검색 입력값과 실제 검색어 상태를 관리한다.
  * - 검색 실행 시 모든 체험 목록의 필터 상태를 초기화한다.
- * - 인기 체험은 검색/필터/정렬과 독립적으로 조회한다.
+ * - 인기 체험은 검색/필터/정렬과 독립적으로 유지한다.
  * - 검색어와 체험 목록 상태를 URL query string과 동기화한다.
  *
  * @example
@@ -34,17 +34,20 @@ export function MainInteractiveContent() {
   const handleSearch = (nextKeyword: string) => {
     const trimmedKeyword = nextKeyword.trim();
 
-    updateSearchParams((params) => {
-      if (trimmedKeyword) {
-        params.set('keyword', trimmedKeyword);
-      } else {
-        params.delete('keyword');
-      }
+    updateSearchParams(
+      (params) => {
+        if (trimmedKeyword) {
+          params.set('keyword', trimmedKeyword);
+        } else {
+          params.delete('keyword');
+        }
 
-      params.delete('category');
-      params.delete('sort');
-      params.delete('page');
-    });
+        params.delete('category');
+        params.delete('sort');
+        params.delete('page');
+      },
+      { history: 'push' }
+    );
   };
 
   const handleResetSearchInput = () => {
@@ -59,7 +62,7 @@ export function MainInteractiveContent() {
         onSearch={handleSearch}
       />
 
-      {!isSearchMode && <PopularActivitySection />}
+      <PopularActivitySection />
 
       <AllActivitySection
         keyword={keyword}

--- a/src/app/(main)/hooks/useUpdateSearchParams.ts
+++ b/src/app/(main)/hooks/useUpdateSearchParams.ts
@@ -1,7 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
 
 type UpdateSearchParamsOptions = {
   history?: 'push' | 'replace';
@@ -19,9 +18,10 @@ const createQueryString = (
 /**
  * 메인 페이지 URL query string을 갱신하는 커스텀 훅
  *
- * - 현재 searchParams를 기준으로 query string을 갱신한다.
+ * - 현재 window.location.search를 기준으로 query string을 갱신한다.
  * - 검색 실행처럼 뒤로가기가 필요한 동작은 history push로 처리한다.
  * - 필터, 정렬, 페이지네이션처럼 현재 상태만 바꾸는 동작은 history replace로 처리한다.
+ * - 같은 URL로 갱신되는 경우 불필요한 history entry를 추가하지 않는다.
  *
  * @example
  * const updateSearchParams = useUpdateSearchParams();
@@ -31,25 +31,26 @@ const createQueryString = (
  * });
  */
 export const useUpdateSearchParams = () => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const searchParamsRef = useRef(searchParams);
-
-  useEffect(() => {
-    searchParamsRef.current = searchParams;
-  }, [searchParams]);
-
   const updateSearchParams = useCallback(
     (
       updateParams: (params: URLSearchParams) => void,
       options: UpdateSearchParamsOptions = {}
     ) => {
-      const params = new URLSearchParams(searchParamsRef.current.toString());
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const params = new URLSearchParams(window.location.search);
       const history = options.history ?? 'replace';
+      const currentUrl = `${window.location.pathname}${window.location.search}`;
 
       updateParams(params);
 
-      const nextUrl = createQueryString(pathname, params);
+      const nextUrl = createQueryString(window.location.pathname, params);
+
+      if (nextUrl === currentUrl) {
+        return;
+      }
 
       if (history === 'push') {
         window.history.pushState(null, '', nextUrl);
@@ -58,7 +59,7 @@ export const useUpdateSearchParams = () => {
 
       window.history.replaceState(null, '', nextUrl);
     },
-    [pathname]
+    []
   );
 
   return updateSearchParams;

--- a/src/app/(main)/hooks/useUpdateSearchParams.ts
+++ b/src/app/(main)/hooks/useUpdateSearchParams.ts
@@ -1,7 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+type UpdateSearchParamsOptions = {
+  history?: 'push' | 'replace';
+};
 
 const createQueryString = (
   pathname: string,
@@ -16,7 +20,8 @@ const createQueryString = (
  * 메인 페이지 URL query string을 갱신하는 커스텀 훅
  *
  * - 현재 searchParams를 기준으로 query string을 갱신한다.
- * - query string 갱신 시 스크롤 위치를 유지한다.
+ * - 검색 실행처럼 뒤로가기가 필요한 동작은 history push로 처리한다.
+ * - 필터, 정렬, 페이지네이션처럼 현재 상태만 바꾸는 동작은 history replace로 처리한다.
  *
  * @example
  * const updateSearchParams = useUpdateSearchParams();
@@ -26,7 +31,6 @@ const createQueryString = (
  * });
  */
 export const useUpdateSearchParams = () => {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const searchParamsRef = useRef(searchParams);
@@ -36,14 +40,25 @@ export const useUpdateSearchParams = () => {
   }, [searchParams]);
 
   const updateSearchParams = useCallback(
-    (updateParams: (params: URLSearchParams) => void) => {
+    (
+      updateParams: (params: URLSearchParams) => void,
+      options: UpdateSearchParamsOptions = {}
+    ) => {
       const params = new URLSearchParams(searchParamsRef.current.toString());
+      const history = options.history ?? 'replace';
 
       updateParams(params);
 
-      router.replace(createQueryString(pathname, params), { scroll: false });
+      const nextUrl = createQueryString(pathname, params);
+
+      if (history === 'push') {
+        window.history.pushState(null, '', nextUrl);
+        return;
+      }
+
+      window.history.replaceState(null, '', nextUrl);
     },
-    [pathname, router]
+    [pathname]
   );
 
   return updateSearchParams;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #289 

## ☑️ 체크 사항

### 1. 기본 확인

- [x]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [x]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [x]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [x]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [x]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [x]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [x]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [x]  디자인 시안과 비교했을 때 UI가 일치하는가
- [x]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [x]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [x]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [x]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [x]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [x]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [x]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [x]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [x]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.
- 메인 페이지 검색 후 브라우저 뒤로가기를 눌렀을 때 검색 전 메인 화면 상태로 돌아가도록 수정했습니다.
- 검색어를 URL query string과 동기화하도록 개선했습니다.
- 검색 실행 시에는 browser history에 새 상태를 추가하도록 처리했습니다.
- 카테고리 / 정렬 / 페이지 변경 시에는 기존처럼 현재 URL 상태만 갱신하도록 유지했습니다.
- 검색 / 카테고리 / 정렬 상태가 변경되어도 인기 체험 섹션이 초기화되지 않도록 수정했습니다.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬 리뷰 포인트 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 참고할 사항이 있다면 작성해주세요.
