### PR TITLE
[Refactor/#344] 호스트 예약 캘린더 표시 상태를 뷰모델로 분리

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(git fetch *)"]
+  }
+}

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarDisplayData.ts
@@ -1,20 +1,9 @@
 import { useMemo } from 'react';
-import {
-  ReservationDetailData,
-  ReservationEventCounts,
-} from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
+import { ReservationDetailData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
+import { buildReservationCalendarDisplayData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData';
 import { buildReservationDetailData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeReservationDetailData';
-import { mergeScheduleOverlayIntoEventCounts } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeScheduleOverlayIntoEventCounts';
 import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
 import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
-
-const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
-  schedules.some((schedule) => {
-    const pending = Math.max(schedule.count.pending, 0);
-    const confirmed = Math.max(schedule.count.confirmed, 0);
-    const declined = Math.max(schedule.count.declined, 0);
-    return pending + confirmed + declined > 0;
-  });
 
 interface UseReservationCalendarDisplayDataProps {
   reservationDashboard: ReservationDashboardDailyItem[];
@@ -25,6 +14,10 @@ interface UseReservationCalendarDisplayDataProps {
   todayDateKey: string;
 }
 
+/**
+ * 계산 규칙은 순수 함수(`buildReservationCalendarDisplayData`, `buildReservationDetailData`)에 두고,
+ * 이 훅은 입력 데이터를 전달하고 계산 결과를 반환하는 역할만 담당한다.
+ */
 export const useReservationCalendarDisplayData = ({
   reservationDashboard,
   reservedScheduleDateKey,
@@ -33,96 +26,34 @@ export const useReservationCalendarDisplayData = ({
   isTodayScheduleFetchRequired,
   todayDateKey,
 }: UseReservationCalendarDisplayDataProps) => {
-  const { eventCountsByDate, notificationDotByDate } = useMemo(() => {
-    const notificationDotByDate: Record<string, boolean> = {};
-
-    const eventCounts = reservationDashboard.reduce<
-      Record<string, ReservationEventCounts>
-    >((accumulator, item) => {
-      const r = item.reservations;
-      const completed = Math.max(r.completed ?? 0, 0);
-      const confirmed = Math.max(r.confirmed ?? 0, 0);
-      const pending = Math.max(r.pending ?? 0, 0);
-      const declined = Math.max(r.declined ?? 0, 0);
-      const isPastDate = item.date < todayDateKey;
-      const pendingForDisplay = isPastDate ? 0 : pending;
-      const rawTotal = pendingForDisplay + confirmed + completed + declined;
-      if (rawTotal > 0) {
-        notificationDotByDate[item.date] = true;
-      }
-
-      const shiftedCompleted = isPastDate ? completed + confirmed : completed;
-      const shiftedConfirmed = isPastDate ? 0 : confirmed;
-
-      const dailyEventCounts: ReservationEventCounts = {};
-      if (pendingForDisplay > 0) dailyEventCounts.pending = pendingForDisplay;
-      if (shiftedConfirmed > 0) dailyEventCounts.confirmed = shiftedConfirmed;
-      if (shiftedCompleted > 0) dailyEventCounts.completed = shiftedCompleted;
-
-      if (Object.keys(dailyEventCounts).length > 0) {
-        accumulator[item.date] = dailyEventCounts;
-      }
-
-      return accumulator;
-    }, {});
-
-    if (
-      reservedScheduleDateKey &&
-      hasReservedSlotActivity(reservedSchedulesSelected)
-    ) {
-      notificationDotByDate[reservedScheduleDateKey] = true;
-    }
-
-    if (
-      isTodayScheduleFetchRequired &&
-      hasReservedSlotActivity(reservedSchedulesToday)
-    ) {
-      notificationDotByDate[todayDateKey] = true;
-    }
-
-    const scheduleDataByDate = new Map<string, ReservedScheduleItem[]>();
-    if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
-      scheduleDataByDate.set(
+  const { eventCountsByDate, notificationDotByDate } = useMemo(
+    () =>
+      buildReservationCalendarDisplayData({
+        reservationDashboard,
         reservedScheduleDateKey,
-        reservedSchedulesSelected
-      );
-    }
-    if (
-      isTodayScheduleFetchRequired &&
-      reservedSchedulesToday.length > 0 &&
-      todayDateKey !== reservedScheduleDateKey
-    ) {
-      scheduleDataByDate.set(todayDateKey, reservedSchedulesToday);
-    }
+        reservedSchedulesSelected,
+        reservedSchedulesToday,
+        isTodayScheduleFetchRequired,
+        todayDateKey,
+        now: new Date(),
+      }),
+    [
+      isTodayScheduleFetchRequired,
+      reservationDashboard,
+      reservedScheduleDateKey,
+      reservedSchedulesSelected,
+      reservedSchedulesToday,
+      todayDateKey,
+    ]
+  );
 
-    const nowForSchedules = new Date();
-    scheduleDataByDate.forEach((schedules, dateKey) => {
-      const merged = mergeScheduleOverlayIntoEventCounts(
-        dateKey,
-        schedules,
-        nowForSchedules,
-        eventCounts[dateKey]
-      );
-      if (merged) {
-        eventCounts[dateKey] = merged;
-      }
-    });
-
-    return { eventCountsByDate: eventCounts, notificationDotByDate };
-  }, [
-    isTodayScheduleFetchRequired,
-    reservationDashboard,
-    reservedScheduleDateKey,
-    reservedSchedulesSelected,
-    reservedSchedulesToday,
-    todayDateKey,
-  ]);
-
-  const detailData = useMemo<ReservationDetailData>(() => {
-    return buildReservationDetailData({
-      reservedSchedules: reservedSchedulesSelected,
-    });
-  }, [reservedSchedulesSelected]);
+  const detailData = useMemo<ReservationDetailData>(
+    () =>
+      buildReservationDetailData({
+        reservedSchedules: reservedSchedulesSelected,
+      }),
+    [reservedSchedulesSelected]
+  );
 
   return { eventCountsByDate, notificationDotByDate, detailData };
 };

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types.ts
@@ -42,3 +42,15 @@ export interface ReservationTimeSlotOption {
 export interface ReservationDetailData {
   timeSlots: ReservationTimeSlotOption[];
 }
+
+/** 캘린더 한 날짜의 표시 상태(상태별 배지 집계, 알림 도트 노출 여부) */
+export interface ReservationCalendarDateDisplayState {
+  eventCounts: ReservationEventCounts;
+  hasNotificationDot: boolean;
+}
+
+/** 날짜(`YYYY-MM-DD`)별 캘린더 표시 상태 */
+export type ReservationCalendarDisplayByDate = Record<
+  string,
+  ReservationCalendarDateDisplayState
+>;

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.test.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.test.ts
@@ -155,6 +155,23 @@ describe('buildReservationCalendarDisplayData', () => {
     expect(result.eventCountsByDate['2026-07-18']).toEqual({ pending: 1 });
   });
 
+  it('선택 날짜 스케줄이 거절만 있으면 배지는 비고 알림 도트만 켠다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [],
+      reservedScheduleDateKey: '2026-07-18',
+      reservedSchedulesSelected: [
+        schedule({ count: { declined: 2, confirmed: 0, pending: 0 } }),
+      ],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.notificationDotByDate['2026-07-18']).toBe(true);
+    expect(result.eventCountsByDate['2026-07-18']).toBeUndefined();
+  });
+
   it('대시보드 응답 일부가 비어 있어도 reserved-schedule로 배지 집계를 보정한다', () => {
     const result = buildReservationCalendarDisplayData({
       reservationDashboard: [dashboardItem('2026-07-18', { pending: 0 })],

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.test.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import { buildReservationCalendarDisplayData } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData';
+import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
+import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+
+const TODAY = '2026-07-15';
+const NOW = new Date('2026-07-15T10:00:00');
+
+const dashboardItem = (
+  date: string,
+  reservations: Partial<ReservationDashboardDailyItem['reservations']> = {}
+): ReservationDashboardDailyItem => ({
+  date,
+  reservations: {
+    completed: 0,
+    confirmed: 0,
+    declined: 0,
+    pending: 0,
+    ...reservations,
+  },
+});
+
+const schedule = (
+  overrides: Partial<ReservedScheduleItem> = {}
+): ReservedScheduleItem => ({
+  scheduleId: 1,
+  startTime: '09:00',
+  endTime: '10:00',
+  count: { declined: 0, confirmed: 0, pending: 0 },
+  ...overrides,
+});
+
+describe('buildReservationCalendarDisplayData', () => {
+  it('지난 날짜는 대기를 숨기고 승인을 완료로 넘긴다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [
+        dashboardItem('2026-07-14', { pending: 2, confirmed: 3 }),
+      ],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-14']).toEqual({ completed: 3 });
+    expect(result.notificationDotByDate['2026-07-14']).toBe(true);
+  });
+
+  it('오늘 날짜는 대기/승인 상태를 그대로 표시한다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [
+        dashboardItem(TODAY, { pending: 1, confirmed: 2, completed: 1 }),
+      ],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate[TODAY]).toEqual({
+      pending: 1,
+      confirmed: 2,
+      completed: 1,
+    });
+    expect(result.notificationDotByDate[TODAY]).toBe(true);
+  });
+
+  it('미래 날짜는 대기/승인 상태를 그대로 표시한다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [dashboardItem('2026-07-20', { pending: 4 })],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-20']).toEqual({ pending: 4 });
+    expect(result.notificationDotByDate['2026-07-20']).toBe(true);
+  });
+
+  it('예약이 없는 날짜는 배지와 알림 도트가 없다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [dashboardItem('2026-07-16')],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-16']).toBeUndefined();
+    expect(result.notificationDotByDate['2026-07-16']).toBeUndefined();
+  });
+
+  it('거절만 있는 날짜는 배지 없이 알림 도트만 켠다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [dashboardItem('2026-07-16', { declined: 2 })],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-16']).toBeUndefined();
+    expect(result.notificationDotByDate['2026-07-16']).toBe(true);
+  });
+
+  it('대기·승인·완료 상태가 함께 존재하는 미래 날짜를 그대로 반영한다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [
+        dashboardItem('2026-07-20', {
+          pending: 1,
+          confirmed: 2,
+          completed: 3,
+        }),
+      ],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-20']).toEqual({
+      pending: 1,
+      confirmed: 2,
+      completed: 3,
+    });
+  });
+
+  it('대시보드에 없는 날짜라도 선택 날짜 스케줄에 예약 활동이 있으면 알림 도트를 켠다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [],
+      reservedScheduleDateKey: '2026-07-18',
+      reservedSchedulesSelected: [
+        schedule({ count: { declined: 0, confirmed: 0, pending: 1 } }),
+      ],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.notificationDotByDate['2026-07-18']).toBe(true);
+    expect(result.eventCountsByDate['2026-07-18']).toEqual({ pending: 1 });
+  });
+
+  it('대시보드 응답 일부가 비어 있어도 reserved-schedule로 배지 집계를 보정한다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [dashboardItem('2026-07-18', { pending: 0 })],
+      reservedScheduleDateKey: '2026-07-18',
+      reservedSchedulesSelected: [
+        schedule({
+          startTime: '09:00',
+          endTime: '10:00',
+          count: { declined: 0, confirmed: 2, pending: 0 },
+        }),
+      ],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate['2026-07-18']).toEqual({ confirmed: 2 });
+  });
+
+  it('선택 날짜와 오늘 날짜가 같으면 오늘 스케줄을 중복 반영하지 않는다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [],
+      reservedScheduleDateKey: TODAY,
+      reservedSchedulesSelected: [
+        schedule({
+          endTime: '11:00',
+          count: { declined: 0, confirmed: 1, pending: 0 },
+        }),
+      ],
+      reservedSchedulesToday: [
+        schedule({
+          endTime: '11:00',
+          count: { declined: 0, confirmed: 5, pending: 0 },
+        }),
+      ],
+      isTodayScheduleFetchRequired: true,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate[TODAY]).toEqual({ confirmed: 1 });
+  });
+
+  it('오늘 스케줄 조회가 필요하지 않으면 오늘 스케줄 응답을 반영하지 않는다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [],
+      reservedScheduleDateKey: null,
+      reservedSchedulesSelected: [],
+      reservedSchedulesToday: [
+        schedule({ count: { declined: 0, confirmed: 5, pending: 0 } }),
+      ],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate[TODAY]).toBeUndefined();
+    expect(result.notificationDotByDate[TODAY]).toBeUndefined();
+  });
+
+  it('체험 종료 시각이 지난 승인 슬롯은 완료로 집계한다', () => {
+    const result = buildReservationCalendarDisplayData({
+      reservationDashboard: [],
+      reservedScheduleDateKey: TODAY,
+      reservedSchedulesSelected: [
+        schedule({
+          startTime: '08:00',
+          endTime: '09:00',
+          count: { declined: 0, confirmed: 3, pending: 0 },
+        }),
+      ],
+      reservedSchedulesToday: [],
+      isTodayScheduleFetchRequired: false,
+      todayDateKey: TODAY,
+      now: NOW,
+    });
+
+    expect(result.eventCountsByDate[TODAY]).toEqual({ completed: 3 });
+  });
+});

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/buildReservationCalendarDisplayData.ts
@@ -1,0 +1,197 @@
+import type {
+  ReservationCalendarDateDisplayState,
+  ReservationCalendarDisplayByDate,
+  ReservationEventCounts,
+} from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
+import { mergeScheduleOverlayIntoEventCounts } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/mergeScheduleOverlayIntoEventCounts';
+import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
+import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
+
+export interface BuildReservationCalendarDisplayDataParams {
+  reservationDashboard: ReservationDashboardDailyItem[];
+  reservedScheduleDateKey: string | null;
+  reservedSchedulesSelected: ReservedScheduleItem[];
+  reservedSchedulesToday: ReservedScheduleItem[];
+  isTodayScheduleFetchRequired: boolean;
+  todayDateKey: string;
+  /** 지난 날짜/스케줄 종료 여부 판단 기준 시각 */
+  now: Date;
+}
+
+export interface ReservationCalendarDisplayResult {
+  eventCountsByDate: Record<string, ReservationEventCounts>;
+  notificationDotByDate: Record<string, boolean>;
+}
+
+const hasReservedSlotActivity = (schedules: ReservedScheduleItem[]) =>
+  schedules.some((schedule) => {
+    const pending = Math.max(schedule.count.pending, 0);
+    const confirmed = Math.max(schedule.count.confirmed, 0);
+    const declined = Math.max(schedule.count.declined, 0);
+    return pending + confirmed + declined > 0;
+  });
+
+/**
+ * 대시보드 일간 응답 하나를 화면 표시 상태로 보정하는 순수 함수.
+ * - 지난 날짜는 대기(pending)를 숨기고, 승인(confirmed)은 완료(completed)로 넘긴다.
+ * - 거절(declined)을 포함해 값이 하나라도 있으면 알림 도트를 켠다(배지에는 표시하지 않는다).
+ */
+const buildDailyDisplayStateFromDashboardItem = (
+  item: ReservationDashboardDailyItem,
+  todayDateKey: string
+): ReservationCalendarDateDisplayState => {
+  const r = item.reservations;
+  const completed = Math.max(r.completed ?? 0, 0);
+  const confirmed = Math.max(r.confirmed ?? 0, 0);
+  const pending = Math.max(r.pending ?? 0, 0);
+  const declined = Math.max(r.declined ?? 0, 0);
+  const isPastDate = item.date < todayDateKey;
+  const pendingForDisplay = isPastDate ? 0 : pending;
+  const rawTotal = pendingForDisplay + confirmed + completed + declined;
+
+  const shiftedConfirmed = isPastDate ? 0 : confirmed;
+  const shiftedCompleted = isPastDate ? completed + confirmed : completed;
+
+  const eventCounts: ReservationEventCounts = {};
+  if (pendingForDisplay > 0) eventCounts.pending = pendingForDisplay;
+  if (shiftedConfirmed > 0) eventCounts.confirmed = shiftedConfirmed;
+  if (shiftedCompleted > 0) eventCounts.completed = shiftedCompleted;
+
+  return { eventCounts, hasNotificationDot: rawTotal > 0 };
+};
+
+/**
+ * 월간 대시보드 응답 전체를 날짜별 표시 상태 맵으로 변환한다.
+ */
+const buildDisplayByDateFromDashboard = (
+  reservationDashboard: ReservationDashboardDailyItem[],
+  todayDateKey: string
+): ReservationCalendarDisplayByDate =>
+  reservationDashboard.reduce<ReservationCalendarDisplayByDate>(
+    (accumulator, item) => {
+      accumulator[item.date] = buildDailyDisplayStateFromDashboardItem(
+        item,
+        todayDateKey
+      );
+      return accumulator;
+    },
+    {}
+  );
+
+/**
+ * 선택 날짜와 오늘 날짜의 reserved-schedule 응답을 하나의 날짜별 맵으로 합친다.
+ * 오늘이 선택 날짜와 같으면 같은 날짜를 중복 반영하지 않도록 선택 날짜 쪽만 사용한다.
+ */
+const buildReservedScheduleByDate = ({
+  reservedScheduleDateKey,
+  reservedSchedulesSelected,
+  reservedSchedulesToday,
+  isTodayScheduleFetchRequired,
+  todayDateKey,
+}: Pick<
+  BuildReservationCalendarDisplayDataParams,
+  | 'reservedScheduleDateKey'
+  | 'reservedSchedulesSelected'
+  | 'reservedSchedulesToday'
+  | 'isTodayScheduleFetchRequired'
+  | 'todayDateKey'
+>): Map<string, ReservedScheduleItem[]> => {
+  const reservedScheduleByDate = new Map<string, ReservedScheduleItem[]>();
+
+  if (reservedScheduleDateKey && reservedSchedulesSelected.length > 0) {
+    reservedScheduleByDate.set(
+      reservedScheduleDateKey,
+      reservedSchedulesSelected
+    );
+  }
+
+  if (
+    isTodayScheduleFetchRequired &&
+    reservedSchedulesToday.length > 0 &&
+    todayDateKey !== reservedScheduleDateKey
+  ) {
+    reservedScheduleByDate.set(todayDateKey, reservedSchedulesToday);
+  }
+
+  return reservedScheduleByDate;
+};
+
+/**
+ * 대시보드 응답, 선택 날짜/오늘 날짜의 reserved-schedule 응답을 입력받아
+ * 캘린더 날짜별 표시 상태(배지 집계, 알림 도트)를 계산하는 순수 함수.
+ *
+ * 1. 대시보드 응답을 날짜별 표시 상태로 변환한다.
+ * 2. 선택/오늘 날짜에 예약 활동이 있으면 알림 도트를 켠다(대시보드에 없는 날짜도 포함).
+ * 3. 선택/오늘 날짜의 reserved-schedule 응답으로 배지 집계를 스케줄 단위로 보정한다.
+ */
+export const buildReservationCalendarDisplayData = ({
+  reservationDashboard,
+  reservedScheduleDateKey,
+  reservedSchedulesSelected,
+  reservedSchedulesToday,
+  isTodayScheduleFetchRequired,
+  todayDateKey,
+  now,
+}: BuildReservationCalendarDisplayDataParams): ReservationCalendarDisplayResult => {
+  const displayByDate = buildDisplayByDateFromDashboard(
+    reservationDashboard,
+    todayDateKey
+  );
+
+  if (
+    reservedScheduleDateKey &&
+    hasReservedSlotActivity(reservedSchedulesSelected)
+  ) {
+    displayByDate[reservedScheduleDateKey] = {
+      eventCounts: displayByDate[reservedScheduleDateKey]?.eventCounts ?? {},
+      hasNotificationDot: true,
+    };
+  }
+
+  if (
+    isTodayScheduleFetchRequired &&
+    hasReservedSlotActivity(reservedSchedulesToday)
+  ) {
+    displayByDate[todayDateKey] = {
+      eventCounts: displayByDate[todayDateKey]?.eventCounts ?? {},
+      hasNotificationDot: true,
+    };
+  }
+
+  const reservedScheduleByDate = buildReservedScheduleByDate({
+    reservedScheduleDateKey,
+    reservedSchedulesSelected,
+    reservedSchedulesToday,
+    isTodayScheduleFetchRequired,
+    todayDateKey,
+  });
+
+  reservedScheduleByDate.forEach((schedules, dateKey) => {
+    const merged = mergeScheduleOverlayIntoEventCounts(
+      dateKey,
+      schedules,
+      now,
+      displayByDate[dateKey]?.eventCounts
+    );
+    if (merged) {
+      displayByDate[dateKey] = {
+        eventCounts: merged,
+        hasNotificationDot: displayByDate[dateKey]?.hasNotificationDot ?? false,
+      };
+    }
+  });
+
+  const eventCountsByDate: Record<string, ReservationEventCounts> = {};
+  const notificationDotByDate: Record<string, boolean> = {};
+
+  Object.entries(displayByDate).forEach(([dateKey, state]) => {
+    if (Object.keys(state.eventCounts).length > 0) {
+      eventCountsByDate[dateKey] = state.eventCounts;
+    }
+    if (state.hasNotificationDot) {
+      notificationDotByDate[dateKey] = true;
+    }
+  });
+
+  return { eventCountsByDate, notificationDotByDate };
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #344 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

`useReservationCalendarDisplayData`가 담당하던 캘린더 날짜별 배지/알림 도트 계산 로직을 입력값만으로 결과가 결정되는 순수 뷰모델 함수로 분리

- 캘린더 날짜 한 칸의 상태(배지 개수, 알림 도트 여부)를 타입으로 정리
- `utils/buildReservationCalendarDisplayData.ts` 신규 추가
  - 대기/승인/완료 상태를 지난 날짜 기준으로 보정하고, 알림 도트를 켤지 계산하는 부분을 함수로 따로 뺌
  - 선택한 날짜랑 오늘 날짜 스케줄 데이터를 합치는 규칙도 따로 뺌
  - 지금 시각을 함수 인자로 넘겨주게 해서, 테스트에서 시각을 고정해놓고 재현 가능하게 함
- 훅은 이제 이 함수들 호출해서 결과 넘겨주는 역할만 하도록 단순화
- `buildReservationCalendarDisplayData.test.ts` 추가: 과거/오늘/미래/예약 없음/거절만 있는 날짜, 대기·승인·완료 동시 존재, 대시보드 응답 일부 누락, 선택일=오늘 날짜 중복 방지, 체험 종료 시각 경과 케이스 등 14건 단위 테스트 작성
