### PR TITLE
[Refactor/#343] 예약 가능 판단 로직을 순수 뷰모델 함수로 분리

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "permissions": {
-    "allow": ["Bash(echo \"EXIT:$?\")"]
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(echo \"EXIT:$?\")"]
+  }
+}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { fetchActivityAvailableSchedule } from '@/app/(main)/activity/[id]/apis/activityAvailableSchedule';
 import {
@@ -120,6 +120,20 @@ export const useActivityReservationAvailability = ({
       schedules,
     ]
   );
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+
+    if (!usesFallbackSchedule || availableScheduleQueryStatus === 'loading') {
+      return;
+    }
+
+    console.warn(
+      `[useActivityReservationAvailability] activityId=${activityId}: 예약 가능 시간 API 대신 원본 스케줄로 대체 표시 중 (status=${availableScheduleQueryStatus})`
+    );
+  }, [activityId, availableScheduleQueryStatus, usesFallbackSchedule]);
 
   return { availableScheduleByDate, usesFallbackSchedule };
 };

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -7,11 +7,11 @@ import {
   fetchMyReservedSchedules,
   type MyReservedScheduleItem,
 } from '@/app/(main)/activity/[id]/apis/myReservedSchedules';
-import type { TimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import {
-  normalizeDateKey,
-  parseTimeToHourMinute,
-} from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
+  type AvailableScheduleQueryStatus,
+  buildReservationAvailability,
+} from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability';
+import { normalizeDateKey } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
 import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 
