### PR TITLE
[Refactor/#326] 예약 현황 캘린더 데이터 훅 책임 분리

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -3,11 +3,16 @@
 import { useMemo } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { fetchActivityAvailableSchedule } from '@/app/(main)/activity/[id]/apis/activityAvailableSchedule';
-import { fetchMyReservedSchedules } from '@/app/(main)/activity/[id]/apis/myReservedSchedules';
+import {
+  fetchMyReservedSchedules,
+  type MyReservedScheduleItem,
+} from '@/app/(main)/activity/[id]/apis/myReservedSchedules';
 import type { TimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 import { formatDateKey } from '@/shared/utils/formatDate';
+
+const EMPTY_RESERVED_SCHEDULES: MyReservedScheduleItem[] = [];
 
 interface UseActivityReservationAvailabilityProps {
   activityId: number;
@@ -144,7 +149,7 @@ export const useActivityReservationAvailability = ({
     (query) => query.isError
   );
 
-  const { data: myReservedSchedules = [] } = useQuery({
+  const { data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES } = useQuery({
     queryKey: [...QUERY_KEYS.MY_RESERVATIONS, 'reservedSchedules'],
     queryFn: fetchMyReservedSchedules,
     enabled: isAuthenticated,

--- a/src/app/(main)/my/activities-dashboard/components/myActivitiesDashboardContent.tsx
+++ b/src/app/(main)/my/activities-dashboard/components/myActivitiesDashboardContent.tsx
@@ -9,6 +9,9 @@ import { ReservationCalendarClient } from '@/app/(main)/my/activities-dashboard/
 import { Dropdown } from '@/shared/components/dropdown';
 import { DropdownOption } from '@/shared/components/dropdown/dropdown.types';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import type { Activities } from '@/shared/types/myActivities.types';
+
+const EMPTY_ACTIVITIES: Activities[] = [];
 
 /**
  * 예약 현황 페이지의 체험 선택 / 캘린더 영역 렌더링
@@ -21,7 +24,7 @@ export function MyActivitiesDashboardContent() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const { data: activities = [], isLoading } = useQuery({
+  const { data: activities = EMPTY_ACTIVITIES, isLoading } = useQuery({
     queryKey: QUERY_KEYS.MY_ACTIVITIES_DASHBOARD,
     queryFn: fetchMyActivitiesForDashboard,
   });

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -113,7 +113,7 @@ export const useAutoDeclineExpiredReservations = ({
         }
       }
 
-      if (isCancelled || !hasDeclinedAny) return;
+      if (!hasDeclinedAny) return;
 
       await Promise.all(
         ACTIVITY_RESERVATION_CACHE_ROOTS.map((root) =>

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -87,13 +87,13 @@ export const useAutoDeclineExpiredReservations = ({
     const candidates = [...candidatesByScheduleId.values()];
     if (candidates.length === 0) return;
 
-    let cancelled = false;
+    let isCancelled = false;
 
     void (async () => {
-      let declinedAny = false;
+      let hasDeclinedAny = false;
 
       for (const { schedule } of candidates) {
-        if (cancelled) return;
+        if (isCancelled) return;
 
         try {
           const ids = await collectPendingReservationIdsForSchedule({
@@ -101,10 +101,10 @@ export const useAutoDeclineExpiredReservations = ({
             scheduleId: schedule.scheduleId,
           });
           if (ids.length === 0) continue;
-          if (cancelled) return;
+          if (isCancelled) return;
 
           // `declinePendingReservationIds`는 일부만 거절돼도 실패분이 있으면 throw하므로 무효화 여부는 거절 시도 직전에 반영
-          declinedAny = true;
+          hasDeclinedAny = true;
           await declinePendingReservationIds(activityId, ids);
         } catch {
           // 다음 스케줄 처리 계속
@@ -113,7 +113,7 @@ export const useAutoDeclineExpiredReservations = ({
         }
       }
 
-      if (cancelled || !declinedAny) return;
+      if (isCancelled || !hasDeclinedAny) return;
 
       await Promise.all(
         ACTIVITY_RESERVATION_CACHE_ROOTS.map((root) =>
@@ -125,7 +125,7 @@ export const useAutoDeclineExpiredReservations = ({
     })();
 
     return () => {
-      cancelled = true;
+      isCancelled = true;
     };
   }, [
     activityId,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  collectPendingReservationIdsForSchedule,
+  declinePendingReservationIds,
+} from '@/app/(main)/my/activities-dashboard/apis/reservations';
+import { isScheduleStartReached } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus';
+import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+
+/** 자동 거절 후 접두 `[root, activityId]`로 무효화할 쿼리 루트 */
+const ACTIVITY_RESERVATION_CACHE_ROOTS = [
+  QUERY_KEYS.MY_ACTIVITY_RESERVATIONS[0],
+  QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE[0],
+  QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD[0],
+] as const;
+
+interface UseAutoDeclineExpiredReservationsProps {
+  activityId: number | null;
+  reservedScheduleDateKey: string | null;
+  todayDateKey: string;
+  fetchTodayScheduleInBackground: boolean;
+  reservedSchedulesSelected: ReservedScheduleItem[];
+  reservedSchedulesToday: ReservedScheduleItem[];
+}
+
+export const useAutoDeclineExpiredReservations = ({
+  activityId,
+  reservedScheduleDateKey,
+  todayDateKey,
+  fetchTodayScheduleInBackground,
+  reservedSchedulesSelected,
+  reservedSchedulesToday,
+}: UseAutoDeclineExpiredReservationsProps) => {
+  const queryClient = useQueryClient();
+  /** 선택일·체험이 바뀌기 전까지 자동 거절을 이미 시도한 `scheduleId` (무한 invalidate 루프 방지) */
+  const autoDeclineAttemptedScheduleIdsRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    autoDeclineAttemptedScheduleIdsRef.current.clear();
+  }, [activityId, reservedScheduleDateKey, todayDateKey]);
+
+  useEffect(() => {
+    if (activityId === null) return;
+
+    const scheduleLoads: {
+      dateKey: string;
+      schedules: ReservedScheduleItem[];
+    }[] = [];
+
+    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
+      scheduleLoads.push({
+        dateKey: reservedScheduleDateKey,
+        schedules: reservedSchedulesSelected,
+      });
+    }
+
+    if (
+      fetchTodayScheduleInBackground &&
+      reservedSchedulesToday.length > 0 &&
+      !scheduleLoads.some((entry) => entry.dateKey === todayDateKey)
+    ) {
+      scheduleLoads.push({
+        dateKey: todayDateKey,
+        schedules: reservedSchedulesToday,
+      });
+    }
+
+    if (scheduleLoads.length === 0) return;
+
+    const now = new Date();
+    const candidatesByScheduleId = new Map<
+      number,
+      { dateKey: string; schedule: ReservedScheduleItem }
+    >();
+
+    for (const { dateKey, schedules } of scheduleLoads) {
+      for (const schedule of schedules) {
+        if (Math.max(schedule.count.pending, 0) <= 0) continue;
+        if (!isScheduleStartReached(dateKey, schedule.startTime, now)) continue;
+        if (autoDeclineAttemptedScheduleIdsRef.current.has(schedule.scheduleId))
+          continue;
+        candidatesByScheduleId.set(schedule.scheduleId, { dateKey, schedule });
+      }
+    }
+
+    const candidates = [...candidatesByScheduleId.values()];
+    if (candidates.length === 0) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      let declinedAny = false;
+
+      for (const { schedule } of candidates) {
+        if (cancelled) return;
+
+        try {
+          const ids = await collectPendingReservationIdsForSchedule({
+            activityId,
+            scheduleId: schedule.scheduleId,
+          });
+          if (ids.length === 0) continue;
+          if (cancelled) return;
+
+          // `declinePendingReservationIds`는 일부만 거절돼도 실패분이 있으면 throw하므로 무효화 여부는 거절 시도 직전에 반영
+          declinedAny = true;
+          await declinePendingReservationIds(activityId, ids);
+        } catch {
+          // 다음 스케줄 처리 계속
+        } finally {
+          autoDeclineAttemptedScheduleIdsRef.current.add(schedule.scheduleId);
+        }
+      }
+
+      if (cancelled || !declinedAny) return;
+
+      await Promise.all(
+        ACTIVITY_RESERVATION_CACHE_ROOTS.map((root) =>
+          queryClient.invalidateQueries({
+            queryKey: [root, activityId],
+          })
+        )
+      );
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activityId,
+    fetchTodayScheduleInBackground,
+    queryClient,
+    reservedScheduleDateKey,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+    todayDateKey,
+  ]);
+};

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -93,7 +93,7 @@ export const useAutoDeclineExpiredReservations = ({
       let hasDeclinedAny = false;
 
       for (const { schedule } of candidates) {
-        if (isCancelled) return;
+        if (isCancelled) break;
 
         try {
           const ids = await collectPendingReservationIdsForSchedule({
@@ -101,7 +101,7 @@ export const useAutoDeclineExpiredReservations = ({
             scheduleId: schedule.scheduleId,
           });
           if (ids.length === 0) continue;
-          if (isCancelled) return;
+          if (isCancelled) break;
 
           // `declinePendingReservationIds`는 일부만 거절돼도 실패분이 있으면 throw하므로 무효화 여부는 거절 시도 직전에 반영
           hasDeclinedAny = true;

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -19,7 +19,7 @@ interface UseAutoDeclineExpiredReservationsProps {
   activityId: number | null;
   reservedScheduleDateKey: string | null;
   todayDateKey: string;
-  fetchTodayScheduleInBackground: boolean;
+  isTodayScheduleFetchRequired: boolean;
   reservedSchedulesSelected: ReservedScheduleItem[];
   reservedSchedulesToday: ReservedScheduleItem[];
 }
@@ -28,7 +28,7 @@ export const useAutoDeclineExpiredReservations = ({
   activityId,
   reservedScheduleDateKey,
   todayDateKey,
-  fetchTodayScheduleInBackground,
+  isTodayScheduleFetchRequired,
   reservedSchedulesSelected,
   reservedSchedulesToday,
 }: UseAutoDeclineExpiredReservationsProps) => {
@@ -56,7 +56,7 @@ export const useAutoDeclineExpiredReservations = ({
     }
 
     if (
-      fetchTodayScheduleInBackground &&
+      isTodayScheduleFetchRequired &&
       reservedSchedulesToday.length > 0 &&
       !scheduleLoads.some((entry) => entry.dateKey === todayDateKey)
     ) {
@@ -129,7 +129,7 @@ export const useAutoDeclineExpiredReservations = ({
     };
   }, [
     activityId,
-    fetchTodayScheduleInBackground,
+    isTodayScheduleFetchRequired,
     queryClient,
     reservedScheduleDateKey,
     reservedSchedulesSelected,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -39,7 +39,7 @@ export const useReservationCalendarData = ({
     );
   }, [currentYear, currentMonth]);
 
-  const fetchTodayScheduleInBackground =
+  const isTodayScheduleFetchRequired =
     isTodayInVisibleMonth &&
     (reservedScheduleDateKey === null ||
       reservedScheduleDateKey !== todayDateKey);
@@ -54,14 +54,14 @@ export const useReservationCalendarData = ({
     currentMonth,
     reservedScheduleDateKey,
     todayDateKey,
-    fetchTodayScheduleInBackground,
+    isTodayScheduleFetchRequired,
   });
 
   useAutoDeclineExpiredReservations({
     activityId,
     reservedScheduleDateKey,
     todayDateKey,
-    fetchTodayScheduleInBackground,
+    isTodayScheduleFetchRequired,
     reservedSchedulesSelected,
     reservedSchedulesToday,
   });
@@ -72,7 +72,7 @@ export const useReservationCalendarData = ({
       reservedScheduleDateKey,
       reservedSchedulesSelected,
       reservedSchedulesToday,
-      fetchTodayScheduleInBackground,
+      isTodayScheduleFetchRequired,
       todayDateKey,
     });
 

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarData.ts
@@ -1,36 +1,8 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchReservationDashboard } from '@/app/(main)/my/activities-dashboard/apis/reservationDashboard';
-import {
-  collectPendingReservationIdsForSchedule,
-  declinePendingReservationIds,
-} from '@/app/(main)/my/activities-dashboard/apis/reservations';
-import { fetchReservedSchedule } from '@/app/(main)/my/activities-dashboard/apis/reservedSchedule';
-import {
-  ReservationDetailData,
-  ReservationEventCounts,
-} from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
-import { buildReservationDetailData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeReservationDetailData';
-import { mergeScheduleOverlayIntoEventCounts } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeScheduleOverlayIntoEventCounts';
-import { isScheduleStartReached } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
-import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+import { useMemo } from 'react';
+import { useAutoDeclineExpiredReservations } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations';
+import { useReservationCalendarDisplayData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData';
+import { useReservationCalendarQueries } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries';
 import { formatDateKey } from '@/shared/utils/formatDate';
-
-/** 자동 거절 후 접두 `[root, activityId]`로 무효화할 쿼리 루트 */
-const ACTIVITY_RESERVATION_CACHE_ROOTS = [
-  QUERY_KEYS.MY_ACTIVITY_RESERVATIONS[0],
-  QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE[0],
-  QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD[0],
-] as const;
-
-const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
-  schedules.some((schedule) => {
-    const pending = Math.max(schedule.count.pending, 0);
-    const confirmed = Math.max(schedule.count.confirmed, 0);
-    const declined = Math.max(schedule.count.declined, 0);
-    return pending + confirmed + declined > 0;
-  });
 
 interface UseReservationCalendarDataProps {
   activityId: number | null;
@@ -59,263 +31,50 @@ export const useReservationCalendarData = ({
   currentMonth,
   reservedScheduleDateKey,
 }: UseReservationCalendarDataProps) => {
-  const queryClient = useQueryClient();
-  /** 선택일·체험이 바뀌기 전까지 자동 거절을 이미 시도한 `scheduleId` (무한 invalidate 루프 방지) */
-  const autoDeclineAttemptedScheduleIdsRef = useRef<Set<number>>(new Set());
-
   const todayDateKey = formatDateKey(new Date());
   const isTodayInVisibleMonth = useMemo(() => {
     const now = new Date();
     return (
       now.getFullYear() === currentYear && now.getMonth() + 1 === currentMonth
     );
-  }, [currentYear, currentMonth, todayDateKey]);
+  }, [currentYear, currentMonth]);
 
   const fetchTodayScheduleInBackground =
     isTodayInVisibleMonth &&
     (reservedScheduleDateKey === null ||
       reservedScheduleDateKey !== todayDateKey);
 
-  const { data: reservationDashboard = [] } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
-      activityId,
-      currentYear,
-      currentMonth,
-    ],
-    queryFn: () =>
-      fetchReservationDashboard({
-        activityId: activityId as number,
-        year: currentYear,
-        month: currentMonth,
-      }),
-    enabled: activityId !== null,
-    refetchInterval: activityId !== null ? 60_000 : false,
-  });
-
-  const { data: reservedSchedulesSelected = [] } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
-      activityId,
-      reservedScheduleDateKey,
-    ],
-    queryFn: () =>
-      fetchReservedSchedule({
-        activityId: activityId as number,
-        date: reservedScheduleDateKey as string,
-      }),
-    enabled: activityId !== null && Boolean(reservedScheduleDateKey),
-    refetchInterval:
-      activityId !== null && Boolean(reservedScheduleDateKey) ? 60_000 : false,
-  });
-
-  const { data: reservedSchedulesToday = [] } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
-      activityId,
-      todayDateKey,
-    ],
-    queryFn: () =>
-      fetchReservedSchedule({
-        activityId: activityId as number,
-        date: todayDateKey,
-      }),
-    enabled: activityId !== null && fetchTodayScheduleInBackground,
-    refetchInterval:
-      activityId !== null && fetchTodayScheduleInBackground ? 60_000 : false,
-  });
-
-  useEffect(() => {
-    autoDeclineAttemptedScheduleIdsRef.current.clear();
-  }, [activityId, reservedScheduleDateKey, todayDateKey]);
-
-  useEffect(() => {
-    if (activityId === null) return;
-
-    const scheduleLoads: {
-      dateKey: string;
-      schedules: ReservedScheduleItem[];
-    }[] = [];
-
-    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
-      scheduleLoads.push({
-        dateKey: reservedScheduleDateKey,
-        schedules: reservedSchedulesSelected,
-      });
-    }
-
-    if (
-      fetchTodayScheduleInBackground &&
-      reservedSchedulesToday.length > 0 &&
-      !scheduleLoads.some((entry) => entry.dateKey === todayDateKey)
-    ) {
-      scheduleLoads.push({
-        dateKey: todayDateKey,
-        schedules: reservedSchedulesToday,
-      });
-    }
-
-    if (scheduleLoads.length === 0) return;
-
-    const now = new Date();
-    const candidatesByScheduleId = new Map<
-      number,
-      { dateKey: string; schedule: ReservedScheduleItem }
-    >();
-
-    for (const { dateKey, schedules } of scheduleLoads) {
-      for (const schedule of schedules) {
-        if (Math.max(schedule.count.pending, 0) <= 0) continue;
-        if (!isScheduleStartReached(dateKey, schedule.startTime, now)) continue;
-        if (autoDeclineAttemptedScheduleIdsRef.current.has(schedule.scheduleId))
-          continue;
-        candidatesByScheduleId.set(schedule.scheduleId, { dateKey, schedule });
-      }
-    }
-
-    const candidates = [...candidatesByScheduleId.values()];
-    if (candidates.length === 0) return;
-
-    let cancelled = false;
-
-    void (async () => {
-      let declinedAny = false;
-
-      for (const { schedule } of candidates) {
-        if (cancelled) return;
-
-        try {
-          const ids = await collectPendingReservationIdsForSchedule({
-            activityId,
-            scheduleId: schedule.scheduleId,
-          });
-          if (ids.length === 0) continue;
-          if (cancelled) return;
-
-          // `declinePendingReservationIds`는 일부만 거절돼도 실패분이 있으면 throw하므로 무효화 여부는 거절 시도 직전에 반영
-          declinedAny = true;
-          await declinePendingReservationIds(activityId, ids);
-        } catch {
-          // 다음 스케줄 처리 계속
-        } finally {
-          autoDeclineAttemptedScheduleIdsRef.current.add(schedule.scheduleId);
-        }
-      }
-
-      if (cancelled || !declinedAny) return;
-
-      await Promise.all(
-        ACTIVITY_RESERVATION_CACHE_ROOTS.map((root) =>
-          queryClient.invalidateQueries({
-            queryKey: [root, activityId],
-          })
-        )
-      );
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    activityId,
-    fetchTodayScheduleInBackground,
-    queryClient,
-    reservedScheduleDateKey,
-    reservedSchedulesSelected,
-    reservedSchedulesToday,
-    todayDateKey,
-  ]);
-
-  const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
-    const notificationDotByDate: Record<string, boolean> = {};
-
-    const eventCounts = reservationDashboard.reduce<
-      Record<string, ReservationEventCounts>
-    >((accumulator, item) => {
-      const r = item.reservations;
-      const completed = Math.max(r.completed ?? 0, 0);
-      const confirmed = Math.max(r.confirmed ?? 0, 0);
-      const pending = Math.max(r.pending ?? 0, 0);
-      const declined = Math.max(r.declined ?? 0, 0);
-      const isPastDate = item.date < todayDateKey;
-      const pendingForDisplay = isPastDate ? 0 : pending;
-      const rawTotal = pendingForDisplay + confirmed + completed + declined;
-      if (rawTotal > 0) {
-        notificationDotByDate[item.date] = true;
-      }
-
-      const shiftedCompleted = isPastDate ? completed + confirmed : completed;
-      const shiftedConfirmed = isPastDate ? 0 : confirmed;
-
-      const dailyEventCounts: ReservationEventCounts = {};
-      if (pendingForDisplay > 0) dailyEventCounts.pending = pendingForDisplay;
-      if (shiftedConfirmed > 0) dailyEventCounts.confirmed = shiftedConfirmed;
-      if (shiftedCompleted > 0) dailyEventCounts.completed = shiftedCompleted;
-
-      if (Object.keys(dailyEventCounts).length > 0) {
-        accumulator[item.date] = dailyEventCounts;
-      }
-
-      return accumulator;
-    }, {});
-
-    if (
-      reservedScheduleDateKey &&
-      hasReservedSlotActivity(reservedSchedulesSelected)
-    ) {
-      notificationDotByDate[reservedScheduleDateKey] = true;
-    }
-
-    if (
-      fetchTodayScheduleInBackground &&
-      hasReservedSlotActivity(reservedSchedulesToday)
-    ) {
-      notificationDotByDate[todayDateKey] = true;
-    }
-
-    const scheduleDataByDate = new Map<string, ReservedScheduleItem[]>();
-    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
-      scheduleDataByDate.set(
-        reservedScheduleDateKey,
-        reservedSchedulesSelected
-      );
-    }
-    if (
-      fetchTodayScheduleInBackground &&
-      reservedSchedulesToday.length > 0 &&
-      todayDateKey !== reservedScheduleDateKey
-    ) {
-      scheduleDataByDate.set(todayDateKey, reservedSchedulesToday);
-    }
-
-    const nowForSchedules = new Date();
-    scheduleDataByDate.forEach((schedules, dateKey) => {
-      const merged = mergeScheduleOverlayIntoEventCounts(
-        dateKey,
-        schedules,
-        nowForSchedules,
-        eventCounts[dateKey]
-      );
-      if (merged) {
-        eventCounts[dateKey] = merged;
-      }
-    });
-
-    return { eventCountsByDate: eventCounts, notificationDotByDate };
-  }, [
-    fetchTodayScheduleInBackground,
+  const {
     reservationDashboard,
-    reservedScheduleDateKey,
     reservedSchedulesSelected,
     reservedSchedulesToday,
+  } = useReservationCalendarQueries({
+    activityId,
+    currentYear,
+    currentMonth,
+    reservedScheduleDateKey,
     todayDateKey,
-  ]);
+    fetchTodayScheduleInBackground,
+  });
 
-  const detailData = useMemo<ReservationDetailData>(() => {
-    return buildReservationDetailData({
-      reservedSchedules: reservedSchedulesSelected,
+  useAutoDeclineExpiredReservations({
+    activityId,
+    reservedScheduleDateKey,
+    todayDateKey,
+    fetchTodayScheduleInBackground,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+  });
+
+  const { eventCountsByDate, notificationDotByDate, detailData } =
+    useReservationCalendarDisplayData({
+      reservationDashboard,
+      reservedScheduleDateKey,
+      reservedSchedulesSelected,
+      reservedSchedulesToday,
+      fetchTodayScheduleInBackground,
+      todayDateKey,
     });
-  }, [reservedSchedulesSelected]);
 
   return {
     detailData,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+import {
+  ReservationDetailData,
+  ReservationEventCounts,
+} from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
+import { buildReservationDetailData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeReservationDetailData';
+import { mergeScheduleOverlayIntoEventCounts } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeScheduleOverlayIntoEventCounts';
+import type { ReservationDashboardItem } from '@/shared/types/reservationDashboard.types';
+import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+
+const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
+  schedules.some((schedule) => {
+    const pending = Math.max(schedule.count.pending, 0);
+    const confirmed = Math.max(schedule.count.confirmed, 0);
+    const declined = Math.max(schedule.count.declined, 0);
+    return pending + confirmed + declined > 0;
+  });
+
+interface UseReservationCalendarDisplayDataProps {
+  reservationDashboard: ReservationDashboardItem[];
+  reservedScheduleDateKey: string | null;
+  reservedSchedulesSelected: ReservedScheduleItem[];
+  reservedSchedulesToday: ReservedScheduleItem[];
+  fetchTodayScheduleInBackground: boolean;
+  todayDateKey: string;
+}
+
+export const useReservationCalendarDisplayData = ({
+  reservationDashboard,
+  reservedScheduleDateKey,
+  reservedSchedulesSelected,
+  reservedSchedulesToday,
+  fetchTodayScheduleInBackground,
+  todayDateKey,
+}: UseReservationCalendarDisplayDataProps) => {
+  const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
+    const notificationDotByDate: Record<string, boolean> = {};
+
+    const eventCounts = reservationDashboard.reduce<
+      Record<string, ReservationEventCounts>
+    >((accumulator, item) => {
+      const r = item.reservations;
+      const completed = Math.max(r.completed ?? 0, 0);
+      const confirmed = Math.max(r.confirmed ?? 0, 0);
+      const pending = Math.max(r.pending ?? 0, 0);
+      const declined = Math.max(r.declined ?? 0, 0);
+      const isPastDate = item.date < todayDateKey;
+      const pendingForDisplay = isPastDate ? 0 : pending;
+      const rawTotal = pendingForDisplay + confirmed + completed + declined;
+      if (rawTotal > 0) {
+        notificationDotByDate[item.date] = true;
+      }
+
+      const shiftedCompleted = isPastDate ? completed + confirmed : completed;
+      const shiftedConfirmed = isPastDate ? 0 : confirmed;
+
+      const dailyEventCounts: ReservationEventCounts = {};
+      if (pendingForDisplay > 0) dailyEventCounts.pending = pendingForDisplay;
+      if (shiftedConfirmed > 0) dailyEventCounts.confirmed = shiftedConfirmed;
+      if (shiftedCompleted > 0) dailyEventCounts.completed = shiftedCompleted;
+
+      if (Object.keys(dailyEventCounts).length > 0) {
+        accumulator[item.date] = dailyEventCounts;
+      }
+
+      return accumulator;
+    }, {});
+
+    if (
+      reservedScheduleDateKey &&
+      hasReservedSlotActivity(reservedSchedulesSelected)
+    ) {
+      notificationDotByDate[reservedScheduleDateKey] = true;
+    }
+
+    if (
+      fetchTodayScheduleInBackground &&
+      hasReservedSlotActivity(reservedSchedulesToday)
+    ) {
+      notificationDotByDate[todayDateKey] = true;
+    }
+
+    const scheduleDataByDate = new Map<string, ReservedScheduleItem[]>();
+    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
+      scheduleDataByDate.set(
+        reservedScheduleDateKey,
+        reservedSchedulesSelected
+      );
+    }
+    if (
+      fetchTodayScheduleInBackground &&
+      reservedSchedulesToday.length > 0 &&
+      todayDateKey !== reservedScheduleDateKey
+    ) {
+      scheduleDataByDate.set(todayDateKey, reservedSchedulesToday);
+    }
+
+    const nowForSchedules = new Date();
+    scheduleDataByDate.forEach((schedules, dateKey) => {
+      const merged = mergeScheduleOverlayIntoEventCounts(
+        dateKey,
+        schedules,
+        nowForSchedules,
+        eventCounts[dateKey]
+      );
+      if (merged) {
+        eventCounts[dateKey] = merged;
+      }
+    });
+
+    return { eventCountsByDate: eventCounts, notificationDotByDate };
+  }, [
+    fetchTodayScheduleInBackground,
+    reservationDashboard,
+    reservedScheduleDateKey,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+    todayDateKey,
+  ]);
+
+  const detailData = useMemo<ReservationDetailData>(() => {
+    return buildReservationDetailData({
+      reservedSchedules: reservedSchedulesSelected,
+    });
+  }, [reservedSchedulesSelected]);
+
+  return { eventCountsByDate, notificationDotByDate, detailData };
+};

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
@@ -5,7 +5,7 @@ import {
 } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
 import { buildReservationDetailData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeReservationDetailData';
 import { mergeScheduleOverlayIntoEventCounts } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeScheduleOverlayIntoEventCounts';
-import type { ReservationDashboardItem } from '@/shared/types/reservationDashboard.types';
+import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
 import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
 
 const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
@@ -17,7 +17,7 @@ const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
   });
 
 interface UseReservationCalendarDisplayDataProps {
-  reservationDashboard: ReservationDashboardItem[];
+  reservationDashboard: ReservationDashboardDailyItem[];
   reservedScheduleDateKey: string | null;
   reservedSchedulesSelected: ReservedScheduleItem[];
   reservedSchedulesToday: ReservedScheduleItem[];

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
@@ -21,7 +21,7 @@ interface UseReservationCalendarDisplayDataProps {
   reservedScheduleDateKey: string | null;
   reservedSchedulesSelected: ReservedScheduleItem[];
   reservedSchedulesToday: ReservedScheduleItem[];
-  fetchTodayScheduleInBackground: boolean;
+  isTodayScheduleFetchRequired: boolean;
   todayDateKey: string;
 }
 
@@ -30,7 +30,7 @@ export const useReservationCalendarDisplayData = ({
   reservedScheduleDateKey,
   reservedSchedulesSelected,
   reservedSchedulesToday,
-  fetchTodayScheduleInBackground,
+  isTodayScheduleFetchRequired,
   todayDateKey,
 }: UseReservationCalendarDisplayDataProps) => {
   const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
@@ -74,7 +74,7 @@ export const useReservationCalendarDisplayData = ({
     }
 
     if (
-      fetchTodayScheduleInBackground &&
+      isTodayScheduleFetchRequired &&
       hasReservedSlotActivity(reservedSchedulesToday)
     ) {
       notificationDotByDate[todayDateKey] = true;
@@ -88,7 +88,7 @@ export const useReservationCalendarDisplayData = ({
       );
     }
     if (
-      fetchTodayScheduleInBackground &&
+      isTodayScheduleFetchRequired &&
       reservedSchedulesToday.length > 0 &&
       todayDateKey !== reservedScheduleDateKey
     ) {
@@ -110,7 +110,7 @@ export const useReservationCalendarDisplayData = ({
 
     return { eventCountsByDate: eventCounts, notificationDotByDate };
   }, [
-    fetchTodayScheduleInBackground,
+    isTodayScheduleFetchRequired,
     reservationDashboard,
     reservedScheduleDateKey,
     reservedSchedulesSelected,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
@@ -2,9 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchReservationDashboard } from '@/app/(main)/my/activities-dashboard/apis/reservationDashboard';
 import { fetchReservedSchedule } from '@/app/(main)/my/activities-dashboard/apis/reservedSchedule';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
 import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
 
 const EMPTY_SCHEDULES: ReservedScheduleItem[] = [];
+const EMPTY_DASHBOARD: ReservationDashboardDailyItem[] = [];
 
 interface UseReservationCalendarQueriesProps {
   activityId: number | null;
@@ -23,7 +25,7 @@ export const useReservationCalendarQueries = ({
   todayDateKey,
   isTodayScheduleFetchRequired,
 }: UseReservationCalendarQueriesProps) => {
-  const { data: reservationDashboard = [] } = useQuery({
+  const { data: reservationDashboard = EMPTY_DASHBOARD } = useQuery({
     queryKey: [
       ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
       activityId,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
@@ -2,6 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchReservationDashboard } from '@/app/(main)/my/activities-dashboard/apis/reservationDashboard';
 import { fetchReservedSchedule } from '@/app/(main)/my/activities-dashboard/apis/reservedSchedule';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+
+const EMPTY_SCHEDULES: ReservedScheduleItem[] = [];
 
 interface UseReservationCalendarQueriesProps {
   activityId: number | null;
@@ -37,7 +40,7 @@ export const useReservationCalendarQueries = ({
     refetchInterval: activityId !== null ? 60_000 : false,
   });
 
-  const { data: reservedSchedulesSelected = [] } = useQuery({
+  const { data: reservedSchedulesSelected = EMPTY_SCHEDULES } = useQuery({
     queryKey: [
       ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
       activityId,
@@ -53,7 +56,7 @@ export const useReservationCalendarQueries = ({
       activityId !== null && Boolean(reservedScheduleDateKey) ? 60_000 : false,
   });
 
-  const { data: reservedSchedulesToday = [] } = useQuery({
+  const { data: reservedSchedulesToday = EMPTY_SCHEDULES } = useQuery({
     queryKey: [
       ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
       activityId,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchReservationDashboard } from '@/app/(main)/my/activities-dashboard/apis/reservationDashboard';
+import { fetchReservedSchedule } from '@/app/(main)/my/activities-dashboard/apis/reservedSchedule';
+import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+
+interface UseReservationCalendarQueriesProps {
+  activityId: number | null;
+  currentYear: number;
+  currentMonth: number;
+  reservedScheduleDateKey: string | null;
+  todayDateKey: string;
+  fetchTodayScheduleInBackground: boolean;
+}
+
+export const useReservationCalendarQueries = ({
+  activityId,
+  currentYear,
+  currentMonth,
+  reservedScheduleDateKey,
+  todayDateKey,
+  fetchTodayScheduleInBackground,
+}: UseReservationCalendarQueriesProps) => {
+  const { data: reservationDashboard = [] } = useQuery({
+    queryKey: [
+      ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
+      activityId,
+      currentYear,
+      currentMonth,
+    ],
+    queryFn: () =>
+      fetchReservationDashboard({
+        activityId: activityId as number,
+        year: currentYear,
+        month: currentMonth,
+      }),
+    enabled: activityId !== null,
+    refetchInterval: activityId !== null ? 60_000 : false,
+  });
+
+  const { data: reservedSchedulesSelected = [] } = useQuery({
+    queryKey: [
+      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
+      activityId,
+      reservedScheduleDateKey,
+    ],
+    queryFn: () =>
+      fetchReservedSchedule({
+        activityId: activityId as number,
+        date: reservedScheduleDateKey as string,
+      }),
+    enabled: activityId !== null && Boolean(reservedScheduleDateKey),
+    refetchInterval:
+      activityId !== null && Boolean(reservedScheduleDateKey) ? 60_000 : false,
+  });
+
+  const { data: reservedSchedulesToday = [] } = useQuery({
+    queryKey: [
+      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
+      activityId,
+      todayDateKey,
+    ],
+    queryFn: () =>
+      fetchReservedSchedule({
+        activityId: activityId as number,
+        date: todayDateKey,
+      }),
+    enabled: activityId !== null && fetchTodayScheduleInBackground,
+    refetchInterval:
+      activityId !== null && fetchTodayScheduleInBackground ? 60_000 : false,
+  });
+
+  return {
+    reservationDashboard,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+  };
+};

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
@@ -12,7 +12,7 @@ interface UseReservationCalendarQueriesProps {
   currentMonth: number;
   reservedScheduleDateKey: string | null;
   todayDateKey: string;
-  fetchTodayScheduleInBackground: boolean;
+  isTodayScheduleFetchRequired: boolean;
 }
 
 export const useReservationCalendarQueries = ({
@@ -21,7 +21,7 @@ export const useReservationCalendarQueries = ({
   currentMonth,
   reservedScheduleDateKey,
   todayDateKey,
-  fetchTodayScheduleInBackground,
+  isTodayScheduleFetchRequired,
 }: UseReservationCalendarQueriesProps) => {
   const { data: reservationDashboard = [] } = useQuery({
     queryKey: [
@@ -67,9 +67,9 @@ export const useReservationCalendarQueries = ({
         activityId: activityId as number,
         date: todayDateKey,
       }),
-    enabled: activityId !== null && fetchTodayScheduleInBackground,
+    enabled: activityId !== null && isTodayScheduleFetchRequired,
     refetchInterval:
-      activityId !== null && fetchTodayScheduleInBackground ? 60_000 : false,
+      activityId !== null && isTodayScheduleFetchRequired ? 60_000 : false,
   });
 
   return {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #326 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용
- 단일 훅에 책임이 몰려 있어 정책 변경/버그 수정 시 영향 범위가 커지는 문제를 줄이고
- 자동 거절 로직과 표시 규칙을 독립시켜 테스트 가능성과 유지보수성을 높이기 위해 작업 진행

- `useReservationCalendarData`에서 조회/자동 거절/표시 데이터 가공 책임을 분리해 오케스트레이션 역할만 남기도록 진행
- 조회 로직을 `useReservationCalendarQueries`, 자동 거절 effect를 `useAutoDeclineExpiredReservations`, 표시 데이터 가공을 `useReservationCalendarDisplayData`로 분리
- 기존 동작(월간 대시보드 조회, 선택일/오늘 스케줄 조회, 지난 pending 자동 거절, 캘린더 배지/도트/상세 데이터 계산)은 유지