### PR TITLE
[Perf/#318] 예약현황 - 캘린더 버튼 접근성 이름 개선

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/headCountStepperIconButton.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/headCountStepperIconButton.tsx
@@ -25,6 +25,8 @@ export type HeadCountStepperIconButtonProps = Omit<
   ComponentPropsWithoutRef<'button'>,
   'type'
 > & {
+  /** 아이콘 버튼 접근성 이름(스크린리더 전용) */
+  'aria-label': string;
   children: ReactNode;
 };
 

--- a/src/app/(main)/activity/components/form-calendar/index.tsx
+++ b/src/app/(main)/activity/components/form-calendar/index.tsx
@@ -102,6 +102,9 @@ export function FormCalendar({
             className="form-calendar"
             onChange={handleClick}
             value={date ? new Date(date + 'T00:00:00') : null}
+            navigationAriaLabel="월 선택"
+            prevAriaLabel="이전 달"
+            nextAriaLabel="다음 달"
             prev2Label={null}
             next2Label={null}
             prevLabel={

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/index.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/index.tsx
@@ -116,6 +116,9 @@ export function ReservationCalendar({ activityId }: ReservationCalendarProps) {
           if (activeStartDate) setCurrentDate(activeStartDate);
         }}
         showNeighboringMonth
+        navigationAriaLabel="월 선택"
+        prevAriaLabel="이전 달"
+        nextAriaLabel="다음 달"
         prevLabel={
           <span className="inline-flex h-6 w-6 items-center justify-center text-gray-950">
             <IcArrowLeft className="h-6 w-6" />

--- a/src/app/(main)/my/reservations/components/reserve-filter/reserveFilter.constants.ts
+++ b/src/app/(main)/my/reservations/components/reserve-filter/reserveFilter.constants.ts
@@ -10,4 +10,4 @@ export const FILTER_ORDER: ReservationStatus[] = [
 
 export const SCROLL_END_THRESHOLD = 20;
 
-export const FILTER_BUTTON_CLASS = 'h-10 min-w-20.5 md:min-w-23.25';
+export const FILTER_BUTTON_CLASS = 'h-11 min-w-20.5 md:min-w-23.25';

--- a/src/shared/components/footer/index.tsx
+++ b/src/shared/components/footer/index.tsx
@@ -28,7 +28,7 @@ export function Footer() {
           target="_blank"
           rel="noopener noreferrer"
           aria-label="팀 GitHub 저장소 새 탭에서 열기"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md"
+          className="focus-visible:ring-primary-500/50 flex h-11 w-11 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-gray-100 focus-visible:ring-2 focus-visible:outline-none"
         >
           <IcGithub className="h-6 w-6 text-gray-600" aria-hidden="true" />
         </a>

--- a/src/shared/components/footer/index.tsx
+++ b/src/shared/components/footer/index.tsx
@@ -28,7 +28,7 @@ export function Footer() {
           target="_blank"
           rel="noopener noreferrer"
           aria-label="팀 GitHub 저장소 새 탭에서 열기"
-          className="flex h-8 w-8 shrink-0 items-center justify-center"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md"
         >
           <IcGithub className="h-6 w-6 text-gray-600" aria-hidden="true" />
         </a>


### PR DESCRIPTION
## 🔗 관련 이슈

- close #317 
- close #318 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 예약현황 페이지 필터 버튼의 터치 타겟 확대 (`h-10` → `h-11`)
- 공통 푸터 GitHub 링크 버튼의 터치 타겟 확대 (`h-8 w-8` → `h-11 w-11`)
-  react-calendar 네비게이션 버튼의 접근성 이름 추가
  - `navigationAriaLabel="월 선택"`
  - `prevAriaLabel="이전 달"`
  - `nextAriaLabel="다음 달"`
- 아이콘 버튼 접근성 이름 누락 방지를 위해 stepper 버튼 컴포넌트에서 `aria-label`을 필수로 보강

## 확인
- [ ] 예약내역 페이지에서 필터 버튼 터치 영역이 기존보다 넓게 동작하는지 확인
- [ ] 모바일/태블릿에서 필터 가로 스크롤 및 버튼 클릭 동작이 정상인지 확인
- [ ] 푸터 GitHub 버튼 클릭 시 새 탭으로 정상 이동하는지 확인
- [ ] 레이아웃 깨짐 없이 기존 UI가 유지되는지 확인

## 📸 스크린샷
| Before | After |
| :---: | :---: |
| <img width="1907" height="806" alt="image" src="https://github.com/user-attachments/assets/7864672e-1c1d-494c-b4c9-135519b13254" /> | <img width="1903" height="801" alt="image" src="https://github.com/user-attachments/assets/fd7509ad-3ac0-4289-856d-526837ee179f" /> |