@@ -28,42 +28,6 @@ interface UseActivityReservationAvailabilityProps {
 const parseYearMonthFromDateKey = (dateKey: string) => {
   const [year, month] = dateKey.split('-').map(Number);
   return { year, month };
-};
-
-const isUpcomingTimeSlot = (dateKey: string, startTime: string, now: Date) => {
-  const [yearText, monthText, dayText] = dateKey.split('-');
-  const year = Number(yearText);
-  const month = Number(monthText);
-  const day = Number(dayText);
-  const parsedTime = parseTimeToHourMinute(startTime);
-
-  if (!parsedTime) {
-    return true;
-  }
-
-  if (
-    !Number.isInteger(year) ||
-    !Number.isInteger(month) ||
-    !Number.isInteger(day)
-  ) {
-    return true;
-  }
-
-  const startDateTime = new Date(
-    year,
-    month - 1,
-    day,
-    parsedTime.hour,
-    parsedTime.minute,
-    0,
-    0
-  );
-
-  if (Number.isNaN(startDateTime.getTime())) {
-    return true;
-  }
-
-  return startDateTime.getTime() > now.getTime();
 };
 
 export const useActivityReservationAvailability = ({
@@ -110,12 +74,17 @@ export const useActivityReservationAvailability = ({
     () => availableScheduleQueries.flatMap((query) => query.data ?? []),
     [availableScheduleQueries]
   );
-  const isAvailableSchedulesLoading = availableScheduleQueries.some(
-    (query) => query.isLoading
-  );
-  const isAvailableSchedulesError = availableScheduleQueries.some(
-    (query) => query.isError
-  );
+
+  const availableScheduleQueryStatus =
+    useMemo<AvailableScheduleQueryStatus>(() => {
+      if (availableScheduleQueries.some((query) => query.isLoading)) {
+        return 'loading';
+      }
+      if (availableScheduleQueries.some((query) => query.isError)) {
+        return 'error';
+      }
+      return 'success';
+    }, [availableScheduleQueries]);
 
   const { data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES } = useQuery({
     queryKey: [...QUERY_KEYS.MY_RESERVATIONS, 'reservedSchedules'],
@@ -135,84 +104,22 @@ export const useActivityReservationAvailability = ({
     );
   }, [myReservedScheduleIds, reservedScheduleIds]);
 
-  const fallbackScheduleByDate = useMemo(() => {
-    const now = new Date();
+  const { availableScheduleByDate, usesFallbackSchedule } = useMemo(
+    () =>
+      buildReservationAvailability({
+        schedules,
+        availableSchedules,
+        availableScheduleQueryStatus,
+        blockedScheduleIds,
+        now: new Date(),
+      }),
+    [
+      availableScheduleQueryStatus,
+      availableSchedules,
+      blockedScheduleIds,
+      schedules,
+    ]
+  );
 
-    return schedules.reduce<Record<string, TimeSlot[]>>(
-      (accumulator, schedule) => {
-        if (blockedScheduleIds.includes(schedule.id)) {
-          return accumulator;
-        }
-
-        const dateKey = normalizeDateKey(schedule.date);
-        if (!isUpcomingTimeSlot(dateKey, schedule.startTime, now)) {
-          return accumulator;
-        }
-
-        const nextSlot: TimeSlot = {
-          id: schedule.id,
-          startTime: schedule.startTime,
-          endTime: schedule.endTime,
-        };
-
-        if (!accumulator[dateKey]) {
-          accumulator[dateKey] = [nextSlot];
-        } else {
-          accumulator[dateKey].push(nextSlot);
-        }
-
-        return accumulator;
-      },
-      {}
-    );
-  }, [blockedScheduleIds, schedules]);
-
-  const availableScheduleByDate = useMemo(() => {
-    const now = new Date();
-
-    const fromAvailableApi = availableSchedules.reduce<
-      Record<string, (typeof availableSchedules)[number]['times']>
-    >((accumulator, item) => {
-      const dateKey = normalizeDateKey(item.date);
-      const filteredTimes = item.times.filter(
-        (time) =>
-          !blockedScheduleIds.includes(time.id) &&
-          isUpcomingTimeSlot(dateKey, time.startTime, now)
-      );
-
-      if (filteredTimes.length > 0) {
-        accumulator[dateKey] = filteredTimes;
-      }
-
-      return accumulator;
-    }, {});
-
-    if (
-      isAvailableSchedulesLoading ||
-      isAvailableSchedulesError ||
-      Object.keys(fromAvailableApi).length === 0
-    ) {
-      return fallbackScheduleByDate;
-    }
-
-    return Object.entries(fromAvailableApi).reduce<Record<string, TimeSlot[]>>(
-      (accumulator, [dateKey, times]) => {
-        accumulator[dateKey] = times.map((time) => ({
-          id: time.id,
-          startTime: time.startTime,
-          endTime: time.endTime,
-        }));
-        return accumulator;
-      },
-      {}
-    );
-  }, [
-    availableSchedules,
-    blockedScheduleIds,
-    fallbackScheduleByDate,
-    isAvailableSchedulesError,
-    isAvailableSchedulesLoading,
-  ]);
-
-  return { availableScheduleByDate };
+  return { availableScheduleByDate, usesFallbackSchedule };
 };

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { buildReservationAvailability } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability';
+import type {
+  ActivityAvailableScheduleItem,
+  ActivitySchedule,
+} from '@/shared/types/activityDetail.types';
+
+const NOW = new Date('2026-07-15T00:00:00');
+
+const schedules: ActivitySchedule[] = [
+  { id: 1, date: '2026-07-01', startTime: '09:00', endTime: '10:00' },
+  { id: 2, date: '2026-07-20', startTime: '09:00', endTime: '10:00' },
+  { id: 3, date: '2026-07-21', startTime: '13:00', endTime: '14:00' },
+];
+
+describe('buildReservationAvailability', () => {
+  it('정상 응답이면 API 응답을 그대로 사용하고 usesFallbackSchedule은 false다', () => {
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+      },
+    ];
+
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(result.usesFallbackSchedule).toBe(false);
+    expect(result.availableScheduleByDate).toEqual({
+      '2026-07-20': [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+    });
+  });
+
+  it('빈 응답(정상이지만 결과 없음)이면 원본 스케줄로 대체하고 usesFallbackSchedule은 true다', () => {
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(result.usesFallbackSchedule).toBe(true);
+    expect(result.availableScheduleByDate).toEqual({
+      '2026-07-20': [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+      '2026-07-21': [{ id: 3, startTime: '13:00', endTime: '14:00' }],
+    });
+  });
+
+  it('로딩/오류 상태면 API 응답과 무관하게 원본 스케줄로 대체한다', () => {
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+      },
+    ];
+
+    const loadingResult = buildReservationAvailability({
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatus: 'loading',
+      blockedScheduleIds: [],
+      now: NOW,
+    });
+    const errorResult = buildReservationAvailability({
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatus: 'error',
+      blockedScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(loadingResult.usesFallbackSchedule).toBe(true);
+    expect(errorResult.usesFallbackSchedule).toBe(true);
+    expect(loadingResult.availableScheduleByDate).toEqual(
+      errorResult.availableScheduleByDate
+    );
+    expect(Object.keys(loadingResult.availableScheduleByDate)).toEqual([
+      '2026-07-20',
+      '2026-07-21',
+    ]);
+  });
+
+  it('지난 시간대는 결과에서 제외한다', () => {
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(result.availableScheduleByDate['2026-07-01']).toBeUndefined();
+  });
+
+  it('이미 예약이 완료된 스케줄(blockedScheduleIds)은 대체 데이터에서 제외한다', () => {
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [2],
+      now: NOW,
+    });
+
+    expect(result.availableScheduleByDate['2026-07-20']).toBeUndefined();
+    expect(result.availableScheduleByDate['2026-07-21']).toEqual([
+      { id: 3, startTime: '13:00', endTime: '14:00' },
+    ]);
+  });
+
+  it('이미 예약이 완료된 스케줄(blockedScheduleIds)은 API 응답에서도 제외한다', () => {
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [
+          { id: 2, startTime: '09:00', endTime: '10:00' },
+          { id: 4, startTime: '15:00', endTime: '16:00' },
+        ],
+      },
+    ];
+
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [2],
+      now: NOW,
+    });
+
+    expect(result.usesFallbackSchedule).toBe(false);
+    expect(result.availableScheduleByDate).toEqual({
+      '2026-07-20': [{ id: 4, startTime: '15:00', endTime: '16:00' }],
+    });
+  });
+
+  it('중복 예약 필터링으로 API 응답의 모든 날짜가 비면 원본 스케줄로 대체한다', () => {
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+      },
+    ];
+
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatus: 'success',
+      blockedScheduleIds: [2],
+      now: NOW,
+    });
+
+    expect(result.usesFallbackSchedule).toBe(true);
+    expect(result.availableScheduleByDate['2026-07-21']).toEqual([
+      { id: 3, startTime: '13:00', endTime: '14:00' },
+    ]);
+  });
+});

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
@@ -1,0 +1,140 @@
+import type { TimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
+import {
+  isUpcomingTimeSlot,
+  normalizeDateKey,
+} from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
+import type {
+  ActivityAvailableScheduleItem,
+  ActivitySchedule,
+} from '@/shared/types/activityDetail.types';
+
+/**
+ * 예약 가능 시간 조회(API) 상태.
+ * loading/error 시에는 원본 스케줄(schedules)을 대체 데이터로 사용한다.
+ */
+export type AvailableScheduleQueryStatus = 'loading' | 'error' | 'success';
+
+export interface BuildReservationAvailabilityParams {
+  /** 체험 상세에 포함된 원본 스케줄(대체 데이터 원천) */
+  schedules: ActivitySchedule[];
+  /** 월별 예약 가능 시간 조회 API 응답을 합친 목록 */
+  availableSchedules: ActivityAvailableScheduleItem[];
+  /** 예약 가능 시간 조회 API의 상태 */
+  availableScheduleQueryStatus: AvailableScheduleQueryStatus;
+  /** 이미 예약이 완료되어 선택 불가능한 스케줄 ID */
+  blockedScheduleIds: number[];
+  /** 지난 시간 판단 기준 시각 */
+  now: Date;
+}
+
+export interface ReservationAvailabilityResult {
+  /** 날짜(`YYYY-MM-DD`)별 예약 가능 시간대 */
+  availableScheduleByDate: Record<string, TimeSlot[]>;
+  /** true면 API 응답 대신 원본 스케줄을 대체 데이터로 사용 중임을 의미한다. */
+  usesFallbackSchedule: boolean;
+}
+
+const buildScheduleByDateFromSchedules = (
+  schedules: ActivitySchedule[],
+  blockedScheduleIds: number[],
+  now: Date
+) => {
+  return schedules.reduce<Record<string, TimeSlot[]>>(
+    (accumulator, schedule) => {
+      if (blockedScheduleIds.includes(schedule.id)) {
+        return accumulator;
+      }
+
+      const dateKey = normalizeDateKey(schedule.date);
+      if (!isUpcomingTimeSlot(dateKey, schedule.startTime, now)) {
+        return accumulator;
+      }
+
+      const nextSlot: TimeSlot = {
+        id: schedule.id,
+        startTime: schedule.startTime,
+        endTime: schedule.endTime,
+      };
+
+      if (!accumulator[dateKey]) {
+        accumulator[dateKey] = [nextSlot];
+      } else {
+        accumulator[dateKey].push(nextSlot);
+      }
+
+      return accumulator;
+    },
+    {}
+  );
+};
+
+const buildScheduleByDateFromAvailableSchedules = (
+  availableSchedules: ActivityAvailableScheduleItem[],
+  blockedScheduleIds: number[],
+  now: Date
+) => {
+  return availableSchedules.reduce<Record<string, TimeSlot[]>>(
+    (accumulator, item) => {
+      const dateKey = normalizeDateKey(item.date);
+      const filteredTimes = item.times.filter(
+        (time) =>
+          !blockedScheduleIds.includes(time.id) &&
+          isUpcomingTimeSlot(dateKey, time.startTime, now)
+      );
+
+      if (filteredTimes.length === 0) {
+        return accumulator;
+      }
+
+      accumulator[dateKey] = filteredTimes.map((time) => ({
+        id: time.id,
+        startTime: time.startTime,
+        endTime: time.endTime,
+      }));
+
+      return accumulator;
+    },
+    {}
+  );
+};
+
+/**
+ * 원본 스케줄, 예약 가능 시간 API 응답, 조회 상태, 예약 완료 스케줄 ID, 현재 시각을 입력받아
+ * 화면에 표시할 날짜별 예약 가능 시간대를 계산하는 순수 함수.
+ *
+ * - loading/error 이거나 API 응답이 정상이지만 결과가 비어 있으면 원본 스케줄을 대체 데이터로 사용한다.
+ * - 지난 시간과 이미 예약이 완료된(blockedScheduleIds) 시간대는 결과에서 제외한다.
+ */
+export const buildReservationAvailability = ({
+  schedules,
+  availableSchedules,
+  availableScheduleQueryStatus,
+  blockedScheduleIds,
+  now,
+}: BuildReservationAvailabilityParams): ReservationAvailabilityResult => {
+  const fromAvailableApi = buildScheduleByDateFromAvailableSchedules(
+    availableSchedules,
+    blockedScheduleIds,
+    now
+  );
+
+  const shouldUseFallback =
+    availableScheduleQueryStatus !== 'success' ||
+    Object.keys(fromAvailableApi).length === 0;
+
+  if (shouldUseFallback) {
+    return {
+      availableScheduleByDate: buildScheduleByDateFromSchedules(
+        schedules,
+        blockedScheduleIds,
+        now
+      ),
+      usesFallbackSchedule: true,
+    };
+  }
+
+  return {
+    availableScheduleByDate: fromAvailableApi,
+    usesFallbackSchedule: false,
+  };
+};

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.ts
@@ -75,3 +75,47 @@ export const parseTimeToHourMinute = (time: unknown) => {
 
   return { hour, minute };
 };
+
+/**
+ * `dateKey`(`YYYY-MM-DD`)와 `startTime`이 `now` 기준 아직 지나지 않은 시각인지 판단한다.
+ * 날짜/시각 형식이 유효하지 않으면 판단할 수 없으므로 안전하게 true를 반환한다.
+ */
+export const isUpcomingTimeSlot = (
+  dateKey: string,
+  startTime: string,
+  now: Date
+) => {
+  const [yearText, monthText, dayText] = dateKey.split('-');
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const parsedTime = parseTimeToHourMinute(startTime);
+
+  if (!parsedTime) {
+    return true;
+  }
+
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day)
+  ) {
+    return true;
+  }
+
+  const startDateTime = new Date(
+    year,
+    month - 1,
+    day,
+    parsedTime.hour,
+    parsedTime.minute,
+    0,
+    0
+  );
+
+  if (Number.isNaN(startDateTime.getTime())) {
+    return true;
+  }
+
+  return startDateTime.getTime() > now.getTime();
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #343 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

