### PR TITLE
[Perf/#299] 체험 상세 이미지 전달 최적화 (압축/포맷/사이즈)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,8 @@ const nextConfig: NextConfig = {
 
   images: {
     dangerouslyAllowLocalIP: process.env.NODE_ENV === 'development',
+    formats: ['image/avif', 'image/webp'],
+    minimumCacheTTL: 60 * 60 * 24 * 30,
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
@@ -236,7 +236,8 @@ export function ActivityImageLightbox({
                 alt={`${title} 이미지 ${index + 1}`}
                 fill
                 className="object-contain"
-                sizes="(max-width: 768px) 100vw, 1152px"
+                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 84vw, 1152px"
+                quality={80}
                 priority
                 draggable={false}
               />

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
@@ -9,12 +9,14 @@ function GalleryImageSlotInner({
   src,
   alt,
   sizes,
+  quality = 70,
   priority = false,
   loading,
 }: {
   src: string;
   alt: string;
   sizes: string;
+  quality?: number;
   priority?: boolean;
   loading?: 'eager' | 'lazy';
 }) {
@@ -59,6 +61,7 @@ function GalleryImageSlotInner({
         priority={priority}
         loading={normalizedLoading}
         sizes={sizes}
+        quality={quality}
         className={cn(
           'object-cover',
           shouldFadeIn && 'transition-opacity duration-300',
@@ -78,6 +81,7 @@ export function GalleryImageSlot({
   alt,
   className,
   sizes = '(max-width: 768px) 100vw, 50vw',
+  quality = 70,
   onOpen,
   priority = false,
   loading,
@@ -86,6 +90,7 @@ export function GalleryImageSlot({
   alt: string;
   className?: string;
   sizes?: string;
+  quality?: number;
   onOpen?: () => void;
   priority?: boolean;
   loading?: 'eager' | 'lazy';
@@ -109,6 +114,7 @@ export function GalleryImageSlot({
             src={src}
             alt={alt}
             sizes={sizes}
+            quality={quality}
             priority={priority}
             loading={loading}
           />
@@ -125,6 +131,7 @@ export function GalleryImageSlot({
           src={src}
           alt={alt}
           sizes={sizes}
+          quality={quality}
           priority={priority}
           loading={loading}
         />

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -13,6 +13,13 @@ interface ActivityImageGalleryProps {
   className?: string;
 }
 
+const DESKTOP_MAIN_IMAGE_SIZES =
+  '(max-width: 768px) 100vw, (max-width: 1536px) 75vw, 672px';
+const DESKTOP_GRID_IMAGE_SIZES =
+  '(max-width: 768px) 50vw, (max-width: 1536px) 38vw, 336px';
+const LCP_IMAGE_QUALITY = 75;
+const REGULAR_IMAGE_QUALITY = 68;
+
 /**
  * 체험 상세 페이지 이미지 갤러리
  *
@@ -29,13 +36,6 @@ export function ActivityImageGallery({
   title = '체험',
   className,
 }: ActivityImageGalleryProps) {
-  const desktopMainImageSizes =
-    '(max-width: 768px) 100vw, (max-width: 1536px) 75vw, 672px';
-  const desktopGridImageSizes =
-    '(max-width: 768px) 50vw, (max-width: 1536px) 38vw, 336px';
-  const lcpImageQuality = 75;
-  const regularImageQuality = 68;
-
   const imageUrls = [
     ...(bannerImageUrl ? [bannerImageUrl] : []),
     ...subImageUrls.filter(Boolean),
@@ -86,8 +86,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={title}
             className="h-full w-full"
-            sizes={desktopMainImageSizes}
-            quality={lcpImageQuality}
+            sizes={DESKTOP_MAIN_IMAGE_SIZES}
+            quality={LCP_IMAGE_QUALITY}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -111,8 +111,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={`${title} 이미지 1`}
             className="min-h-0 flex-1"
-            sizes={desktopMainImageSizes}
-            quality={lcpImageQuality}
+            sizes={DESKTOP_MAIN_IMAGE_SIZES}
+            quality={LCP_IMAGE_QUALITY}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -120,8 +120,8 @@ export function ActivityImageGallery({
             src={imageUrls[1]}
             alt={`${title} 이미지 2`}
             className="min-h-0 flex-1"
-            sizes={desktopMainImageSizes}
-            quality={regularImageQuality}
+            sizes={DESKTOP_MAIN_IMAGE_SIZES}
+            quality={REGULAR_IMAGE_QUALITY}
             onOpen={() => setLightboxIndex(1)}
           />
         </div>
@@ -144,8 +144,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={title}
             className="row-span-2 h-full min-h-0"
-            sizes={desktopGridImageSizes}
-            quality={lcpImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={LCP_IMAGE_QUALITY}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -154,16 +154,16 @@ export function ActivityImageGallery({
               src={imageUrls[1]}
               alt={`${title} 추가 이미지 1`}
               className="min-h-0 flex-1"
-              sizes={desktopGridImageSizes}
-              quality={regularImageQuality}
+              sizes={DESKTOP_GRID_IMAGE_SIZES}
+              quality={REGULAR_IMAGE_QUALITY}
               onOpen={() => setLightboxIndex(1)}
             />
             <GalleryImageSlot
               src={imageUrls[2]}
               alt={`${title} 추가 이미지 2`}
               className="min-h-0 flex-1"
-              sizes={desktopGridImageSizes}
-              quality={regularImageQuality}
+              sizes={DESKTOP_GRID_IMAGE_SIZES}
+              quality={REGULAR_IMAGE_QUALITY}
               onOpen={() => setLightboxIndex(2)}
             />
           </div>
@@ -189,8 +189,8 @@ export function ActivityImageGallery({
               src={url}
               alt={`${title} 이미지 ${index + 1}`}
               className="min-h-0"
-              sizes={desktopGridImageSizes}
-              quality={index === 0 ? lcpImageQuality : regularImageQuality}
+              sizes={DESKTOP_GRID_IMAGE_SIZES}
+              quality={index === 0 ? LCP_IMAGE_QUALITY : REGULAR_IMAGE_QUALITY}
               priority={index === 0}
               loading="lazy"
               onOpen={() => setLightboxIndex(index)}
@@ -218,8 +218,8 @@ export function ActivityImageGallery({
             src={five[0]}
             alt={`${title} 이미지 1`}
             className="min-h-0 flex-1"
-            sizes={desktopGridImageSizes}
-            quality={lcpImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={LCP_IMAGE_QUALITY}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -227,8 +227,8 @@ export function ActivityImageGallery({
             src={five[1]}
             alt={`${title} 이미지 2`}
             className="min-h-0 flex-1"
-            sizes={desktopGridImageSizes}
-            quality={regularImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={REGULAR_IMAGE_QUALITY}
             onOpen={() => setLightboxIndex(1)}
           />
         </div>
@@ -237,24 +237,24 @@ export function ActivityImageGallery({
             src={five[2]}
             alt={`${title} 이미지 3`}
             className="min-h-0 flex-1"
-            sizes={desktopGridImageSizes}
-            quality={regularImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={REGULAR_IMAGE_QUALITY}
             onOpen={() => setLightboxIndex(2)}
           />
           <GalleryImageSlot
             src={five[3]}
             alt={`${title} 이미지 4`}
             className="min-h-0 flex-1"
-            sizes={desktopGridImageSizes}
-            quality={regularImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={REGULAR_IMAGE_QUALITY}
             onOpen={() => setLightboxIndex(3)}
           />
           <GalleryImageSlot
             src={five[4]}
             alt={`${title} 이미지 5`}
             className="min-h-0 flex-1"
-            sizes={desktopGridImageSizes}
-            quality={regularImageQuality}
+            sizes={DESKTOP_GRID_IMAGE_SIZES}
+            quality={REGULAR_IMAGE_QUALITY}
             onOpen={() => setLightboxIndex(4)}
           />
         </div>

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -29,6 +29,13 @@ export function ActivityImageGallery({
   title = '체험',
   className,
 }: ActivityImageGalleryProps) {
+  const desktopMainImageSizes =
+    '(max-width: 768px) 100vw, (max-width: 1536px) 75vw, 672px';
+  const desktopGridImageSizes =
+    '(max-width: 768px) 50vw, (max-width: 1536px) 38vw, 336px';
+  const lcpImageQuality = 75;
+  const regularImageQuality = 68;
+
   const imageUrls = [
     ...(bannerImageUrl ? [bannerImageUrl] : []),
     ...subImageUrls.filter(Boolean),
@@ -79,7 +86,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={title}
             className="h-full w-full"
-            sizes="(max-width: 768px) 100vw, 75vw"
+            sizes={desktopMainImageSizes}
+            quality={lcpImageQuality}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -103,7 +111,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={`${title} 이미지 1`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 100vw, 75vw"
+            sizes={desktopMainImageSizes}
+            quality={lcpImageQuality}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -111,7 +120,8 @@ export function ActivityImageGallery({
             src={imageUrls[1]}
             alt={`${title} 이미지 2`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 100vw, 75vw"
+            sizes={desktopMainImageSizes}
+            quality={regularImageQuality}
             onOpen={() => setLightboxIndex(1)}
           />
         </div>
@@ -134,6 +144,8 @@ export function ActivityImageGallery({
             src={imageUrls[0]}
             alt={title}
             className="row-span-2 h-full min-h-0"
+            sizes={desktopGridImageSizes}
+            quality={lcpImageQuality}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -142,12 +154,16 @@ export function ActivityImageGallery({
               src={imageUrls[1]}
               alt={`${title} 추가 이미지 1`}
               className="min-h-0 flex-1"
+              sizes={desktopGridImageSizes}
+              quality={regularImageQuality}
               onOpen={() => setLightboxIndex(1)}
             />
             <GalleryImageSlot
               src={imageUrls[2]}
               alt={`${title} 추가 이미지 2`}
               className="min-h-0 flex-1"
+              sizes={desktopGridImageSizes}
+              quality={regularImageQuality}
               onOpen={() => setLightboxIndex(2)}
             />
           </div>
@@ -173,7 +189,8 @@ export function ActivityImageGallery({
               src={url}
               alt={`${title} 이미지 ${index + 1}`}
               className="min-h-0"
-              sizes="(max-width: 768px) 50vw, 38vw"
+              sizes={desktopGridImageSizes}
+              quality={index === 0 ? lcpImageQuality : regularImageQuality}
               priority={index === 0}
               loading="lazy"
               onOpen={() => setLightboxIndex(index)}
@@ -201,7 +218,8 @@ export function ActivityImageGallery({
             src={five[0]}
             alt={`${title} 이미지 1`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 50vw, 38vw"
+            sizes={desktopGridImageSizes}
+            quality={lcpImageQuality}
             priority
             onOpen={() => setLightboxIndex(0)}
           />
@@ -209,7 +227,8 @@ export function ActivityImageGallery({
             src={five[1]}
             alt={`${title} 이미지 2`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 50vw, 38vw"
+            sizes={desktopGridImageSizes}
+            quality={regularImageQuality}
             onOpen={() => setLightboxIndex(1)}
           />
         </div>
@@ -218,21 +237,24 @@ export function ActivityImageGallery({
             src={five[2]}
             alt={`${title} 이미지 3`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 50vw, 38vw"
+            sizes={desktopGridImageSizes}
+            quality={regularImageQuality}
             onOpen={() => setLightboxIndex(2)}
           />
           <GalleryImageSlot
             src={five[3]}
             alt={`${title} 이미지 4`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 50vw, 38vw"
+            sizes={desktopGridImageSizes}
+            quality={regularImageQuality}
             onOpen={() => setLightboxIndex(3)}
           />
           <GalleryImageSlot
             src={five[4]}
             alt={`${title} 이미지 5`}
             className="min-h-0 flex-1"
-            sizes="(max-width: 768px) 50vw, 38vw"
+            sizes={desktopGridImageSizes}
+            quality={regularImageQuality}
             onOpen={() => setLightboxIndex(4)}
           />
         </div>

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -192,7 +192,6 @@ export function ActivityImageGallery({
               sizes={DESKTOP_GRID_IMAGE_SIZES}
               quality={index === 0 ? LCP_IMAGE_QUALITY : REGULAR_IMAGE_QUALITY}
               priority={index === 0}
-              loading="lazy"
               onOpen={() => setLightboxIndex(index)}
             />
           ))}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #299

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

체험 상세 첫 진입 시 이미지 바이트를 줄여 초기 렌더 성능(LCP/체감 속도)을 개선하기 위한 작업 진행

- 체험 상세 이미지 최적화 설정 추가
  - `next.config.ts`에 `images.formats`(AVIF/WebP), `minimumCacheTTL` 적용
- 갤러리 이미지 전송 최적화
  - `GalleryImageSlot`에 `quality` 제어 추가
  - LCP 후보 이미지와 일반 썸네일 품질 분리 적용
  - 레이아웃 폭 기반으로 `sizes` 정밀화해 과대 이미지 요청 방지
- 라이트박스 이미지 최적화
  - `quality` 지정 및 `sizes` 조건 보정으로 중간/대형 화면 전송량 개선

## 확인
- [ ] 모바일/태블릿/데스크톱에서 체험 상세 진입 시 이미지 노출 정상 확인
- [ ] Network 탭에서 메인/서브 이미지 전송량(Transferred) 감소 확인
- [ ] 이미지 응답 포맷이 AVIF/WebP로 협상되는지 확인
- [ ] 라이트박스 열기/좌우 이동/닫기 동작 정상 확인
- [ ] 화질 저하 체감 여부 확인(특히 라이트박스)
- [ ] Lighthouse/Performance에서 LCP 관련 회귀 없는지 확인

### 스크린샷 
### LCP 비교
| Before1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="3170" height="1610" alt="image" src="https://github.com/user-attachments/assets/d28eb911-a4b9-4af0-ab8a-9303dea2c31d" /> | <img width="3170" height="1622" alt="image" src="https://github.com/user-attachments/assets/68a042f7-5d3f-4990-ab71-2979e2c37bbb" /> | <img width="3168" height="1622" alt="image" src="https://github.com/user-attachments/assets/d36fb50a-e199-4ee5-be32-b4614483ecf0" /> |

| After1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="3170" height="1608" alt="image" src="https://github.com/user-attachments/assets/b396460d-797c-4181-8c08-7ddbe79b74cb" /> | <img width="3174" height="1614" alt="image" src="https://github.com/user-attachments/assets/8e8398aa-6092-4401-bc9b-4c56e319affe" /> | <img width="3172" height="1608" alt="image" src="https://github.com/user-attachments/assets/b90d4de5-5061-4a28-a4c3-9bf46efd4fcc" /> |

### Improve image delivery 비교
| Before | After |
| :---: | :---: |
| <img width="3172" height="1624" alt="image" src="https://github.com/user-attachments/assets/30f54d14-358f-40cd-b842-23f028f0bf36" /> | <img width="3168" height="1616" alt="image" src="https://github.com/user-attachments/assets/691b0cda-1c72-4fe2-951b-089bee8ee098" /> |