### PR TITLE
[Perf/#314] Lighthouse Best Practices 개선을 위한 보안 헤더 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://dapi.kakao.com https://t1.daumcdn.net",
       "style-src 'self' 'unsafe-inline' https:",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data: https:",

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,7 +17,15 @@ if (!imageUrl) {
   );
 }
 
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+if (!apiBaseUrl) {
+  throw new Error(
+    '🚨 NEXT_PUBLIC_API_BASE_URL 환경 변수가 누락되었습니다. .env 파일을 확인해주세요!'
+  );
+}
+
 const imageHostname = parseImageHostname(imageUrl);
+const apiHostname = parseImageHostname(apiBaseUrl);
 
 const SECURITY_HEADERS = [
   {
@@ -25,10 +33,10 @@ const SECURITY_HEADERS = [
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://dapi.kakao.com https://t1.daumcdn.net",
-      "style-src 'self' 'unsafe-inline' https:",
-      "img-src 'self' data: blob: https:",
-      "font-src 'self' data: https:",
-      "connect-src 'self' https: wss:",
+      "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+      `img-src 'self' data: blob: https://${imageHostname} https://t1.daumcdn.net https://*.daumcdn.net`,
+      "font-src 'self' data: https://cdn.jsdelivr.net",
+      `connect-src 'self' https://${apiHostname} https://dapi.kakao.com wss:`,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,11 @@
 import type { NextConfig } from 'next';
 
-function parseImageHostname(url: string) {
+function parseEnvUrl(envName: string, value: string) {
   try {
-    return new URL(url).hostname;
+    return new URL(value);
   } catch {
     throw new Error(
-      '🚨 NEXT_PUBLIC_IMAGE_URL 환경 변수 형식이 올바르지 않습니다. .env 파일을 확인해주세요!'
+      `🚨 ${envName} 환경 변수 형식이 올바르지 않습니다. .env 파일을 확인해주세요!`
     );
   }
 }
@@ -24,8 +24,14 @@ if (!apiBaseUrl) {
   );
 }
 
-const imageHostname = parseImageHostname(imageUrl);
-const apiHostname = parseImageHostname(apiBaseUrl);
+const parsedImageUrl = parseEnvUrl('NEXT_PUBLIC_IMAGE_URL', imageUrl);
+const parsedApiBaseUrl = parseEnvUrl('NEXT_PUBLIC_API_BASE_URL', apiBaseUrl);
+
+const imageHostname = parsedImageUrl.hostname;
+const apiHostname = parsedApiBaseUrl.hostname;
+const imageOrigin = `${parsedImageUrl.protocol}//${imageHostname}`;
+const apiOrigin = `${parsedApiBaseUrl.protocol}//${apiHostname}`;
+const imageRemotePatternProtocol = parsedImageUrl.protocol.replace(':', '');
 
 const SECURITY_HEADERS = [
   {
@@ -34,9 +40,9 @@ const SECURITY_HEADERS = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://dapi.kakao.com https://t1.daumcdn.net",
       "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-      `img-src 'self' data: blob: https://${imageHostname} https://t1.daumcdn.net https://*.daumcdn.net`,
+      `img-src 'self' data: blob: ${imageOrigin} https://t1.daumcdn.net https://*.daumcdn.net`,
       "font-src 'self' data: https://cdn.jsdelivr.net",
-      `connect-src 'self' https://${apiHostname} https://dapi.kakao.com wss:`,
+      `connect-src 'self' ${apiOrigin} https://dapi.kakao.com wss:`,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -100,7 +106,8 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 30,
     remotePatterns: [
       {
-        protocol: 'https',
+        protocol:
+          imageRemotePatternProtocol === 'http' ? 'http' : ('https' as const),
         hostname: imageHostname,
       },
     ],

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,7 @@ if (!imageUrl) {
 
 const imageHostname = parseImageHostname(imageUrl);
 
-const securityHeaders = [
+const SECURITY_HEADERS = [
   {
     key: 'Content-Security-Policy',
     value: [
@@ -63,7 +63,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/:path*',
-        headers: securityHeaders,
+        headers: SECURITY_HEADERS,
       },
     ];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,55 @@ if (!imageUrl) {
 
 const imageHostname = parseImageHostname(imageUrl);
 
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+      "style-src 'self' 'unsafe-inline' https:",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data: https:",
+      "connect-src 'self' https: wss:",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      'upgrade-insecure-requests',
+    ].join('; '),
+  },
+  {
+    key: 'Cross-Origin-Opener-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
+
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
@@ -63,14 +63,14 @@ export function ActivityDetailContent({
   return (
     <section className={cn('w-full', className)}>
       <div className="mb-5 border-b border-gray-100 pb-5 md:mb-8 md:pb-8 2xl:mb-10 2xl:pb-10">
-        <Heading as="h3">체험 설명</Heading>
+        <Heading as="h2">체험 설명</Heading>
         <p className="typo-lg-medium mt-4 wrap-anywhere whitespace-pre-line text-gray-950">
           {description}
         </p>
       </div>
 
       <div className="mb-5 border-b border-gray-100 pb-5 md:mb-8 md:pb-8 2xl:mb-10 2xl:pb-10">
-        <Heading as="h3">오시는 길</Heading>
+        <Heading as="h2">오시는 길</Heading>
         <div className="mt-2 flex items-center gap-1">
           <IcMap aria-hidden="true" className="size-4 shrink-0 text-black" />
           <p className="typo-md-semibold text-gray-950">{address}</p>

--- a/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
@@ -37,10 +37,8 @@ export function ActivityDetailContent({
 
   const currentHostname =
     typeof window === 'undefined' ? '' : window.location.hostname;
-  const isVercelPreviewHostname = currentHostname.endsWith('.vercel.app');
   const isMapEnabled =
-    currentHostname !== '' &&
-    (allowedHostnames.has(currentHostname) || isVercelPreviewHostname);
+    currentHostname !== '' && allowedHostnames.has(currentHostname);
   const { mapContainerRef, isMapLoading, mapErrorMessage } = useKakaoMap({
     address,
     appKey,

--- a/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
@@ -19,9 +19,23 @@ export function ActivityDetailContent({
 }: ActivityDetailContentProps) {
   const showToast = useShowToast();
   const appKey = (process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY ?? '').trim();
+  const appBaseUrl = (process.env.NEXT_PUBLIC_APP_URL ?? '').trim();
+  const allowedHostnames = new Set<string>(['localhost', '127.0.0.1']);
+  if (appBaseUrl) {
+    try {
+      allowedHostnames.add(new URL(appBaseUrl).hostname);
+    } catch {
+      // 잘못된 환경 변수 형식은 런타임 오류 대신 기본 허용 호스트만 사용한다.
+    }
+  }
+  const currentHostname =
+    typeof window === 'undefined' ? '' : window.location.hostname;
+  const isMapEnabled =
+    currentHostname !== '' && allowedHostnames.has(currentHostname);
   const { mapContainerRef, isMapLoading, mapErrorMessage } = useKakaoMap({
     address,
     appKey,
+    isEnabled: isMapEnabled,
   });
   const handleCopyAddress = async () => {
     if (!navigator.clipboard) {

--- a/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
@@ -37,8 +37,10 @@ export function ActivityDetailContent({
 
   const currentHostname =
     typeof window === 'undefined' ? '' : window.location.hostname;
+  const isVercelPreviewHostname = currentHostname.endsWith('.vercel.app');
   const isMapEnabled =
-    currentHostname !== '' && allowedHostnames.has(currentHostname);
+    currentHostname !== '' &&
+    (allowedHostnames.has(currentHostname) || isVercelPreviewHostname);
   const { mapContainerRef, isMapLoading, mapErrorMessage } = useKakaoMap({
     address,
     appKey,

--- a/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-detail-content/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { IcCopy, IcMap } from '@/shared/assets/icons';
 import { Heading } from '@/shared/components/heading';
 import { useKakaoMap } from '@/shared/hooks/useKakaoMap';
@@ -19,15 +20,21 @@ export function ActivityDetailContent({
 }: ActivityDetailContentProps) {
   const showToast = useShowToast();
   const appKey = (process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY ?? '').trim();
-  const appBaseUrl = (process.env.NEXT_PUBLIC_APP_URL ?? '').trim();
-  const allowedHostnames = new Set<string>(['localhost', '127.0.0.1']);
-  if (appBaseUrl) {
-    try {
-      allowedHostnames.add(new URL(appBaseUrl).hostname);
-    } catch {
-      // 잘못된 환경 변수 형식은 런타임 오류 대신 기본 허용 호스트만 사용한다.
+  const allowedHostnames = useMemo(() => {
+    const appBaseUrl = (process.env.NEXT_PUBLIC_APP_URL ?? '').trim();
+    const hostnames = new Set<string>(['localhost', '127.0.0.1']);
+
+    if (appBaseUrl) {
+      try {
+        hostnames.add(new URL(appBaseUrl).hostname);
+      } catch {
+        // 잘못된 환경 변수 형식은 런타임 오류 대신 기본 허용 호스트만 사용한다.
+      }
     }
-  }
+
+    return hostnames;
+  }, []);
+
   const currentHostname =
     typeof window === 'undefined' ? '' : window.location.hostname;
   const isMapEnabled =

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -5,6 +5,7 @@ import { ActivityImageLightbox } from '@/app/(main)/activity/[id]/components/act
 import { GalleryImageSlot } from '@/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot';
 import { ACTIVITY_IMAGE_GALLERY_FRAME_CLASS } from '@/shared/constants/activityImageGallery.constants';
 import { cn } from '@/shared/utils/cn';
+import { resolveSafeImageUrl } from '@/shared/utils/resolveSafeImageUrl';
 
 interface ActivityImageGalleryProps {
   bannerImageUrl?: string;
@@ -12,26 +13,6 @@ interface ActivityImageGalleryProps {
   title?: string;
   className?: string;
 }
-
-const normalizeImageUrl = (url?: string | null) => {
-  if (!url) return null;
-  const trimmed = url.trim();
-  if (!trimmed) return null;
-
-  if (trimmed.startsWith('/')) {
-    return trimmed;
-  }
-
-  if (trimmed.startsWith('http://')) {
-    return trimmed.replace(/^http:\/\//, 'https://');
-  }
-
-  if (trimmed.startsWith('https://')) {
-    return trimmed;
-  }
-
-  return null;
-};
 
 const DESKTOP_MAIN_IMAGE_SIZES =
   '(max-width: 768px) 100vw, (max-width: 1536px) 75vw, 672px';
@@ -56,9 +37,13 @@ export function ActivityImageGallery({
   title = '체험',
   className,
 }: ActivityImageGalleryProps) {
-  const normalizedBannerUrl = normalizeImageUrl(bannerImageUrl);
+  const imageBaseUrl =
+    process.env.NEXT_PUBLIC_IMAGE_URL?.trim() ??
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ??
+    'https://globalnomad-team2.vercel.app';
+  const normalizedBannerUrl = resolveSafeImageUrl(bannerImageUrl, imageBaseUrl);
   const normalizedSubImageUrls = subImageUrls
-    .map((url) => normalizeImageUrl(url))
+    .map((url) => resolveSafeImageUrl(url, imageBaseUrl))
     .filter((url): url is string => Boolean(url));
   const imageUrls = [
     ...(normalizedBannerUrl ? [normalizedBannerUrl] : []),

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -13,6 +13,26 @@ interface ActivityImageGalleryProps {
   className?: string;
 }
 
+const normalizeImageUrl = (url?: string | null) => {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('http://')) {
+    return trimmed.replace(/^http:\/\//, 'https://');
+  }
+
+  if (trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+
+  return null;
+};
+
 const DESKTOP_MAIN_IMAGE_SIZES =
   '(max-width: 768px) 100vw, (max-width: 1536px) 75vw, 672px';
 const DESKTOP_GRID_IMAGE_SIZES =
@@ -36,9 +56,13 @@ export function ActivityImageGallery({
   title = '체험',
   className,
 }: ActivityImageGalleryProps) {
+  const normalizedBannerUrl = normalizeImageUrl(bannerImageUrl);
+  const normalizedSubImageUrls = subImageUrls
+    .map((url) => normalizeImageUrl(url))
+    .filter((url): url is string => Boolean(url));
   const imageUrls = [
-    ...(bannerImageUrl ? [bannerImageUrl] : []),
-    ...subImageUrls.filter(Boolean),
+    ...(normalizedBannerUrl ? [normalizedBannerUrl] : []),
+    ...normalizedSubImageUrls,
   ];
   const count = imageUrls.length;
   /** 갤러리에 최대 5장만 노출; 라이트박스도 동일 목록 사용 */

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
@@ -200,7 +200,7 @@ export function MobileReservationSheet({
                   <span className="typo-md-bold text-gray-950">
                     {selectedDateText}
                   </span>
-                  <span className="typo-xs-medium text-gray-400">
+                  <span className="typo-xs-medium text-gray-600">
                     {selectedTimeSlot
                       ? `${selectedTimeSlot.startTime} ~ ${selectedTimeSlot.endTime}`
                       : '-'}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/reservationCalendarView.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/reservationCalendarView.tsx
@@ -37,6 +37,9 @@ export function ReservationCalendarView({
       showNeighboringMonth
       locale="ko-KR"
       calendarType="gregory"
+      navigationAriaLabel="월 선택"
+      prevAriaLabel="이전 달"
+      nextAriaLabel="다음 달"
       prevLabel={
         <span className="inline-flex h-6 w-6 items-center justify-center text-gray-950">
           <IcArrowLeft className="h-5 w-5" />

--- a/src/app/(main)/activity/[id]/components/activity-reviews/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reviews/index.tsx
@@ -70,9 +70,9 @@ export function ActivityReviews({
   return (
     <section className={cn('w-full', className)}>
       <div className="flex items-center gap-2">
-        <h3 className="typo-md-bold md:typo-2lg-bold leading-none tracking-tight text-gray-950">
+        <h2 className="typo-md-bold md:typo-2lg-bold leading-none tracking-tight text-gray-950">
           체험 후기
-        </h3>
+        </h2>
         <span className="typo-md-semibold md:typo-lg-bold leading-6 tracking-tight text-gray-600 md:leading-none">
           {formatCount(totalCount)}개
         </span>

--- a/src/app/(main)/activity/[id]/page.tsx
+++ b/src/app/(main)/activity/[id]/page.tsx
@@ -29,6 +29,24 @@ const getSiteUrl = () => {
   );
 };
 
+const resolveSafeImageUrl = (
+  imageUrl: string | null | undefined,
+  fallbackBaseUrl: string
+) => {
+  const raw = imageUrl?.trim();
+  if (!raw) return null;
+
+  if (raw.startsWith('http://')) {
+    return raw.replace(/^http:\/\//, 'https://');
+  }
+
+  if (raw.startsWith('https://')) {
+    return raw;
+  }
+
+  return new URL(raw, fallbackBaseUrl).toString();
+};
+
 /**
  * 체험 상세 페이지 메타데이터를 동적으로 생성
  */
@@ -51,12 +69,10 @@ export const generateMetadata = async ({
     const pageUrl = new URL(`/activity/${activity.id}`, baseUrl).toString();
     const bannerImageUrl = activity.bannerImageUrl?.trim();
     const imageBaseUrl = process.env.NEXT_PUBLIC_IMAGE_URL?.trim();
-    const resolvedBannerImageUrl = bannerImageUrl
-      ? bannerImageUrl.startsWith('http://') ||
-        bannerImageUrl.startsWith('https://')
-        ? bannerImageUrl
-        : new URL(bannerImageUrl, imageBaseUrl || baseUrl).toString()
-      : null;
+    const resolvedBannerImageUrl = resolveSafeImageUrl(
+      bannerImageUrl,
+      imageBaseUrl || baseUrl
+    );
     const ogImageUrl = resolvedBannerImageUrl
       ? new URL(
           `/api/og-image?src=${encodeURIComponent(resolvedBannerImageUrl)}&v=${encodeURIComponent(activity.updatedAt)}`,

--- a/src/app/(main)/activity/[id]/page.tsx
+++ b/src/app/(main)/activity/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ApiError } from '@/shared/apis/apiError';
 import { User } from '@/shared/apis/auth/auth.types';
 import { fetchInstanceServer } from '@/shared/apis/fetchInstance.server';
 import { ActivityDetailResponse } from '@/shared/types/activityDetail.types';
+import { resolveSafeImageUrl } from '@/shared/utils/resolveSafeImageUrl';
 
 interface ActivityDetailPageProps {
   params: Promise<{ id: string }>;
@@ -27,24 +28,6 @@ const getSiteUrl = () => {
   return (
     process.env.NEXT_PUBLIC_APP_URL || 'https://globalnomad-team2.vercel.app'
   );
-};
-
-const resolveSafeImageUrl = (
-  imageUrl: string | null | undefined,
-  fallbackBaseUrl: string
-) => {
-  const raw = imageUrl?.trim();
-  if (!raw) return null;
-
-  if (raw.startsWith('http://')) {
-    return raw.replace(/^http:\/\//, 'https://');
-  }
-
-  if (raw.startsWith('https://')) {
-    return raw;
-  }
-
-  return new URL(raw, fallbackBaseUrl).toString();
 };
 
 /**

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -13,7 +13,9 @@ interface ErrorProps {
 
 export default function Error({ error, reset }: ErrorProps) {
   useEffect(() => {
-    console.error(error);
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(error);
+    }
   }, [error]);
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -11,7 +11,9 @@ interface GlobalErrorProps {
 
 export default function GlobalError({ error, reset }: GlobalErrorProps) {
   useEffect(() => {
-    console.error(error);
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(error);
+    }
   }, [error]);
 
   return (

--- a/src/shared/assets/icons/ic-copy.svg
+++ b/src/shared/assets/icons/ic-copy.svg
@@ -1,7 +1,4 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
- "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+<svg xmlns="http://www.w3.org/2000/svg"
  width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000"
  preserveAspectRatio="xMidYMid meet">
 

--- a/src/shared/assets/icons/ic-share.svg
+++ b/src/shared/assets/icons/ic-share.svg
@@ -1,7 +1,4 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
- "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+<svg xmlns="http://www.w3.org/2000/svg"
  width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000"
  preserveAspectRatio="xMidYMid meet">
 

--- a/src/shared/hooks/useKakaoMap.ts
+++ b/src/shared/hooks/useKakaoMap.ts
@@ -43,6 +43,7 @@ interface KakaoMapNamespace {
 interface UseKakaoMapParams {
   address: string;
   appKey: string;
+  isEnabled?: boolean;
 }
 
 const KAKAO_MAP_SCRIPT_ID = 'kakao-map-sdk';
@@ -110,7 +111,11 @@ const loadKakaoMapSdk = (appKey: string) => {
 /**
  * 주소 문자열 기준으로 카카오 지도, 마커 렌더링
  */
-export const useKakaoMap = ({ address, appKey }: UseKakaoMapParams) => {
+export const useKakaoMap = ({
+  address,
+  appKey,
+  isEnabled = true,
+}: UseKakaoMapParams) => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<{
     setCenter: (position: unknown) => void;
@@ -126,6 +131,14 @@ export const useKakaoMap = ({ address, appKey }: UseKakaoMapParams) => {
     let isCancelled = false;
 
     const initializeMap = async () => {
+      if (!isEnabled) {
+        setMapErrorMessage(
+          '현재 환경에서는 지도 미리보기를 지원하지 않습니다.'
+        );
+        setIsMapLoading(false);
+        return;
+      }
+
       if (!appKey) {
         setMapErrorMessage('지도 정보를 불러올 수 없습니다.');
         return;
@@ -194,7 +207,7 @@ export const useKakaoMap = ({ address, appKey }: UseKakaoMapParams) => {
       markerRef.current = null;
       mapRef.current = null;
     };
-  }, [address, appKey]);
+  }, [address, appKey, isEnabled]);
 
   return {
     mapContainerRef,

--- a/src/shared/utils/resolveSafeImageUrl.ts
+++ b/src/shared/utils/resolveSafeImageUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * 이미지 URL을 안전한 표시용 URL로 정규화한다.
+ *
+ * 규칙:
+ * - 빈 값은 null 반환
+ * - http:// 는 https:// 로 승격
+ * - https:// 는 그대로 허용
+ * - 그 외 상대 경로는 fallbackBaseUrl 기준 절대 URL로 변환
+ * - URL 파싱 실패 시 null 반환
+ */
+export const resolveSafeImageUrl = (
+  imageUrl: string | null | undefined,
+  fallbackBaseUrl: string
+) => {
+  const raw = imageUrl?.trim();
+  if (!raw) return null;
+
+  if (raw.startsWith('http://')) {
+    return raw.replace(/^http:\/\//, 'https://');
+  }
+
+  if (raw.startsWith('https://')) {
+    return raw;
+  }
+
+  try {
+    return new URL(raw, fallbackBaseUrl).toString();
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #314  

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

Lighthouse `Best Practices` 점수 개선을 위해 보안 관련 응답 헤더 우선 적용
(대상: activity 상세 페이지 포함 전역 경로)

- `next.config.ts`에 전역 보안 헤더 추가
  - `Content-Security-Policy`
  - `Cross-Origin-Opener-Policy: same-origin`
  - `X-Frame-Options: SAMEORIGIN`
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy`
- `headers()` 설정으로 `/:path*` 전체 경로에 적용

## 📸스크린샷
| Before1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="1904" height="804" alt="image" src="https://github.com/user-attachments/assets/7fa38632-4bb1-452c-a7f2-2c26c772a896" /> | <img width="1906" height="809" alt="image" src="https://github.com/user-attachments/assets/82e413a7-bed8-473a-afeb-35d0bdf8e5f3" /> | <img width="1906" height="812" alt="image" src="https://github.com/user-attachments/assets/b7a0d982-183a-4e0d-8859-81fbe015abd3" /> |

| After1 | 2 | 3 |
| :---: | :---: | :---: |
| <img width="1905" height="801" alt="image" src="https://github.com/user-attachments/assets/64f5179d-8bf8-4a13-bf48-41c783478fc5" /> | <img width="1905" height="804" alt="image" src="https://github.com/user-attachments/assets/99d0c0f1-4ddd-435b-9eec-1f0e1c9592ea" /> | <img width="1906" height="806" alt="image" src="https://github.com/user-attachments/assets/93da4a64-90cd-460e-9558-ed3f9cd998c4" /> |