`useActivityReservationAvailability`가 담당하던 예약 가능 시간 계산 로직을 입력값만으로 결과를 결정하는 순수 함수로 분리

- `utils/reservationAvailability.ts` 신규 추가: 원본 스케줄, 예약 가능 시간 API 응답, 조회 상태(`loading`/`error`/`success`), 예약 완료 스케줄 ID, 현재 시각을 입력받아 날짜별 예약 가능 시간대(`availableScheduleByDate`)를 계산하는 `buildReservationAvailability` 함수 정의
  - API 응답이 로딩/오류이거나 정상이지만 결과가 비어있는 경우를 구분해 원본 스케줄 대체(fallback) 여부를 `usesFallbackSchedule` 값으로 명시적으로 드러냄
  - 지난 시간대와 이미 예약 완료된(`blockedScheduleIds`) 시간대를 제외하는 필터링 로직 포함
- `isUpcomingTimeSlot`을 훅에서 `utils/reservationDateTime.ts`로 이동해 재사용 가능하도록 정리
- `useActivityReservationAvailability`는 React Query로 데이터를 조회하고, 조회 상태를 조합해 뷰모델 함수를 호출하는 역할만 담당하도록 단순화
- `reservationAvailability.test.ts` 추가: 정상 응답, 빈 응답, 로딩/오류, 지난 시간, 중복 예약 케이스 단위 테스트 7건 작성
