### PR TITLE
[Perf/#298] Devtools 개발 전용 로드 보장

### DIFF
--- a/src/shared/components/query-provider/index.tsx
+++ b/src/shared/components/query-provider/index.tsx
@@ -4,13 +4,16 @@ import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const ReactQueryDevtools = dynamic(
-  () =>
-    import('@tanstack/react-query-devtools').then(
-      (mod) => mod.ReactQueryDevtools
-    ),
-  { ssr: false }
-);
+const ReactQueryDevtools =
+  process.env.NODE_ENV === 'production'
+    ? () => null
+    : dynamic(
+        () =>
+          import('@tanstack/react-query-devtools').then(
+            (mod) => mod.ReactQueryDevtools
+          ),
+        { ssr: false }
+      );
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const isDevelopment = process.env.NODE_ENV === 'development';

--- a/src/shared/components/query-provider/index.tsx
+++ b/src/shared/components/query-provider/index.tsx
@@ -1,10 +1,20 @@
 'use client';
 
 import { useState } from 'react';
+import dynamic from 'next/dynamic';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then(
+      (mod) => mod.ReactQueryDevtools
+    ),
+  { ssr: false }
+);
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -20,7 +30,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      <ReactQueryDevtools initialIsOpen={false} />
+      {isDevelopment ? <ReactQueryDevtools initialIsOpen={false} /> : null}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #298 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

체험 상세 페이지를 포함한 전체 앱의 초기 JS 부담을 줄이기 위해
개발 편의 기능(Devtools)이 프로덕션 번들/런타임 경로에 섞이지 않도록 분리

- `QueryProvider`에서 `@tanstack/react-query-devtools` 정적 import 제거
- `next/dynamic` 기반 동적 import 적용 (`ssr: false`)
- `process.env.NODE_ENV === 'development'`일 때만 `ReactQueryDevtools` 렌더
- 프로덕션에서 불필요한 Devtools JS 로드 경로 차단

## 확인 방법
- [ ] preview(또는 production)에서 `/activity/[id]` 진입 후 DevTools Network 확인
- [ ] `react-query-devtools` 관련 청크 요청이 없는지 확인
- [ ] Lighthouse를 동일 조건에서 3~5회 실행 후 중앙값 비교

### 스크린샷 
| Before1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="1993" height="886" alt="image" src="https://github.com/user-attachments/assets/ef6b98ee-8975-4af9-a9eb-1ba7711d6317" /> | <img width="3174" height="1552" alt="image" src="https://github.com/user-attachments/assets/01c0a44b-282a-4305-a8be-ff74c7d3d84d" /> | <img width="3170" height="1514" alt="image" src="https://github.com/user-attachments/assets/0e60513e-5af1-4e60-ae40-d61f2b879d6b" /> |

| After 1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="3168" height="1628" alt="image" src="https://github.com/user-attachments/assets/a29e898f-8417-4886-b6d8-15727da36f34" /> | <img width="3170" height="1602" alt="image" src="https://github.com/user-attachments/assets/a64f2dcc-ac7a-4c65-9ff0-4b9bd1531895" /> | <img width="3176" height="1614" alt="image" src="https://github.com/user-attachments/assets/c9dec9b4-5a4b-4775-8998-961075c151ee" /> |