### PR TITLE
[Perf/#297] 체험 상세 렌더 차단 리소스 축소 (폰트 로딩 전략 개선)

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,0 +1,11 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+      />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,19 @@ export default function RootLayout({ children }: RootLayoutProps) {
       </noscript>
       <body className="flex min-h-full flex-col font-sans">
         <Script id="pretendard-font-loader" strategy="afterInteractive">
-          {`(function(){var href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css';if(document.querySelector('link[data-pretendard]'))return;var link=document.createElement('link');link.rel='stylesheet';link.href=href;link.setAttribute('data-pretendard','true');document.head.appendChild(link);})();`}
+          {`
+            (function () {
+              const href =
+                'https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css';
+              if (document.querySelector('link[data-pretendard]')) return;
+
+              const link = document.createElement('link');
+              link.rel = 'stylesheet';
+              link.href = href;
+              link.setAttribute('data-pretendard', 'true');
+              document.head.appendChild(link);
+            })();
+          `}
         </Script>
         <ToastContainer />
         <QueryProvider>{children}</QueryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import { QueryProvider } from '@/shared/components/query-provider';
 import { ToastContainer } from '@/shared/components/toast/toast-container';
 import '@/app/styles/globals.css';
@@ -31,7 +32,19 @@ type RootLayoutProps = Readonly<{
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="ko" className={'h-full antialiased'}>
+      <head>
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
+        <noscript>
+          <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+          />
+        </noscript>
+      </head>
       <body className="flex min-h-full flex-col font-sans">
+        <Script id="pretendard-font-loader" strategy="afterInteractive">
+          {`(function(){var href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css';if(document.querySelector('link[data-pretendard]'))return;var link=document.createElement('link');link.rel='stylesheet';link.href=href;link.setAttribute('data-pretendard','true');document.head.appendChild(link);})();`}
+        </Script>
         <ToastContainer />
         <QueryProvider>{children}</QueryProvider>
         <div id="modal-root" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,15 +32,13 @@ type RootLayoutProps = Readonly<{
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="ko" className={'h-full antialiased'}>
-      <head>
-        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
-        <noscript>
-          <link
-            rel="stylesheet"
-            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
-          />
-        </noscript>
-      </head>
+      <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
+      <noscript>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+        />
+      </noscript>
       <body className="flex min-h-full flex-col font-sans">
         <Script id="pretendard-font-loader" strategy="afterInteractive">
           {`(function(){var href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css';if(document.querySelector('link[data-pretendard]'))return;var link=document.createElement('link');link.rel='stylesheet';link.href=href;link.setAttribute('data-pretendard','true');document.head.appendChild(link);})();`}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import { QueryProvider } from '@/shared/components/query-provider';
 import { ToastContainer } from '@/shared/components/toast/toast-container';
 import '@/app/styles/globals.css';
@@ -32,29 +31,7 @@ type RootLayoutProps = Readonly<{
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="ko" className={'h-full antialiased'}>
-      <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
-      <noscript>
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
-        />
-      </noscript>
       <body className="flex min-h-full flex-col font-sans">
-        <Script id="pretendard-font-loader" strategy="afterInteractive">
-          {`
-            (function () {
-              const href =
-                'https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css';
-              if (document.querySelector('link[data-pretendard]')) return;
-
-              const link = document.createElement('link');
-              link.rel = 'stylesheet';
-              link.href = href;
-              link.setAttribute('data-pretendard', 'true');
-              document.head.appendChild(link);
-            })();
-          `}
-        </Script>
         <ToastContainer />
         <QueryProvider>{children}</QueryProvider>
         <div id="modal-root" />

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -1,4 +1,3 @@
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 @import 'tailwindcss';
 @import './fonts.css';
 @import './colors.css';

--- a/src/shared/apis/auth/kakao-signup 2.ts
+++ b/src/shared/apis/auth/kakao-signup 2.ts
@@ -1,0 +1,20 @@
+import type {
+  KakaoSignupRequest,
+  KakaoSignupResponse,
+} from '@/shared/apis/auth/auth.types';
+import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
+
+/**
+ * 카카오 간편 회원가입 API 호출 (BFF 경유).
+ *
+ * Next.js Route Handler (`/api/auth/kakao/signup`) 를 호출한다.
+ * Route Handler 가 백엔드 카카오 회원가입을 수행하고,
+ * 받은 토큰을 httpOnly 쿠키로 저장한다.
+ * 클라이언트는 user 정보만 응답으로 받는다.
+ */
+export const kakaoSignup = (params: KakaoSignupRequest) => {
+  return fetchInstanceClient<KakaoSignupResponse>('/api/auth/kakao/signup', {
+    method: 'POST',
+    body: params,
+  });
+};

--- a/src/shared/apis/auth/kakao-signup 3.ts
+++ b/src/shared/apis/auth/kakao-signup 3.ts
@@ -1,0 +1,20 @@
+import type {
+  KakaoSignupRequest,
+  KakaoSignupResponse,
+} from '@/shared/apis/auth/auth.types';
+import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
+
+/**
+ * 카카오 간편 회원가입 API 호출 (BFF 경유).
+ *
+ * Next.js Route Handler (`/api/auth/kakao/signup`) 를 호출한다.
+ * Route Handler 가 백엔드 카카오 회원가입을 수행하고,
+ * 받은 토큰을 httpOnly 쿠키로 저장한다.
+ * 클라이언트는 user 정보만 응답으로 받는다.
+ */
+export const kakaoSignup = (params: KakaoSignupRequest) => {
+  return fetchInstanceClient<KakaoSignupResponse>('/api/auth/kakao/signup', {
+    method: 'POST',
+    body: params,
+  });
+};

--- a/src/shared/apis/auth/kakao-signup 4.ts
+++ b/src/shared/apis/auth/kakao-signup 4.ts
@@ -1,0 +1,20 @@
+import type {
+  KakaoSignupRequest,
+  KakaoSignupResponse,
+} from '@/shared/apis/auth/auth.types';
+import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
+
+/**
+ * 카카오 간편 회원가입 API 호출 (BFF 경유).
+ *
+ * Next.js Route Handler (`/api/auth/kakao/signup`) 를 호출한다.
+ * Route Handler 가 백엔드 카카오 회원가입을 수행하고,
+ * 받은 토큰을 httpOnly 쿠키로 저장한다.
+ * 클라이언트는 user 정보만 응답으로 받는다.
+ */
+export const kakaoSignup = (params: KakaoSignupRequest) => {
+  return fetchInstanceClient<KakaoSignupResponse>('/api/auth/kakao/signup', {
+    method: 'POST',
+    body: params,
+  });
+};

--- a/src/shared/apis/auth/kakao-signup 5.ts
+++ b/src/shared/apis/auth/kakao-signup 5.ts
@@ -1,0 +1,20 @@
+import type {
+  KakaoSignupRequest,
+  KakaoSignupResponse,
+} from '@/shared/apis/auth/auth.types';
+import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
+
+/**
+ * 카카오 간편 회원가입 API 호출 (BFF 경유).
+ *
+ * Next.js Route Handler (`/api/auth/kakao/signup`) 를 호출한다.
+ * Route Handler 가 백엔드 카카오 회원가입을 수행하고,
+ * 받은 토큰을 httpOnly 쿠키로 저장한다.
+ * 클라이언트는 user 정보만 응답으로 받는다.
+ */
+export const kakaoSignup = (params: KakaoSignupRequest) => {
+  return fetchInstanceClient<KakaoSignupResponse>('/api/auth/kakao/signup', {
+    method: 'POST',
+    body: params,
+  });
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #297 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용
- 체험 상세 성능 개선 이슈 중 `렌더 차단 리소스 축소(폰트 로딩 전략 개선)` 적용
- 전역 CSS의 Pretendard 원격 `@import` 제거 → 초기 CSS 파싱 단계의 render-blocking 요인 감소
- `src/app/layout.tsx`에서 폰트 CDN `preconnect` 추가, `next/script (afterInteractive)`로 폰트 stylesheet를 비동기 주입하도록 변경
- JS 비활성 환경을 위해 `noscript` fallback stylesheet 유지
- 원격 폰트 `@import`는 CSS 로딩 체인에 직접 연결되어 초기 렌더 지연 성공
- 폰트 로딩을 비차단 경로로 옮겨 FCP 구간의 병목 완화와 체험 상세 첫 화면 표시를 앞당기기 위함

## 변경사항
- `src/app/styles/globals.css`
  - Pretendard 원격 `@import` 제거
- `src/app/layout.tsx`
  - `cdn.jsdelivr.net` `preconnect` 추가
  - Pretendard stylesheet 동적 주입 스크립트 추가
  - `noscript` fallback 유지

| Before1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="3172" height="1682" alt="image" src="https://github.com/user-attachments/assets/9dc1934a-18f0-4d78-8293-b58b68fa2208" /> | <img width="3176" height="1630" alt="image" src="https://github.com/user-attachments/assets/9437cfe0-6b51-4cb3-a32f-a958c5bf42af" /> | <img width="3178" height="1634" alt="image" src="https://github.com/user-attachments/assets/9a4485bd-dac8-4400-8d39-67f21c436e08" /> |

| After1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="3184" height="1630" alt="image" src="https://github.com/user-attachments/assets/bb0e65e4-445e-4c51-9357-9fcffce99f88" /> | <img width="3184" height="1624" alt="image" src="https://github.com/user-attachments/assets/90fe9529-0a2d-4bc4-8481-d6f90450fd82" /> | <img width="3184" height="1630" alt="image" src="https://github.com/user-attachments/assets/a67efaa1-8a8c-472e-9f33-e35eb18bb3f4" /> |