### PR TITLE
[Refactor/#328] 체험 상세 - 이미지 갤러리 슬롯 렌더링 데이터 기반으로 정리

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -248,7 +248,6 @@ export function ActivityImageGallery({
     );
   }
 
-  const five = imageUrls.slice(0, 5);
   const leftSlots: GallerySlotConfig[] = [
     {
       index: 0,
@@ -300,14 +299,10 @@ export function ActivityImageGallery({
         )}
       >
         <div className="flex min-h-0 w-1/2 min-w-0 flex-1 flex-col gap-2">
-          {leftSlots.map((slot) =>
-            five[slot.index] ? renderSlot(slot) : null
-          )}
+          {leftSlots.map(renderSlot)}
         </div>
         <div className="flex min-h-0 w-1/2 min-w-0 flex-1 flex-col gap-2">
-          {rightSlots.map((slot) =>
-            five[slot.index] ? renderSlot(slot) : null
-          )}
+          {rightSlots.map(renderSlot)}
         </div>
       </div>
       {lightbox}

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -21,6 +21,15 @@ const DESKTOP_GRID_IMAGE_SIZES =
 const LCP_IMAGE_QUALITY = 75;
 const REGULAR_IMAGE_QUALITY = 68;
 
+interface GallerySlotConfig {
+  index: number;
+  alt: string;
+  className: string;
+  sizes: string;
+  quality: number;
+  priority?: boolean;
+}
+
 /**
  * 체험 상세 페이지 이미지 갤러리
  *
@@ -54,6 +63,30 @@ export function ActivityImageGallery({
   const lightboxUrls = imageUrls;
 
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const renderSlot = ({
+    index,
+    alt,
+    className: slotClassName,
+    sizes,
+    quality,
+    priority,
+  }: GallerySlotConfig) => {
+    const url = imageUrls[index];
+    if (!url) return null;
+
+    return (
+      <GalleryImageSlot
+        key={`${url}-${index}`}
+        src={url}
+        alt={alt}
+        className={slotClassName}
+        sizes={sizes}
+        quality={quality}
+        priority={priority}
+        onOpen={() => setLightboxIndex(index)}
+      />
+    );
+  };
 
   const lightbox =
     lightboxIndex !== null && lightboxUrls[lightboxIndex] ? (
@@ -82,6 +115,17 @@ export function ActivityImageGallery({
   }
 
   if (count === 1) {
+    const slots: GallerySlotConfig[] = [
+      {
+        index: 0,
+        alt: title,
+        className: 'h-full w-full',
+        sizes: DESKTOP_MAIN_IMAGE_SIZES,
+        quality: LCP_IMAGE_QUALITY,
+        priority: true,
+      },
+    ];
+
     return (
       <>
         <div
@@ -91,15 +135,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          <GalleryImageSlot
-            src={imageUrls[0]}
-            alt={title}
-            className="h-full w-full"
-            sizes={DESKTOP_MAIN_IMAGE_SIZES}
-            quality={LCP_IMAGE_QUALITY}
-            priority
-            onOpen={() => setLightboxIndex(0)}
-          />
+          {slots.map((slot) => renderSlot(slot))}
         </div>
         {lightbox}
       </>
@@ -107,6 +143,24 @@ export function ActivityImageGallery({
   }
 
   if (count === 2) {
+    const slots: GallerySlotConfig[] = [
+      {
+        index: 0,
+        alt: `${title} 이미지 1`,
+        className: 'min-h-0 flex-1',
+        sizes: DESKTOP_MAIN_IMAGE_SIZES,
+        quality: LCP_IMAGE_QUALITY,
+        priority: true,
+      },
+      {
+        index: 1,
+        alt: `${title} 이미지 2`,
+        className: 'min-h-0 flex-1',
+        sizes: DESKTOP_MAIN_IMAGE_SIZES,
+        quality: REGULAR_IMAGE_QUALITY,
+      },
+    ];
+
     return (
       <>
         <div
@@ -116,23 +170,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          <GalleryImageSlot
-            src={imageUrls[0]}
-            alt={`${title} 이미지 1`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_MAIN_IMAGE_SIZES}
-            quality={LCP_IMAGE_QUALITY}
-            priority
-            onOpen={() => setLightboxIndex(0)}
-          />
-          <GalleryImageSlot
-            src={imageUrls[1]}
-            alt={`${title} 이미지 2`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_MAIN_IMAGE_SIZES}
-            quality={REGULAR_IMAGE_QUALITY}
-            onOpen={() => setLightboxIndex(1)}
-          />
+          {slots.map((slot) => renderSlot(slot))}
         </div>
         {lightbox}
       </>
@@ -140,6 +178,31 @@ export function ActivityImageGallery({
   }
 
   if (count === 3) {
+    const mainSlot: GallerySlotConfig = {
+      index: 0,
+      alt: title,
+      className: 'row-span-2 h-full min-h-0',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: LCP_IMAGE_QUALITY,
+      priority: true,
+    };
+    const rightSlots: GallerySlotConfig[] = [
+      {
+        index: 1,
+        alt: `${title} 추가 이미지 1`,
+        className: 'min-h-0 flex-1',
+        sizes: DESKTOP_GRID_IMAGE_SIZES,
+        quality: REGULAR_IMAGE_QUALITY,
+      },
+      {
+        index: 2,
+        alt: `${title} 추가 이미지 2`,
+        className: 'min-h-0 flex-1',
+        sizes: DESKTOP_GRID_IMAGE_SIZES,
+        quality: REGULAR_IMAGE_QUALITY,
+      },
+    ];
+
     return (
       <>
         <div
@@ -149,32 +212,9 @@ export function ActivityImageGallery({
             className
           )}
         >
-          <GalleryImageSlot
-            src={imageUrls[0]}
-            alt={title}
-            className="row-span-2 h-full min-h-0"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={LCP_IMAGE_QUALITY}
-            priority
-            onOpen={() => setLightboxIndex(0)}
-          />
+          {renderSlot(mainSlot)}
           <div className="row-span-2 flex h-full min-h-0 flex-col gap-2">
-            <GalleryImageSlot
-              src={imageUrls[1]}
-              alt={`${title} 추가 이미지 1`}
-              className="min-h-0 flex-1"
-              sizes={DESKTOP_GRID_IMAGE_SIZES}
-              quality={REGULAR_IMAGE_QUALITY}
-              onOpen={() => setLightboxIndex(1)}
-            />
-            <GalleryImageSlot
-              src={imageUrls[2]}
-              alt={`${title} 추가 이미지 2`}
-              className="min-h-0 flex-1"
-              sizes={DESKTOP_GRID_IMAGE_SIZES}
-              quality={REGULAR_IMAGE_QUALITY}
-              onOpen={() => setLightboxIndex(2)}
-            />
+            {rightSlots.map((slot) => renderSlot(slot))}
           </div>
         </div>
         {lightbox}
@@ -183,6 +223,15 @@ export function ActivityImageGallery({
   }
 
   if (count === 4) {
+    const slots: GallerySlotConfig[] = imageUrls.map((_, index) => ({
+      index,
+      alt: `${title} 이미지 ${index + 1}`,
+      className: 'min-h-0',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: index === 0 ? LCP_IMAGE_QUALITY : REGULAR_IMAGE_QUALITY,
+      priority: index === 0,
+    }));
+
     return (
       <>
         <div
@@ -192,18 +241,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          {imageUrls.map((url, index) => (
-            <GalleryImageSlot
-              key={`${url}-${index}`}
-              src={url}
-              alt={`${title} 이미지 ${index + 1}`}
-              className="min-h-0"
-              sizes={DESKTOP_GRID_IMAGE_SIZES}
-              quality={index === 0 ? LCP_IMAGE_QUALITY : REGULAR_IMAGE_QUALITY}
-              priority={index === 0}
-              onOpen={() => setLightboxIndex(index)}
-            />
-          ))}
+          {slots.map((slot) => renderSlot(slot))}
         </div>
         {lightbox}
       </>
@@ -211,6 +249,46 @@ export function ActivityImageGallery({
   }
 
   const five = imageUrls.slice(0, 5);
+  const leftSlots: GallerySlotConfig[] = [
+    {
+      index: 0,
+      alt: `${title} 이미지 1`,
+      className: 'min-h-0 flex-1',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: LCP_IMAGE_QUALITY,
+      priority: true,
+    },
+    {
+      index: 1,
+      alt: `${title} 이미지 2`,
+      className: 'min-h-0 flex-1',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: REGULAR_IMAGE_QUALITY,
+    },
+  ];
+  const rightSlots: GallerySlotConfig[] = [
+    {
+      index: 2,
+      alt: `${title} 이미지 3`,
+      className: 'min-h-0 flex-1',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: REGULAR_IMAGE_QUALITY,
+    },
+    {
+      index: 3,
+      alt: `${title} 이미지 4`,
+      className: 'min-h-0 flex-1',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: REGULAR_IMAGE_QUALITY,
+    },
+    {
+      index: 4,
+      alt: `${title} 이미지 5`,
+      className: 'min-h-0 flex-1',
+      sizes: DESKTOP_GRID_IMAGE_SIZES,
+      quality: REGULAR_IMAGE_QUALITY,
+    },
+  ];
 
   return (
     <>
@@ -222,49 +300,14 @@ export function ActivityImageGallery({
         )}
       >
         <div className="flex min-h-0 w-1/2 min-w-0 flex-1 flex-col gap-2">
-          <GalleryImageSlot
-            src={five[0]}
-            alt={`${title} 이미지 1`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={LCP_IMAGE_QUALITY}
-            priority
-            onOpen={() => setLightboxIndex(0)}
-          />
-          <GalleryImageSlot
-            src={five[1]}
-            alt={`${title} 이미지 2`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={REGULAR_IMAGE_QUALITY}
-            onOpen={() => setLightboxIndex(1)}
-          />
+          {leftSlots.map((slot) =>
+            five[slot.index] ? renderSlot(slot) : null
+          )}
         </div>
         <div className="flex min-h-0 w-1/2 min-w-0 flex-1 flex-col gap-2">
-          <GalleryImageSlot
-            src={five[2]}
-            alt={`${title} 이미지 3`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={REGULAR_IMAGE_QUALITY}
-            onOpen={() => setLightboxIndex(2)}
-          />
-          <GalleryImageSlot
-            src={five[3]}
-            alt={`${title} 이미지 4`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={REGULAR_IMAGE_QUALITY}
-            onOpen={() => setLightboxIndex(3)}
-          />
-          <GalleryImageSlot
-            src={five[4]}
-            alt={`${title} 이미지 5`}
-            className="min-h-0 flex-1"
-            sizes={DESKTOP_GRID_IMAGE_SIZES}
-            quality={REGULAR_IMAGE_QUALITY}
-            onOpen={() => setLightboxIndex(4)}
-          />
+          {rightSlots.map((slot) =>
+            five[slot.index] ? renderSlot(slot) : null
+          )}
         </div>
       </div>
       {lightbox}

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -135,7 +135,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          {slots.map((slot) => renderSlot(slot))}
+          {slots.map(renderSlot)}
         </div>
         {lightbox}
       </>
@@ -170,7 +170,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          {slots.map((slot) => renderSlot(slot))}
+          {slots.map(renderSlot)}
         </div>
         {lightbox}
       </>
@@ -214,7 +214,7 @@ export function ActivityImageGallery({
         >
           {renderSlot(mainSlot)}
           <div className="row-span-2 flex h-full min-h-0 flex-col gap-2">
-            {rightSlots.map((slot) => renderSlot(slot))}
+            {rightSlots.map(renderSlot)}
           </div>
         </div>
         {lightbox}
@@ -241,7 +241,7 @@ export function ActivityImageGallery({
             className
           )}
         >
-          {slots.map((slot) => renderSlot(slot))}
+          {slots.map(renderSlot)}
         </div>
         {lightbox}
       </>


### PR DESCRIPTION
## 🔗 관련 이슈

- close #328  

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용
- 이미지 개수별 분기에서 동일한 슬롯 렌더 코드가 반복되어 유지보수 비용이 큰 구조임을 확인
- 슬롯 규칙과 렌더링 구현을 분리해 가독성과 수정 용이성을 높이는 것을 목표

- 이미지 개수별(`count`) 분기 내부에서 반복되던 `GalleryImageSlot` JSX를 슬롯 설정 기반(`GallerySlotConfig`)으로 정리
- `renderSlot` 헬퍼 도입으로 렌더링 로직 공통화, 각 레이아웃은 슬롯 데이터만 선언하도록 변경
 
- `src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx`
  - `GallerySlotConfig` 타입 추가
  - `renderSlot` 공통 렌더 함수 추가
  - `count === 1/2/3/4/5+` 분기의 슬롯 렌더링을 배열 + `map` 방식으로 치환 