### PR TITLE
[Fix/#339] 예약 자동 거절 부분 실패 처리 및 캐시 재동기화

### DIFF
--- a/src/app/(main)/my/activities-dashboard/apis/reservations.test.ts
+++ b/src/app/(main)/my/activities-dashboard/apis/reservations.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   confirmReservationAndDeclinePending,
+  declinePendingReservationIds,
   MissingReservationScheduleError,
 } from '@/app/(main)/my/activities-dashboard/apis/reservations';
 import { ApiError } from '@/shared/apis/apiError';
@@ -36,7 +37,7 @@ describe('confirmReservationAndDeclinePending', () => {
       })
       .mockResolvedValue(undefined);
 
-    await confirmReservationAndDeclinePending({
+    const result = await confirmReservationAndDeclinePending({
       activityId: 10,
       reservationId: 11,
       scheduleId: 30,
@@ -82,6 +83,14 @@ describe('confirmReservationAndDeclinePending', () => {
         String(url).endsWith('/approve')
       )
     ).toBe(false);
+    expect(result).toEqual({
+      confirmedReservationId: 11,
+      autoDecline: {
+        succeededIds: [12, 13],
+        failed: [],
+      },
+      pendingCollectionError: null,
+    });
   });
 
   it('승인 요청이 404로 실패하면 기능 미지원으로 간주해 다른 요청으로 우회하지 않는다', async () => {
@@ -116,5 +125,135 @@ describe('confirmReservationAndDeclinePending', () => {
     ).rejects.toBeInstanceOf(MissingReservationScheduleError);
 
     expect(fetchInstanceClientMock).not.toHaveBeenCalled();
+  });
+
+  it('승인 후 대기 예약 조회가 실패하면 승인 성공과 조회 실패를 함께 반환한다', async () => {
+    const error = new ApiError('대기 예약을 불러오지 못했습니다.', 500);
+    fetchInstanceClientMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    const result = await confirmReservationAndDeclinePending({
+      activityId: 10,
+      reservationId: 11,
+      scheduleId: 30,
+    });
+
+    expect(result).toEqual({
+      confirmedReservationId: 11,
+      autoDecline: {
+        succeededIds: [],
+        failed: [],
+      },
+      pendingCollectionError: error,
+    });
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('declinePendingReservationIds', () => {
+  beforeEach(() => {
+    fetchInstanceClientMock.mockReset();
+  });
+
+  it('12건을 동시에 최대 5건까지만 처리한다', async () => {
+    let activeRequestCount = 0;
+    let maxActiveRequestCount = 0;
+
+    fetchInstanceClientMock.mockImplementation(async () => {
+      activeRequestCount += 1;
+      maxActiveRequestCount = Math.max(
+        maxActiveRequestCount,
+        activeRequestCount
+      );
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+
+      activeRequestCount -= 1;
+      return undefined;
+    });
+
+    const reservationIds = Array.from({ length: 12 }, (_, index) => index + 1);
+    const result = await declinePendingReservationIds(10, reservationIds, {
+      maxRetries: 0,
+      retryDelayMs: 0,
+    });
+
+    expect(maxActiveRequestCount).toBe(5);
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(12);
+    expect(result).toEqual({
+      succeededIds: reservationIds,
+      failed: [],
+    });
+  });
+
+  it('실패한 예약만 다시 시도한다', async () => {
+    const attemptsByReservationId = new Map<number, number>();
+
+    fetchInstanceClientMock.mockImplementation(async (url) => {
+      const reservationId = Number(String(url).split('/').at(-1));
+      const attempts = (attemptsByReservationId.get(reservationId) ?? 0) + 1;
+      attemptsByReservationId.set(reservationId, attempts);
+
+      if ((reservationId === 3 || reservationId === 7) && attempts === 1) {
+        throw new Error(`${reservationId}번 거절 실패`);
+      }
+
+      return undefined;
+    });
+
+    const reservationIds = Array.from({ length: 12 }, (_, index) => index + 1);
+    const result = await declinePendingReservationIds(10, reservationIds, {
+      maxRetries: 1,
+      retryDelayMs: 0,
+    });
+
+    expect(result).toEqual({
+      succeededIds: reservationIds,
+      failed: [],
+    });
+    expect(attemptsByReservationId.get(3)).toBe(2);
+    expect(attemptsByReservationId.get(7)).toBe(2);
+    expect(attemptsByReservationId.get(1)).toBe(1);
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(14);
+  });
+
+  it('재시도 후에도 실패한 예약 번호와 원인을 반환한다', async () => {
+    const error = new Error('3번 거절 실패');
+
+    fetchInstanceClientMock.mockImplementation(async (url) => {
+      const reservationId = Number(String(url).split('/').at(-1));
+      if (reservationId === 3) throw error;
+      return undefined;
+    });
+
+    const result = await declinePendingReservationIds(10, [1, 2, 3, 4, 5], {
+      maxRetries: 2,
+      retryDelayMs: 0,
+    });
+
+    expect(result).toEqual({
+      succeededIds: [1, 2, 4, 5],
+      failed: [{ reservationId: 3, reason: error }],
+    });
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(7);
+  });
+
+  it('요청을 다시 보내도 해결되지 않는 오류는 재시도하지 않는다', async () => {
+    const error = new ApiError('이미 처리된 예약입니다.', 400);
+    fetchInstanceClientMock.mockRejectedValue(error);
+
+    const result = await declinePendingReservationIds(10, [3], {
+      maxRetries: 2,
+      retryDelayMs: 0,
+    });
+
+    expect(result).toEqual({
+      succeededIds: [],
+      failed: [{ reservationId: 3, reason: error }],
+    });
+    expect(fetchInstanceClientMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/(main)/my/activities-dashboard/apis/reservations.ts
+++ b/src/app/(main)/my/activities-dashboard/apis/reservations.ts
@@ -1,8 +1,13 @@
+import { ApiError } from '@/shared/apis/apiError';
 import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
 
 const RESERVATION_PAGE_SIZE = 10;
 /** 대기 예약 일괄 거절 시 동시 PATCH 상한(동시 연결·서버 부하 완화) */
 const DECLINE_PENDING_RESERVATIONS_CONCURRENCY = 5;
+/** 대기 예약 거절 실패 시 추가 시도 횟수 */
+const DECLINE_PENDING_RESERVATIONS_MAX_RETRIES = 2;
+/** 거절 재시도 전 기본 대기 시간(ms) */
+const DECLINE_PENDING_RESERVATIONS_RETRY_DELAY_MS = 300;
 type ReservationRequestStatus = 'pending' | 'confirmed' | 'declined';
 
 interface ReservationRequestItem {
@@ -41,6 +46,11 @@ interface ConfirmReservationAndDeclinePendingProps {
   scheduleId: number | null;
 }
 
+interface DeclinePendingReservationIdsOptions {
+  maxRetries?: number;
+  retryDelayMs?: number;
+}
+
 interface ActivityReservationsResponseLike {
   cursorId?: unknown;
   totalCount?: unknown;
@@ -52,6 +62,22 @@ export class MissingReservationScheduleError extends Error {
     super('예약 시간 정보를 확인할 수 없습니다.');
     this.name = 'MissingReservationScheduleError';
   }
+}
+
+export interface DeclinePendingReservationFailure {
+  reservationId: number;
+  reason: unknown;
+}
+
+export interface DeclinePendingReservationIdsResult {
+  succeededIds: number[];
+  failed: DeclinePendingReservationFailure[];
+}
+
+export interface ConfirmReservationAndDeclinePendingResult {
+  confirmedReservationId: number;
+  autoDecline: DeclinePendingReservationIdsResult;
+  pendingCollectionError: unknown | null;
 }
 
 /**
@@ -209,61 +235,112 @@ export const collectPendingReservationIdsForSchedule = async ({
 
 /**
  * 대기 예약 id 목록 일괄 거절
- * 한 스케줄에 대기 건이 매우 많을 수 있어 전부 병렬로 보내지 않고 청크 단위로 나눈다.
- * 청크 내 한 건이 실패해도 나머지는 계속 처리한다(`Promise.allSettled`).
+ * 한 스케줄에 대기 건이 매우 많을 수 있어 전부 병렬로 보내지 않고 5건씩 나눈다.
+ * 각 요청의 결과를 수집하고 실패한 예약만 대기 시간을 둔 뒤 다시 시도한다.
  */
-export const declinePendingReservationIds = async (
-  activityId: number,
-  reservationIds: number[]
-): Promise<void> => {
-  if (reservationIds.length === 0) return;
+const isRetryableDeclineError = (error: unknown) => {
+  if (!(error instanceof ApiError)) return true;
 
-  const rejectionReasons: unknown[] = [];
-
-  for (
-    let offset = 0;
-    offset < reservationIds.length;
-    offset += DECLINE_PENDING_RESERVATIONS_CONCURRENCY
-  ) {
-    const chunk = reservationIds.slice(
-      offset,
-      offset + DECLINE_PENDING_RESERVATIONS_CONCURRENCY
-    );
-    const results = await Promise.allSettled(
-      chunk.map((reservationId) =>
-        updateActivityReservationStatus({
-          activityId,
-          reservationId,
-          status: 'declined',
-        })
-      )
-    );
-
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        rejectionReasons.push(result.reason);
-      }
-    }
-  }
-
-  if (rejectionReasons.length > 0) {
-    const first = rejectionReasons[0];
-    if (first instanceof Error) throw first;
-    throw new Error(String(first ?? '일부 예약 거절에 실패했습니다.'));
-  }
+  return (
+    error.status === 408 ||
+    error.status === 425 ||
+    error.status === 429 ||
+    error.status >= 500
+  );
 };
 
+export const declinePendingReservationIds = async (
+  activityId: number,
+  reservationIds: number[],
+  {
+    maxRetries = DECLINE_PENDING_RESERVATIONS_MAX_RETRIES,
+    retryDelayMs = DECLINE_PENDING_RESERVATIONS_RETRY_DELAY_MS,
+  }: DeclinePendingReservationIdsOptions = {}
+): Promise<DeclinePendingReservationIdsResult> => {
+  const uniqueReservationIds = Array.from(new Set(reservationIds));
+  const succeededIds = new Set<number>();
+  const finalFailures: DeclinePendingReservationFailure[] = [];
+  let retryTargets = uniqueReservationIds;
+  const normalizedMaxRetries = Math.max(0, Math.floor(maxRetries));
+  const normalizedRetryDelayMs = Math.max(0, retryDelayMs);
+
+  for (
+    let attempt = 0;
+    attempt <= normalizedMaxRetries && retryTargets.length > 0;
+    attempt += 1
+  ) {
+    if (attempt > 0 && normalizedRetryDelayMs > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, normalizedRetryDelayMs * 2 ** (attempt - 1));
+      });
+    }
+
+    const nextRetryTargets: number[] = [];
+
+    for (
+      let offset = 0;
+      offset < retryTargets.length;
+      offset += DECLINE_PENDING_RESERVATIONS_CONCURRENCY
+    ) {
+      const requestGroup = retryTargets.slice(
+        offset,
+        offset + DECLINE_PENDING_RESERVATIONS_CONCURRENCY
+      );
+      const results = await Promise.allSettled(
+        requestGroup.map((reservationId) =>
+          updateActivityReservationStatus({
+            activityId,
+            reservationId,
+            status: 'declined',
+          })
+        )
+      );
+
+      results.forEach((result, index) => {
+        const reservationId = requestGroup[index];
+        if (reservationId === undefined) return;
+
+        if (result.status === 'fulfilled') {
+          succeededIds.add(reservationId);
+          return;
+        }
+
+        const failure = { reservationId, reason: result.reason };
+        const canRetry =
+          attempt < normalizedMaxRetries &&
+          isRetryableDeclineError(result.reason);
+
+        if (canRetry) {
+          nextRetryTargets.push(reservationId);
+        } else {
+          finalFailures.push(failure);
+        }
+      });
+    }
+
+    retryTargets = nextRetryTargets;
+  }
+
+  return {
+    succeededIds: uniqueReservationIds.filter((id) => succeededIds.has(id)),
+    failed: finalFailures,
+  };
+};
+
+const emptyDeclineResult = (): DeclinePendingReservationIdsResult => ({
+  succeededIds: [],
+  failed: [],
+});
+
 /**
- * 예약 승인 후 같은 스케줄의 나머지 대기 예약을 조회해 거절
- *
- * 백엔드가 제공하는 예약 상태 변경 API만 사용하며
- * 존재 여부가 불명확한 별도 승인 API로 우회하지 않는다.
+ * 예약 승인 후 같은 스케줄의 나머지 대기 예약을 조회해 거절한다.
+ * 승인이 완료된 뒤의 조회·거절 실패는 결과에 담아 호출부가 부분 성공으로 처리한다.
  */
 export const confirmReservationAndDeclinePending = async ({
   activityId,
   reservationId,
   scheduleId,
-}: ConfirmReservationAndDeclinePendingProps): Promise<void> => {
+}: ConfirmReservationAndDeclinePendingProps): Promise<ConfirmReservationAndDeclinePendingResult> => {
   if (scheduleId === null) {
     throw new MissingReservationScheduleError();
   }
@@ -274,13 +351,30 @@ export const confirmReservationAndDeclinePending = async ({
     status: 'confirmed',
   });
 
-  const autoDeclineTargets = await collectPendingReservationIdsForSchedule({
-    activityId,
-    scheduleId,
-    excludeReservationId: reservationId,
-  });
+  let autoDeclineTargets: number[];
 
-  if (autoDeclineTargets.length > 0) {
-    await declinePendingReservationIds(activityId, autoDeclineTargets);
+  try {
+    autoDeclineTargets = await collectPendingReservationIdsForSchedule({
+      activityId,
+      scheduleId,
+      excludeReservationId: reservationId,
+    });
+  } catch (error) {
+    return {
+      confirmedReservationId: reservationId,
+      autoDecline: emptyDeclineResult(),
+      pendingCollectionError: error,
+    };
   }
+
+  const autoDecline = await declinePendingReservationIds(
+    activityId,
+    autoDeclineTargets
+  );
+
+  return {
+    confirmedReservationId: reservationId,
+    autoDecline,
+    pendingCollectionError: null,
+  };
 };

--- a/src/app/(main)/my/activities-dashboard/apis/reservations.ts
+++ b/src/app/(main)/my/activities-dashboard/apis/reservations.ts
@@ -8,6 +8,7 @@ const DECLINE_PENDING_RESERVATIONS_CONCURRENCY = 5;
 const DECLINE_PENDING_RESERVATIONS_MAX_RETRIES = 2;
 /** 거절 재시도 전 기본 대기 시간(ms) */
 const DECLINE_PENDING_RESERVATIONS_RETRY_DELAY_MS = 300;
+
 type ReservationRequestStatus = 'pending' | 'confirmed' | 'declined';
 
 interface ReservationRequestItem {

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   confirmReservationAndDeclinePending,
+  type ConfirmReservationAndDeclinePendingResult,
   MissingReservationScheduleError,
   updateActivityReservationStatus,
 } from '@/app/(main)/my/activities-dashboard/apis/reservations';
@@ -18,6 +19,11 @@ type ReservationStatusUpdateAction = {
 
 const MISSING_RESERVATION_SCHEDULE_MESSAGE =
   '예약 시간 정보를 확인할 수 없습니다. 새로고침 후 다시 시도해주세요.';
+const AUTO_DECLINE_LOOKUP_FAILED_MESSAGE =
+  '예약 승인은 완료됐지만 같은 시간대의 대기 예약을 확인하지 못했습니다. 최신 상태를 확인한 뒤 다시 시도해주세요.';
+
+const getAutoDeclineFailedMessage = (failedCount: number) =>
+  `예약 승인은 완료됐지만 같은 시간대 예약 ${failedCount}건을 자동으로 거절하지 못했습니다. 최신 상태를 확인해주세요.`;
 
 interface UseReservationStatusUpdateParams {
   activityId: number;
@@ -53,25 +59,53 @@ export const useReservationStatusUpdate = ({
             reservationId,
             status,
           });
-          return;
+          return null;
         }
 
-        await confirmReservationAndDeclinePending({
+        return confirmReservationAndDeclinePending({
           activityId,
           reservationId,
           scheduleId,
         });
       },
-      onSuccess: async (_, variables) => {
+      onSuccess: (
+        result: ConfirmReservationAndDeclinePendingResult | null,
+        variables
+      ) => {
+        setPendingStatusUpdateAction(null);
+
+        if (variables.status !== 'confirmed' || result === null) {
+          showToast({
+            theme: 'success',
+            message: '해당 예약신청을 거절했습니다.',
+          });
+          setFeedbackModalMessage(null);
+          return;
+        }
+
+        const partialFailureMessage =
+          result.pendingCollectionError !== null
+            ? AUTO_DECLINE_LOOKUP_FAILED_MESSAGE
+            : result.autoDecline.failed.length > 0
+              ? getAutoDeclineFailedMessage(result.autoDecline.failed.length)
+              : null;
+
+        if (partialFailureMessage) {
+          showToast({
+            theme: 'warning',
+            message: partialFailureMessage,
+          });
+          setFeedbackModalMessage(partialFailureMessage);
+          return;
+        }
+
         showToast({
           theme: 'success',
-          message:
-            variables.status === 'confirmed'
-              ? '승인이 완료되었습니다.'
-              : '해당 예약신청을 거절했습니다.',
+          message: '승인이 완료되었습니다.',
         });
         setFeedbackModalMessage(null);
-
+      },
+      onSettled: async () => {
         await Promise.all([
           queryClient.invalidateQueries({
             queryKey: [...QUERY_KEYS.MY_ACTIVITY_RESERVATIONS, activityId],
@@ -98,6 +132,10 @@ export const useReservationStatusUpdate = ({
           message: errorMessage,
         });
         setFeedbackModalMessage(errorMessage);
+
+        if (error instanceof MissingReservationScheduleError) {
+          setPendingStatusUpdateAction(null);
+        }
       },
     });
 
@@ -147,8 +185,6 @@ export const useReservationStatusUpdate = ({
         status: pendingStatusUpdateAction.status,
         scheduleId: pendingStatusUpdateAction.scheduleId,
       });
-
-      setPendingStatusUpdateAction(null);
     } catch {
       // 실패 시 확인 모달을 유지해 사용자가 재시도/취소를 선택할 수 있게 한다.
     }

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -103,7 +103,7 @@ export const useAutoDeclineExpiredReservations = ({
           if (ids.length === 0) continue;
           if (isCancelled) break;
 
-          // `declinePendingReservationIds`는 일부만 거절돼도 실패분이 있으면 throw하므로 무효화 여부는 거절 시도 직전에 반영
+          // 일부 요청만 성공할 수 있으므로 거절 시도 직전에 무효화 여부를 반영
           hasDeclinedAny = true;
           await declinePendingReservationIds(activityId, ids);
         } catch {

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -105,7 +105,16 @@ export const useAutoDeclineExpiredReservations = ({
 
           // 일부 요청만 성공할 수 있으므로 거절 시도 직전에 무효화 여부를 반영
           hasDeclinedAny = true;
-          await declinePendingReservationIds(activityId, ids);
+          const { failed } = await declinePendingReservationIds(
+            activityId,
+            ids
+          );
+          if (failed.length > 0) {
+            console.error(
+              `[자동 거절] 스케줄 ${schedule.scheduleId}의 예약 ${failed.length}건 거절 실패:`,
+              failed
+            );
+          }
         } catch {
           // 다음 스케줄 처리 계속
         } finally {

--- a/src/app/(main)/my/reservations/components/reserve-container/index.tsx
+++ b/src/app/(main)/my/reservations/components/reserve-container/index.tsx
@@ -15,8 +15,11 @@ export async function ReserveContainer({
   searchParams,
 }: ReserveContainerProps) {
   const queryClient = new QueryClient();
+  const resolvedSearchParams = await searchParams;
   const status =
-    typeof searchParams?.status === 'string' ? searchParams.status : null;
+    typeof resolvedSearchParams.status === 'string'
+      ? resolvedSearchParams.status
+      : null;
 
   const params = new URLSearchParams({ size: String(MY_RESERVATIONS_SIZE) });
   if (status) {

--- a/src/app/(main)/my/reservations/components/reserve-container/reserveContainer.types.ts
+++ b/src/app/(main)/my/reservations/components/reserve-container/reserveContainer.types.ts
@@ -1,3 +1,5 @@
+import { MyReservationsSearchParams } from '@/app/(main)/my/reservations/reservations.types';
+
 export interface ReserveContainerProps {
-  searchParams?: { status?: string };
+  searchParams: Promise<MyReservationsSearchParams>;
 }

--- a/src/app/(main)/my/reservations/reservations.types.ts
+++ b/src/app/(main)/my/reservations/reservations.types.ts
@@ -1,3 +1,7 @@
+export type MyReservationsSearchParams = {
+  [key: string]: string | string[] | undefined;
+};
+
 export interface MyReservationsPageProps {
-  searchParams: { [key: string]: string | string[] | undefined };
+  searchParams: Promise<MyReservationsSearchParams>;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #339 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

### 예약 자동 거절 요청 안정성 개선

- 여러 예약을 자동 거절할 때 한 요청의 실패가 다른 요청 결과에 영향을 주지 않도록 변경
- 한 번에 처리하는 요청 수를 최대 5개로 제한
- 일시적인 네트워크 오류나 서버 오류가 발생한 요청만 최대 2회 다시 요청하도록 처리
- 잘못된 요청과 같이 다시 시도해도 해결되지 않는 오류는 실패로 분류
- 성공한 예약 ID와 실패한 예약 ID 및 원인을 구분해서 반환하도록 응답 구조 개선

### 예약 승인 후 일부 실패 처리

- 선택한 예약의 승인이 성공한 뒤 다른 예약의 자동 거절이 일부 실패하더라도 승인 결과까지 실패로 표시하지 않도록 변경
- 일부 예약을 처리하지 못한 경우 사용자에게 별도의 안내 메시지 표시
- 자동 거절 대상 조회에 실패한 경우에도 승인 성공 결과 유지

### 예약 데이터 재동기화

- 요청 성공 여부와 관계없이 예약 관련 데이터를 다시 불러오도록 변경
- 일부 요청만 성공한 경우에도 화면이 서버의 실제 상태와 일치하도록 보완

### 프로덕션 빌드 오류 수정

- Next.js 16의 페이지 타입 규칙에 맞게 `searchParams`를 비동기 값으로 처리
- 예약 목록 서버 컴포넌트에서 값을 기다리도록 해 기존 Suspense 로딩 UI 유지
