### PR TITLE
[Refactor/#340] 예약 승인 API 분기 제거 및 시간대 검증 추가

### DIFF
--- a/src/app/(main)/my/activities-dashboard/apis/reservations.test.ts
+++ b/src/app/(main)/my/activities-dashboard/apis/reservations.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  confirmReservationAndDeclinePending,
+  MissingReservationScheduleError,
+} from '@/app/(main)/my/activities-dashboard/apis/reservations';
+import { ApiError } from '@/shared/apis/apiError';
+import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
+
+vi.mock('@/shared/apis/fetchInstance.client', () => ({
+  fetchInstanceClient: vi.fn(),
+}));
+
+const fetchInstanceClientMock = vi.mocked(fetchInstanceClient);
+
+const pendingReservation = (id: number) => ({
+  id,
+  nickname: `사용자${id}`,
+  headCount: 1,
+  scheduleId: 30,
+  status: 'pending',
+  createdAt: '2026-07-28T00:00:00.000Z',
+});
+
+describe('confirmReservationAndDeclinePending', () => {
+  beforeEach(() => {
+    fetchInstanceClientMock.mockReset();
+  });
+
+  it('공식 상태 변경 API로 승인한 뒤 같은 스케줄의 대기 예약을 거절한다', async () => {
+    fetchInstanceClientMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        cursorId: null,
+        totalCount: 2,
+        reservations: [pendingReservation(12), pendingReservation(13)],
+      })
+      .mockResolvedValue(undefined);
+
+    await confirmReservationAndDeclinePending({
+      activityId: 10,
+      reservationId: 11,
+      scheduleId: 30,
+    });
+
+    expect(fetchInstanceClientMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/proxy/my-activities/10/reservations/11',
+      {
+        method: 'PATCH',
+        body: { status: 'confirmed' },
+      }
+    );
+    expect(fetchInstanceClientMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/proxy/my-activities/10/reservations',
+      {
+        params: {
+          scheduleId: 30,
+          status: 'pending',
+          size: 50,
+        },
+      }
+    );
+    expect(fetchInstanceClientMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/proxy/my-activities/10/reservations/12',
+      {
+        method: 'PATCH',
+        body: { status: 'declined' },
+      }
+    );
+    expect(fetchInstanceClientMock).toHaveBeenNthCalledWith(
+      4,
+      '/api/proxy/my-activities/10/reservations/13',
+      {
+        method: 'PATCH',
+        body: { status: 'declined' },
+      }
+    );
+    expect(
+      fetchInstanceClientMock.mock.calls.some(([url]) =>
+        String(url).endsWith('/approve')
+      )
+    ).toBe(false);
+  });
+
+  it('승인 요청이 404로 실패하면 기능 미지원으로 간주해 다른 요청으로 우회하지 않는다', async () => {
+    const error = new ApiError('예약을 찾을 수 없습니다.', 404);
+    fetchInstanceClientMock.mockRejectedValueOnce(error);
+
+    await expect(
+      confirmReservationAndDeclinePending({
+        activityId: 10,
+        reservationId: 11,
+        scheduleId: 30,
+      })
+    ).rejects.toBe(error);
+
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(1);
+    expect(fetchInstanceClientMock).toHaveBeenCalledWith(
+      '/api/proxy/my-activities/10/reservations/11',
+      {
+        method: 'PATCH',
+        body: { status: 'confirmed' },
+      }
+    );
+  });
+
+  it('예약 시간 정보가 없으면 승인 요청을 보내지 않는다', async () => {
+    await expect(
+      confirmReservationAndDeclinePending({
+        activityId: 10,
+        reservationId: 11,
+        scheduleId: null,
+      })
+    ).rejects.toBeInstanceOf(MissingReservationScheduleError);
+
+    expect(fetchInstanceClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(main)/my/activities-dashboard/apis/reservations.ts
+++ b/src/app/(main)/my/activities-dashboard/apis/reservations.ts
@@ -1,4 +1,3 @@
-import { ApiError } from '@/shared/apis/apiError';
 import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
 
 const RESERVATION_PAGE_SIZE = 10;
@@ -36,16 +35,23 @@ interface UpdateActivityReservationStatusProps {
   status: 'confirmed' | 'declined';
 }
 
-interface ApproveReservationWithAutoDeclineProps {
+interface ConfirmReservationAndDeclinePendingProps {
   activityId: number;
   reservationId: number;
-  scheduleId: number;
+  scheduleId: number | null;
 }
 
 interface ActivityReservationsResponseLike {
   cursorId?: unknown;
   totalCount?: unknown;
   reservations?: unknown;
+}
+
+export class MissingReservationScheduleError extends Error {
+  constructor() {
+    super('예약 시간 정보를 확인할 수 없습니다.');
+    this.name = 'MissingReservationScheduleError';
+  }
 }
 
 /**
@@ -248,30 +254,33 @@ export const declinePendingReservationIds = async (
 };
 
 /**
- * 승인 시 동시간대 대기 예약 자동 거절을 백엔드 단일 트랜잭션으로 시도
- * - 미지원(404/405/501)인 경우 false를 반환하고, 호출부에서 클라이언트 폴백 수행
+ * 예약 승인 후 같은 스케줄의 나머지 대기 예약을 조회해 거절
+ *
+ * 백엔드가 제공하는 예약 상태 변경 API만 사용하며
+ * 존재 여부가 불명확한 별도 승인 API로 우회하지 않는다.
  */
-export const approveReservationWithAutoDecline = async ({
+export const confirmReservationAndDeclinePending = async ({
   activityId,
   reservationId,
   scheduleId,
-}: ApproveReservationWithAutoDeclineProps): Promise<boolean> => {
-  try {
-    await fetchInstanceClient(
-      `/api/proxy/my-activities/${activityId}/reservations/${reservationId}/approve`,
-      {
-        method: 'PATCH',
-        body: { scheduleId },
-      }
-    );
-    return true;
-  } catch (error) {
-    if (error instanceof ApiError) {
-      const unsupportedStatuses = [404, 405, 501];
-      if (unsupportedStatuses.includes(error.status)) {
-        return false;
-      }
-    }
-    throw error;
+}: ConfirmReservationAndDeclinePendingProps): Promise<void> => {
+  if (scheduleId === null) {
+    throw new MissingReservationScheduleError();
+  }
+
+  await updateActivityReservationStatus({
+    activityId,
+    reservationId,
+    status: 'confirmed',
+  });
+
+  const autoDeclineTargets = await collectPendingReservationIdsForSchedule({
+    activityId,
+    scheduleId,
+    excludeReservationId: reservationId,
+  });
+
+  if (autoDeclineTargets.length > 0) {
+    await declinePendingReservationIds(activityId, autoDeclineTargets);
   }
 };

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
@@ -1,9 +1,8 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  approveReservationWithAutoDecline,
-  collectPendingReservationIdsForSchedule,
-  declinePendingReservationIds,
+  confirmReservationAndDeclinePending,
+  MissingReservationScheduleError,
   updateActivityReservationStatus,
 } from '@/app/(main)/my/activities-dashboard/apis/reservations';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
@@ -54,39 +53,11 @@ export const useReservationStatusUpdate = ({
           return;
         }
 
-        if (scheduleId === null) {
-          await updateActivityReservationStatus({
-            activityId,
-            reservationId,
-            status,
-          });
-          return;
-        }
-
-        const backendHandled = await approveReservationWithAutoDecline({
+        await confirmReservationAndDeclinePending({
           activityId,
           reservationId,
           scheduleId,
         });
-
-        if (backendHandled) return;
-
-        await updateActivityReservationStatus({
-          activityId,
-          reservationId,
-          status,
-        });
-
-        const autoDeclineTargets =
-          await collectPendingReservationIdsForSchedule({
-            activityId,
-            scheduleId,
-            excludeReservationId: reservationId,
-          });
-
-        if (autoDeclineTargets.length > 0) {
-          await declinePendingReservationIds(activityId, autoDeclineTargets);
-        }
       },
       onSuccess: async (_, variables) => {
         showToast({
@@ -113,14 +84,17 @@ export const useReservationStatusUpdate = ({
           }),
         ]);
       },
-      onError: () => {
+      onError: (error) => {
+        const errorMessage =
+          error instanceof MissingReservationScheduleError
+            ? '예약 시간 정보를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.'
+            : '예약 상태 변경에 실패했습니다. 잠시 후 다시 시도해주세요.';
+
         showToast({
           theme: 'error',
-          message: '예약 상태 변경에 실패했습니다. 잠시 후 다시 시도해주세요.',
+          message: errorMessage,
         });
-        setFeedbackModalMessage(
-          '예약 상태 변경에 실패했습니다.\n잠시 후 다시 시도해주세요.'
-        );
+        setFeedbackModalMessage(errorMessage);
       },
     });
 

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
@@ -16,6 +16,9 @@ type ReservationStatusUpdateAction = {
   scheduleId: number | null;
 } | null;
 
+const MISSING_RESERVATION_SCHEDULE_MESSAGE =
+  '예약 시간 정보를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.';
+
 interface UseReservationStatusUpdateParams {
   activityId: number;
   selectedScheduleId: number | null;
@@ -87,7 +90,7 @@ export const useReservationStatusUpdate = ({
       onError: (error) => {
         const errorMessage =
           error instanceof MissingReservationScheduleError
-            ? '예약 시간 정보를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.'
+            ? MISSING_RESERVATION_SCHEDULE_MESSAGE
             : '예약 상태 변경에 실패했습니다. 잠시 후 다시 시도해주세요.';
 
         showToast({
@@ -107,6 +110,15 @@ export const useReservationStatusUpdate = ({
   }, [pendingStatusUpdateAction]);
 
   const handleApproveReservation = (reservationId: number) => {
+    if (selectedScheduleId === null) {
+      showToast({
+        theme: 'error',
+        message: MISSING_RESERVATION_SCHEDULE_MESSAGE,
+      });
+      setFeedbackModalMessage(MISSING_RESERVATION_SCHEDULE_MESSAGE);
+      return;
+    }
+
     setPendingStatusUpdateAction({
       reservationId,
       status: 'confirmed',


### PR DESCRIPTION
## 🔗 관련 이슈

- close #340 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

기존 예약 승인 흐름에서는 존재 여부가 불명확한 `/approve` API를 먼저 호출하고
404/405/501 응답을 기능 미지원으로 판단해 기존 승인 방식으로 우회하고 있던 상황 확인

404는 예약을 찾을 수 없는 경우에도 발생할 수 있어 실제 오류를 기능 미지원으로 잘못 판단할 가능성 확인

이를 개선하기 위해 해당 작업 진행

- `/approve` 선행 요청 제거
- 404·405·501 응답을 기능 미지원으로 판단하던 분기 제거
- 공식 예약 상태 변경 API로 바로 승인하도록 수정
- 승인 후 같은 시간대의 대기 예약을 조회하고 거절하는 흐름을 하나의 함수로 정리
- 예약 시간 정보가 없으면 승인 요청을 보내지 않도록 처리
- 시간 정보 누락을 별도 오류로 구분해 사용자에게 원인을 알리도록 처리
- 아래 경우를 검증하는 테스트 추가
  - 공식 예약 상태 변경 API로 승인하는 경우
  - `/approve` API를 호출하지 않는 경우
  - 승인 요청이 404로 실패해도 다른 방식으로 우회하지 않는 경우
  - 예약 시간 정보가 없을 때 네트워크 요청을 보내지 않는 경우