### PR TITLE
[Chore/#327] 날짜/시간 유틸 단위 테스트 도입

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
         "storybook": "^10.3.5",
         "tailwindcss": "^4",
         "typescript": "^5",
-        "vite-plugin-svgr": "^5.2.0"
+        "vite-plugin-svgr": "^5.2.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3571,7 +3572,6 @@
       "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -3589,7 +3589,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3607,7 +3606,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3625,7 +3623,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3643,7 +3640,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3661,7 +3657,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3679,7 +3674,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3697,7 +3691,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3715,7 +3708,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3733,7 +3725,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3751,7 +3742,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3769,7 +3759,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3787,7 +3776,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3802,7 +3790,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -3819,7 +3806,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -3832,7 +3818,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3844,7 +3829,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
@@ -3870,7 +3854,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3888,7 +3871,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3898,8 +3880,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
       "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -3972,6 +3953,13 @@
       "funding": {
         "url": "https://ko-fi.com/dangreen"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -5763,6 +5751,53 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -5774,6 +5809,112 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -7378,6 +7519,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7963,6 +8111,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8132,7 +8290,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -10321,6 +10478,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -10519,6 +10690,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
@@ -11196,7 +11374,6 @@
       "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.126.0",
         "@rolldown/pluginutils": "1.0.0-rc.16"
@@ -11549,6 +11726,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11626,6 +11810,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12012,6 +12210,13 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -12502,7 +12707,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12643,12 +12847,190 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/warning": {
@@ -12770,6 +13152,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
@@ -53,7 +55,8 @@
     "storybook": "^10.3.5",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vite-plugin-svgr": "^5.2.0"
+    "vite-plugin-svgr": "^5.2.0",
+    "vitest": "^4.1.9"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -8,9 +8,12 @@ import {
   type MyReservedScheduleItem,
 } from '@/app/(main)/activity/[id]/apis/myReservedSchedules';
 import type { TimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
+import {
+  normalizeDateKey,
+  parseTimeToHourMinute,
+} from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
-import { formatDateKey } from '@/shared/utils/formatDate';
 
 const EMPTY_RESERVED_SCHEDULES: MyReservedScheduleItem[] = [];
 
@@ -22,44 +25,9 @@ interface UseActivityReservationAvailabilityProps {
   isAuthenticated: boolean;
 }
 
-const normalizeDateKey = (rawDate: string) => {
-  const trimmed = rawDate.trim();
-  const shortDate = trimmed.slice(0, 10);
-
-  if (/^\d{4}-\d{2}-\d{2}$/.test(shortDate)) {
-    return shortDate;
-  }
-
-  const parsed = new Date(trimmed);
-  if (Number.isNaN(parsed.getTime())) {
-    return trimmed;
-  }
-
-  return formatDateKey(parsed);
-};
-
 const parseYearMonthFromDateKey = (dateKey: string) => {
   const [year, month] = dateKey.split('-').map(Number);
   return { year, month };
-};
-
-const parseTimeToHourMinute = (time: string) => {
-  const [hourText, minuteText] = time.split(':');
-  const hour = Number(hourText);
-  const minute = Number(minuteText);
-
-  if (
-    !Number.isInteger(hour) ||
-    !Number.isInteger(minute) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59
-  ) {
-    return null;
-  }
-
-  return { hour, minute };
 };
 
 const isUpcomingTimeSlot = (dateKey: string, startTime: string, now: Date) => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -5,6 +5,12 @@ import {
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
 
 describe('normalizeDateKey', () => {
+  it('null/undefined 등 유효하지 않은 입력은 빈 문자열을 반환한다', () => {
+    expect(normalizeDateKey(null)).toBe('');
+    expect(normalizeDateKey(undefined)).toBe('');
+    expect(normalizeDateKey(1234)).toBe('');
+  });
+
   it('시간 정보가 포함된 ISO 문자열은 KST 기준 날짜로 변환한다', () => {
     expect(normalizeDateKey('2026-06-30T15:00:00.000Z')).toBe('2026-07-01');
   });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -29,6 +29,13 @@ describe('normalizeDateKey', () => {
 });
 
 describe('parseTimeToHourMinute', () => {
+  it('null/undefined 등 유효하지 않은 입력은 null을 반환한다', () => {
+    expect(parseTimeToHourMinute(null)).toBeNull();
+    expect(parseTimeToHourMinute(undefined)).toBeNull();
+    expect(parseTimeToHourMinute(930)).toBeNull();
+    expect(parseTimeToHourMinute('')).toBeNull();
+  });
+
   it('정상 시각 문자열을 시/분 객체로 반환한다', () => {
     expect(parseTimeToHourMinute('09:30')).toEqual({ hour: 9, minute: 30 });
   });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -3,22 +3,18 @@ import {
   normalizeDateKey,
   parseTimeToHourMinute,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
-import { formatDateKey } from '@/shared/utils/formatDate';
 
 describe('normalizeDateKey', () => {
-  it('시간 정보가 포함된 ISO 문자열은 로컬 타임존 기준 날짜로 변환한다', () => {
-    const isoDateTime = '2026-06-30T15:00:00.000Z';
-    const expected = formatDateKey(new Date(isoDateTime));
-
-    expect(normalizeDateKey(` ${isoDateTime} `)).toBe(expected);
+  it('시간 정보가 포함된 ISO 문자열은 KST 기준 날짜로 변환한다', () => {
+    expect(normalizeDateKey('2026-06-30T15:00:00.000Z')).toBe('2026-07-01');
   });
 
   it('순수 날짜 문자열은 그대로 유지한다', () => {
     expect(normalizeDateKey('2026-06-30')).toBe('2026-06-30');
   });
 
-  it('파싱 가능한 문자열은 YYYY-MM-DD로 정규화한다', () => {
-    expect(normalizeDateKey('2026/06/30 14:30')).toBe('2026-06-30');
+  it('오프셋이 포함된 datetime 문자열은 KST 기준으로 정규화한다', () => {
+    expect(normalizeDateKey('2026-06-30T05:00:00-05:00')).toBe('2026-06-30');
   });
 
   it('파싱 불가능한 문자열은 trim 결과를 반환한다', () => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -3,10 +3,18 @@ import {
   normalizeDateKey,
   parseTimeToHourMinute,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
+import { formatDateKey } from '@/shared/utils/formatDate';
 
 describe('normalizeDateKey', () => {
-  it('ISO 형식 문자열에서 날짜 부분만 추출한다', () => {
-    expect(normalizeDateKey(' 2026-06-30T14:30:00.000Z ')).toBe('2026-06-30');
+  it('시간 정보가 포함된 ISO 문자열은 로컬 타임존 기준 날짜로 변환한다', () => {
+    const isoDateTime = '2026-06-30T15:00:00.000Z';
+    const expected = formatDateKey(new Date(isoDateTime));
+
+    expect(normalizeDateKey(` ${isoDateTime} `)).toBe(expected);
+  });
+
+  it('순수 날짜 문자열은 그대로 유지한다', () => {
+    expect(normalizeDateKey('2026-06-30')).toBe('2026-06-30');
   });
 
   it('파싱 가능한 문자열은 YYYY-MM-DD로 정규화한다', () => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeDateKey,
+  parseTimeToHourMinute,
+} from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
+
+describe('normalizeDateKey', () => {
+  it('ISO 형식 문자열에서 날짜 부분만 추출한다', () => {
+    expect(normalizeDateKey(' 2026-06-30T14:30:00.000Z ')).toBe('2026-06-30');
+  });
+
+  it('파싱 가능한 문자열은 YYYY-MM-DD로 정규화한다', () => {
+    expect(normalizeDateKey('2026/06/30 14:30')).toBe('2026-06-30');
+  });
+
+  it('파싱 불가능한 문자열은 trim 결과를 반환한다', () => {
+    expect(normalizeDateKey(' invalid-date ')).toBe('invalid-date');
+  });
+});
+
+describe('parseTimeToHourMinute', () => {
+  it('정상 시각 문자열을 시/분 객체로 반환한다', () => {
+    expect(parseTimeToHourMinute('09:30')).toEqual({ hour: 9, minute: 30 });
+  });
+
+  it('허용 범위를 벗어난 시각은 null을 반환한다', () => {
+    expect(parseTimeToHourMinute('24:00')).toBeNull();
+    expect(parseTimeToHourMinute('10:60')).toBeNull();
+  });
+
+  it('숫자로 파싱되지 않는 값은 null을 반환한다', () => {
+    expect(parseTimeToHourMinute('aa:bb')).toBeNull();
+  });
+});

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -5,10 +5,17 @@ import {
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
 
 describe('normalizeDateKey', () => {
+  it('Date 객체 입력은 KST 기준 날짜 문자열로 변환한다', () => {
+    expect(normalizeDateKey(new Date('2026-06-30T15:00:00.000Z'))).toBe(
+      '2026-07-01'
+    );
+  });
+
   it('null/undefined 등 유효하지 않은 입력은 빈 문자열을 반환한다', () => {
     expect(normalizeDateKey(null)).toBe('');
     expect(normalizeDateKey(undefined)).toBe('');
     expect(normalizeDateKey(1234)).toBe('');
+    expect(normalizeDateKey(new Date('invalid'))).toBe('');
   });
 
   it('시간 정보가 포함된 ISO 문자열은 KST 기준 날짜로 변환한다', () => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -38,6 +38,7 @@ describe('parseTimeToHourMinute', () => {
 
   it('정상 시각 문자열을 시/분 객체로 반환한다', () => {
     expect(parseTimeToHourMinute('09:30')).toEqual({ hour: 9, minute: 30 });
+    expect(parseTimeToHourMinute('09:30:59')).toEqual({ hour: 9, minute: 30 });
   });
 
   it('허용 범위를 벗어난 시각은 null을 반환한다', () => {
@@ -45,7 +46,10 @@ describe('parseTimeToHourMinute', () => {
     expect(parseTimeToHourMinute('10:60')).toBeNull();
   });
 
-  it('숫자로 파싱되지 않는 값은 null을 반환한다', () => {
+  it('형식이 잘못된 값은 null을 반환한다', () => {
+    expect(parseTimeToHourMinute(':')).toBeNull();
+    expect(parseTimeToHourMinute('12:')).toBeNull();
+    expect(parseTimeToHourMinute(':30')).toBeNull();
     expect(parseTimeToHourMinute('aa:bb')).toBeNull();
   });
 });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -2,10 +2,9 @@ import { formatDateKey } from '@/shared/utils/formatDate';
 
 export const normalizeDateKey = (rawDate: string) => {
   const trimmed = rawDate.trim();
-  const shortDate = trimmed.slice(0, 10);
 
-  if (/^\d{4}-\d{2}-\d{2}$/.test(shortDate)) {
-    return shortDate;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
   }
 
   const parsed = new Date(trimmed);

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -18,7 +18,11 @@ const toKstDateKey = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
-export const normalizeDateKey = (rawDate: string) => {
+export const normalizeDateKey = (rawDate: unknown) => {
+  if (typeof rawDate !== 'string' || rawDate.length === 0) {
+    return '';
+  }
+
   const trimmed = rawDate.trim();
 
   if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -1,0 +1,36 @@
+import { formatDateKey } from '@/shared/utils/formatDate';
+
+export const normalizeDateKey = (rawDate: string) => {
+  const trimmed = rawDate.trim();
+  const shortDate = trimmed.slice(0, 10);
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(shortDate)) {
+    return shortDate;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return trimmed;
+  }
+
+  return formatDateKey(parsed);
+};
+
+export const parseTimeToHourMinute = (time: string) => {
+  const [hourText, minuteText] = time.split(':');
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  return { hour, minute };
+};

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -37,7 +37,11 @@ export const normalizeDateKey = (rawDate: unknown) => {
   return toKstDateKey(parsed) || trimmed;
 };
 
-export const parseTimeToHourMinute = (time: string) => {
+export const parseTimeToHourMinute = (time: unknown) => {
+  if (typeof time !== 'string' || time.length === 0) {
+    return null;
+  }
+
   const [hourText, minuteText] = time.split(':');
   const hour = Number(hourText);
   const minute = Number(minuteText);

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -1,4 +1,22 @@
-import { formatDateKey } from '@/shared/utils/formatDate';
+const KST_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'Asia/Seoul',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const toKstDateKey = (date: Date) => {
+  const parts = KST_DATE_FORMATTER.formatToParts(date);
+  const year = parts.find((part) => part.type === 'year')?.value;
+  const month = parts.find((part) => part.type === 'month')?.value;
+  const day = parts.find((part) => part.type === 'day')?.value;
+
+  if (!year || !month || !day) {
+    return '';
+  }
+
+  return `${year}-${month}-${day}`;
+};
 
 export const normalizeDateKey = (rawDate: string) => {
   const trimmed = rawDate.trim();
@@ -12,7 +30,7 @@ export const normalizeDateKey = (rawDate: string) => {
     return trimmed;
   }
 
-  return formatDateKey(parsed);
+  return toKstDateKey(parsed) || trimmed;
 };
 
 export const parseTimeToHourMinute = (time: string) => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -37,23 +37,25 @@ export const normalizeDateKey = (rawDate: unknown) => {
   return toKstDateKey(parsed) || trimmed;
 };
 
+/**
+ * `HH:MM` 또는 `HH:MM:SS` 형식의 시간 문자열을 파싱해 시/분 반환
+ * 형식이 올바르지 않거나 범위를 벗어나면 null을 반환
+ */
 export const parseTimeToHourMinute = (time: unknown) => {
   if (typeof time !== 'string' || time.length === 0) {
     return null;
   }
 
-  const [hourText, minuteText] = time.split(':');
+  const trimmed = time.trim();
+  if (!/^\d{1,2}:\d{2}(:\d{2})?$/.test(trimmed)) {
+    return null;
+  }
+
+  const [hourText, minuteText] = trimmed.split(':');
   const hour = Number(hourText);
   const minute = Number(minuteText);
 
-  if (
-    !Number.isInteger(hour) ||
-    !Number.isInteger(minute) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59
-  ) {
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
     return null;
   }
 

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -18,7 +18,21 @@ const toKstDateKey = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
+/**
+ * 입력값을 KST 기준 `YYYY-MM-DD` 날짜 키로 정규화한다.
+ *
+ * @example
+ * normalizeDateKey('2026-06-30T15:00:00.000Z') // '2026-07-01'
+ */
 export const normalizeDateKey = (rawDate: unknown) => {
+  if (rawDate instanceof Date) {
+    if (Number.isNaN(rawDate.getTime())) {
+      return '';
+    }
+
+    return toKstDateKey(rawDate);
+  }
+
   if (typeof rawDate !== 'string' || rawDate.length === 0) {
     return '';
   }

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus.test.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isScheduleStartReached } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus';
+
+describe('isScheduleStartReached', () => {
+  it('시작 시각을 지난 경우 true를 반환한다', () => {
+    const now = new Date(2026, 5, 30, 14, 1, 0);
+
+    expect(isScheduleStartReached('2026-06-30', '14:00', now)).toBe(true);
+  });
+
+  it('시작 시각 전이면 false를 반환한다', () => {
+    const now = new Date(2026, 5, 30, 13, 59, 59);
+
+    expect(isScheduleStartReached('2026-06-30', '14:00', now)).toBe(false);
+  });
+
+  it('잘못된 날짜 문자열이면 false를 반환한다', () => {
+    const now = new Date(2026, 5, 30, 14, 1, 0);
+
+    expect(isScheduleStartReached('invalid-date', '14:00', now)).toBe(false);
+  });
+});

--- a/src/shared/utils/formatDate.test.ts
+++ b/src/shared/utils/formatDate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatDateKey } from '@/shared/utils/formatDate';
+
+describe('formatDateKey', () => {
+  it('Date를 YYYY-MM-DD 키로 변환한다', () => {
+    const date = new Date(2026, 5, 30);
+
+    expect(formatDateKey(date)).toBe('2026-06-30');
+  });
+
+  it('월/일 한 자리 수를 0으로 패딩한다', () => {
+    const date = new Date(2026, 0, 5);
+
+    expect(formatDateKey(date)).toBe('2026-01-05');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## 🔗 관련 이슈

- close #327 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용
- 날짜/시간 관련 순수 유틸 함수에 대한 단위 테스트 추가
- 리그레션 위험이 큰 경계값(시작 직전/직후, 포맷 정규화, 시간 파싱 실패) 중심 검증 진행
- 테스트 실행 환경으로 Vitest도입, 스크립트 추가

- 테스트 러너 도입
  - `vitest` devDependency 추가
  - `package.json` 스크립트 추가: `test`, `test:run`
  - `vitest.config.ts` 추가 (`@` alias 설정)
- 유틸 테스트 가능 구조 정리
  - `normalizeDateKey`, `parseTimeToHourMinute`를 별도 유틸로 분리
- 테스트 추가
  - `src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus.test.ts`
    - `isScheduleStartReached` 테스트
  - `src/shared/utils/formatDate.test.ts`
    - `formatDateKey` 테스트
  - `src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts`
    - `normalizeDateKey`, `parseTimeToHourMinute` 테스트
