### PR TITLE
[Refactor/#345] 예약 도메인에 Query Key 팩토리 도입

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -12,7 +12,7 @@ import {
   buildReservationAvailability,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability';
 import { normalizeDateKey } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 
 const EMPTY_RESERVED_SCHEDULES: MyReservedScheduleItem[] = [];
@@ -55,12 +55,11 @@ export const useActivityReservationAvailability = ({
 
   const availableScheduleQueries = useQueries({
     queries: queryTargetMonths.map(({ year, month }) => ({
-      queryKey: [
-        ...QUERY_KEYS.ACTIVITY_AVAILABLE_SCHEDULE,
+      queryKey: reservationKeys.availableSchedule.byMonth(
         activityId,
         year,
-        month,
-      ],
+        month
+      ),
       queryFn: () =>
         fetchActivityAvailableSchedule({
           activityId,
@@ -87,7 +86,7 @@ export const useActivityReservationAvailability = ({
     }, [availableScheduleQueries]);
 
   const { data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES } = useQuery({
-    queryKey: [...QUERY_KEYS.MY_RESERVATIONS, 'reservedSchedules'],
+    queryKey: reservationKeys.myReservations.reservedSchedules(),
     queryFn: fetchMyReservedSchedules,
     enabled: isAuthenticated,
   });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -11,7 +11,7 @@ import type {
 import { useActivityReservationAvailability } from '@/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability';
 import { ApiError } from '@/shared/apis/apiError';
 import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 import { formatDateKey } from '@/shared/utils/formatDate';
 
@@ -153,14 +153,10 @@ export const useActivityReservationCardState = ({
   );
 
   const refreshAvailableSchedule = async () => {
-    await queryClient.invalidateQueries({
-      queryKey: [...QUERY_KEYS.ACTIVITY_AVAILABLE_SCHEDULE, activityId],
-    });
+    const queryKey = reservationKeys.availableSchedule.byActivity(activityId);
 
-    await queryClient.refetchQueries({
-      queryKey: [...QUERY_KEYS.ACTIVITY_AVAILABLE_SCHEDULE, activityId],
-      type: 'active',
-    });
+    await queryClient.invalidateQueries({ queryKey });
+    await queryClient.refetchQueries({ queryKey, type: 'active' });
   };
 
   const { mutate: submitReservation, isPending: isReservationSubmitting } =

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationRequests.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationRequests.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { fetchActivityReservations } from '@/app/(main)/my/activities-dashboard/apis/reservations';
 import type { ReservationTab } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/components/reservationDetailSheet.constants';
 import type { ReservationRequestItem } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/reservationCalendar.types';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 
 interface UseReservationRequestsParams {
   activityId: number;
@@ -33,12 +33,11 @@ export const useReservationRequests = ({
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVATIONS,
+    queryKey: reservationKeys.requests.bySchedule(
       activityId,
       selectedScheduleId,
-      activeTab,
-    ],
+      activeTab
+    ),
     queryFn: ({ pageParam }) =>
       fetchActivityReservations({
         activityId,

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/components/useReservationStatusUpdate.ts
@@ -6,7 +6,7 @@ import {
   MissingReservationScheduleError,
   updateActivityReservationStatus,
 } from '@/app/(main)/my/activities-dashboard/apis/reservations';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import { useShowToast } from '@/shared/store/useToastStore';
 
 type ReservationUpdateStatus = 'confirmed' | 'declined';
@@ -108,16 +108,13 @@ export const useReservationStatusUpdate = ({
       onSettled: async () => {
         await Promise.all([
           queryClient.invalidateQueries({
-            queryKey: [...QUERY_KEYS.MY_ACTIVITY_RESERVATIONS, activityId],
+            queryKey: reservationKeys.requests.byActivity(activityId),
           }),
           queryClient.invalidateQueries({
-            queryKey: [...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE, activityId],
+            queryKey: reservationKeys.reservedSchedule.byActivity(activityId),
           }),
           queryClient.invalidateQueries({
-            queryKey: [
-              ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
-              activityId,
-            ],
+            queryKey: reservationKeys.dashboard.byActivity(activityId),
           }),
         ]);
       },

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useAutoDeclineExpiredReservations.ts
@@ -5,15 +5,8 @@ import {
   declinePendingReservationIds,
 } from '@/app/(main)/my/activities-dashboard/apis/reservations';
 import { isScheduleStartReached } from '@/app/(main)/my/activities-dashboard/components/reservation-calendar/utils/scheduleStatus';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
-
-/** 자동 거절 후 접두 `[root, activityId]`로 무효화할 쿼리 루트 */
-const ACTIVITY_RESERVATION_CACHE_ROOTS = [
-  QUERY_KEYS.MY_ACTIVITY_RESERVATIONS[0],
-  QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE[0],
-  QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD[0],
-] as const;
 
 interface UseAutoDeclineExpiredReservationsProps {
   activityId: number | null;
@@ -125,11 +118,11 @@ export const useAutoDeclineExpiredReservations = ({
       if (!hasDeclinedAny) return;
 
       await Promise.all(
-        ACTIVITY_RESERVATION_CACHE_ROOTS.map((root) =>
-          queryClient.invalidateQueries({
-            queryKey: [root, activityId],
-          })
-        )
+        [
+          reservationKeys.requests.byActivity(activityId),
+          reservationKeys.reservedSchedule.byActivity(activityId),
+          reservationKeys.dashboard.byActivity(activityId),
+        ].map((queryKey) => queryClient.invalidateQueries({ queryKey }))
       );
     })();
 

--- a/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
+++ b/src/app/(main)/my/activities-dashboard/components/reservation-calendar/hooks/useReservationCalendarQueries.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchReservationDashboard } from '@/app/(main)/my/activities-dashboard/apis/reservationDashboard';
 import { fetchReservedSchedule } from '@/app/(main)/my/activities-dashboard/apis/reservedSchedule';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import type { ReservationDashboardDailyItem } from '@/shared/types/reservationDashboard.types';
 import type { ReservedScheduleItem } from '@/shared/types/reservedSchedule.types';
 
@@ -26,12 +26,11 @@ export const useReservationCalendarQueries = ({
   isTodayScheduleFetchRequired,
 }: UseReservationCalendarQueriesProps) => {
   const { data: reservationDashboard = EMPTY_DASHBOARD } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVATION_DASHBOARD,
+    queryKey: reservationKeys.dashboard.byMonth(
       activityId,
       currentYear,
-      currentMonth,
-    ],
+      currentMonth
+    ),
     queryFn: () =>
       fetchReservationDashboard({
         activityId: activityId as number,
@@ -43,11 +42,10 @@ export const useReservationCalendarQueries = ({
   });
 
   const { data: reservedSchedulesSelected = EMPTY_SCHEDULES } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
+    queryKey: reservationKeys.reservedSchedule.byDate(
       activityId,
-      reservedScheduleDateKey,
-    ],
+      reservedScheduleDateKey
+    ),
     queryFn: () =>
       fetchReservedSchedule({
         activityId: activityId as number,
@@ -59,11 +57,7 @@ export const useReservationCalendarQueries = ({
   });
 
   const { data: reservedSchedulesToday = EMPTY_SCHEDULES } = useQuery({
-    queryKey: [
-      ...QUERY_KEYS.MY_ACTIVITY_RESERVED_SCHEDULE,
-      activityId,
-      todayDateKey,
-    ],
+    queryKey: reservationKeys.reservedSchedule.byDate(activityId, todayDateKey),
     queryFn: () =>
       fetchReservedSchedule({
         activityId: activityId as number,

--- a/src/app/(main)/my/reservations/hooks/useCancelReservation.ts
+++ b/src/app/(main)/my/reservations/hooks/useCancelReservation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchMyReservation } from '@/app/(main)/my/reservations/apis/myReservations';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import { useShowToast } from '@/shared/store/useToastStore';
 
 /**
@@ -17,7 +17,7 @@ export const useCancelReservation = () => {
     mutationFn: patchMyReservation,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.MY_RESERVATIONS],
+        queryKey: reservationKeys.myReservations.all,
       });
       showToast({
         theme: 'success',

--- a/src/app/(main)/my/reservations/hooks/useMyReservations.ts
+++ b/src/app/(main)/my/reservations/hooks/useMyReservations.ts
@@ -1,6 +1,6 @@
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { fetchMyReservations } from '@/app/(main)/my/reservations/apis/myReservations';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import { createCursorInfiniteOptions } from '@/shared/utils/createCursorInfiniteOptions';
 
 /**
@@ -8,7 +8,7 @@ import { createCursorInfiniteOptions } from '@/shared/utils/createCursorInfinite
  */
 export const myReservationsOptions = (status?: string | null) =>
   createCursorInfiniteOptions(
-    [QUERY_KEYS.MY_RESERVATIONS, status],
+    reservationKeys.myReservations.list(status),
     ({ pageParam }) => fetchMyReservations({ pageParam, status })
   );
 

--- a/src/app/(main)/my/reservations/hooks/useReviewMutation.ts
+++ b/src/app/(main)/my/reservations/hooks/useReviewMutation.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postReviews } from '@/app/(main)/my/reservations/apis/myReservations';
-import { QUERY_KEYS } from '@/shared/constants/queryKeys.constants';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import { useShowToast } from '@/shared/store/useToastStore';
 
 /**
@@ -19,7 +19,7 @@ export const useReviewMutation = (onCloseModal: () => void) => {
     mutationFn: postReviews,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.MY_RESERVATIONS],
+        queryKey: reservationKeys.myReservations.all,
       });
       showToast({
         theme: 'success',

--- a/src/shared/constants/queryKeys.constants.ts
+++ b/src/shared/constants/queryKeys.constants.ts
@@ -1,14 +1,9 @@
 export const QUERY_KEYS = {
   ACTIVITIES: ['activities'],
   POPULAR_ACTIVITIES: ['popularActivities'],
-  ACTIVITY_AVAILABLE_SCHEDULE: ['activityAvailableSchedule'],
   ACTIVITY_REVIEWS: ['activityReviews'],
   MY_ACTIVITIES: ['myActivities'],
-  MY_RESERVATIONS: ['myReservations'],
   MY_ACTIVITIES_DASHBOARD: ['myActivitiesDashboard'],
-  MY_ACTIVITY_RESERVATION_DASHBOARD: ['myActivityReservationDashboard'],
-  MY_ACTIVITY_RESERVED_SCHEDULE: ['myActivityReservedSchedule'],
-  MY_ACTIVITY_RESERVATIONS: ['myActivityReservations'],
   MY_INFO: ['myInfo'],
   MY_NOTIFICATIONS: ['myNotifications'],
 } as const;

--- a/src/shared/queryKeys/reservationKeys.test.ts
+++ b/src/shared/queryKeys/reservationKeys.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
+
+describe('reservationKeys.myReservations', () => {
+  it('상태값에 따라 목록 키를 생성한다', () => {
+    expect(reservationKeys.myReservations.list('pending')).toEqual([
+      'myReservations',
+      'pending',
+    ]);
+  });
+
+  it('상태값이 없으면 null을 사용한다', () => {
+    expect(reservationKeys.myReservations.list()).toEqual([
+      'myReservations',
+      null,
+    ]);
+  });
+
+  it('목록/상세 캐시 무효화에 사용하는 상위 키는 모든 목록 키의 접두사이다', () => {
+    const root = reservationKeys.myReservations.all;
+    const list = reservationKeys.myReservations.list('confirmed');
+    const reservedSchedules =
+      reservationKeys.myReservations.reservedSchedules();
+
+    expect(list.slice(0, root.length)).toEqual(root);
+    expect(reservedSchedules.slice(0, root.length)).toEqual(root);
+  });
+});
+
+describe('reservationKeys.availableSchedule', () => {
+  it('체험 ID, 연월로 계층적인 키를 생성한다', () => {
+    const byActivity = reservationKeys.availableSchedule.byActivity(1);
+    const byMonth = reservationKeys.availableSchedule.byMonth(1, 2026, 7);
+
+    expect(byActivity).toEqual(['activityAvailableSchedule', 1]);
+    expect(byMonth).toEqual(['activityAvailableSchedule', 1, 2026, 7]);
+    expect(byMonth.slice(0, byActivity.length)).toEqual(byActivity);
+  });
+
+  it('체험이 다르면 서로 다른 키를 생성한다', () => {
+    expect(reservationKeys.availableSchedule.byActivity(1)).not.toEqual(
+      reservationKeys.availableSchedule.byActivity(2)
+    );
+  });
+});
+
+describe('reservationKeys.dashboard', () => {
+  it('체험 ID, 연월로 계층적인 키를 생성한다', () => {
+    const byActivity = reservationKeys.dashboard.byActivity(10);
+    const byMonth = reservationKeys.dashboard.byMonth(10, 2026, 7);
+
+    expect(byActivity).toEqual(['myActivityReservationDashboard', 10]);
+    expect(byMonth).toEqual(['myActivityReservationDashboard', 10, 2026, 7]);
+    expect(byMonth.slice(0, byActivity.length)).toEqual(byActivity);
+  });
+
+  it('선택된 체험이 없으면 null을 포함한 키를 생성한다', () => {
+    expect(reservationKeys.dashboard.byActivity(null)).toEqual([
+      'myActivityReservationDashboard',
+      null,
+    ]);
+  });
+});
+
+describe('reservationKeys.reservedSchedule', () => {
+  it('체험 ID, 날짜로 계층적인 키를 생성한다', () => {
+    const byActivity = reservationKeys.reservedSchedule.byActivity(10);
+    const byDate = reservationKeys.reservedSchedule.byDate(10, '2026-07-28');
+
+    expect(byActivity).toEqual(['myActivityReservedSchedule', 10]);
+    expect(byDate).toEqual(['myActivityReservedSchedule', 10, '2026-07-28']);
+    expect(byDate.slice(0, byActivity.length)).toEqual(byActivity);
+  });
+});
+
+describe('reservationKeys.requests', () => {
+  it('체험 ID, 스케줄 ID, 상태 탭으로 계층적인 키를 생성한다', () => {
+    const byActivity = reservationKeys.requests.byActivity(10);
+    const bySchedule = reservationKeys.requests.bySchedule(10, 5, 'pending');
+
+    expect(byActivity).toEqual(['myActivityReservations', 10]);
+    expect(bySchedule).toEqual(['myActivityReservations', 10, 5, 'pending']);
+    expect(bySchedule.slice(0, byActivity.length)).toEqual(byActivity);
+  });
+});
+
+describe('예약 승인/거절/생성/취소 시 사용하는 조회 키와 무효화 키의 구조가 동일한지 검증', () => {
+  it('예약 승인/거절(useReservationStatusUpdate)이 무효화하는 키는 조회에 사용한 키의 상위 키와 같다', () => {
+    const activityId = 42;
+
+    // useReservationRequests, useReservationCalendarQueries가 조회에 사용하는 키
+    const requestsQueryKey = reservationKeys.requests.bySchedule(
+      activityId,
+      1,
+      'pending'
+    );
+    const reservedScheduleQueryKey = reservationKeys.reservedSchedule.byDate(
+      activityId,
+      '2026-07-28'
+    );
+    const dashboardQueryKey = reservationKeys.dashboard.byMonth(
+      activityId,
+      2026,
+      7
+    );
+
+    // useReservationStatusUpdate, useAutoDeclineExpiredReservations가 무효화에 사용하는 키
+    const requestsInvalidateKey =
+      reservationKeys.requests.byActivity(activityId);
+    const reservedScheduleInvalidateKey =
+      reservationKeys.reservedSchedule.byActivity(activityId);
+    const dashboardInvalidateKey =
+      reservationKeys.dashboard.byActivity(activityId);
+
+    expect(requestsQueryKey.slice(0, requestsInvalidateKey.length)).toEqual(
+      requestsInvalidateKey
+    );
+    expect(
+      reservedScheduleQueryKey.slice(0, reservedScheduleInvalidateKey.length)
+    ).toEqual(reservedScheduleInvalidateKey);
+    expect(dashboardQueryKey.slice(0, dashboardInvalidateKey.length)).toEqual(
+      dashboardInvalidateKey
+    );
+  });
+
+  it('예약 취소/리뷰 작성이 무효화하는 키는 내 예약 목록 조회 키의 상위 키와 같다', () => {
+    const listQueryKey = reservationKeys.myReservations.list('confirmed');
+    const invalidateKey = reservationKeys.myReservations.all;
+
+    expect(listQueryKey.slice(0, invalidateKey.length)).toEqual(invalidateKey);
+  });
+
+  it('예약 생성이 무효화하는 키는 예약 가능 시간 조회 키의 상위 키와 같다', () => {
+    const queryKey = reservationKeys.availableSchedule.byMonth(1, 2026, 7);
+    const invalidateKey = reservationKeys.availableSchedule.byActivity(1);
+
+    expect(queryKey.slice(0, invalidateKey.length)).toEqual(invalidateKey);
+  });
+});

--- a/src/shared/queryKeys/reservationKeys.ts
+++ b/src/shared/queryKeys/reservationKeys.ts
@@ -1,0 +1,69 @@
+/**
+ * 예약 도메인 TanStack Query Key Factory
+ *
+ * 상위(all) → 목록/체험 단위 → 상세 단위로 키 계층을 유지해, 조회에 사용한 키와
+ * 캐시 무효화(invalidate)에 사용한 키가 항상 같은 구조를 공유하도록 한다.
+ * 인자를 타입으로 제한해 다른 값 타입이 섞여 다른 캐시 키가 생성되는 것을 방지한다.
+ */
+export const reservationKeys = {
+  /** 마이페이지 > 내 예약 내역 목록 */
+  myReservations: {
+    all: ['myReservations'] as const,
+    list: (status: string | null = null) =>
+      [...reservationKeys.myReservations.all, status] as const,
+    /** 체험 예약 카드에서 이미 예약한 스케줄을 가리기 위해 조회하는 내 예약 스케줄 목록 */
+    reservedSchedules: () =>
+      [...reservationKeys.myReservations.all, 'reservedSchedules'] as const,
+  },
+  /** 체험 상세 > 예약 가능 시간 (연월 단위) */
+  availableSchedule: {
+    all: ['activityAvailableSchedule'] as const,
+    byActivity: (activityId: number) =>
+      [...reservationKeys.availableSchedule.all, activityId] as const,
+    byMonth: (activityId: number, year: number, month: number) =>
+      [
+        ...reservationKeys.availableSchedule.byActivity(activityId),
+        year,
+        month,
+      ] as const,
+  },
+  /** 호스트 예약 대시보드 > 월별 예약 현황 집계 */
+  dashboard: {
+    all: ['myActivityReservationDashboard'] as const,
+    byActivity: (activityId: number | null) =>
+      [...reservationKeys.dashboard.all, activityId] as const,
+    byMonth: (activityId: number | null, year: number, month: number) =>
+      [
+        ...reservationKeys.dashboard.byActivity(activityId),
+        year,
+        month,
+      ] as const,
+  },
+  /** 호스트 예약 대시보드 > 날짜별 예약 스케줄 */
+  reservedSchedule: {
+    all: ['myActivityReservedSchedule'] as const,
+    byActivity: (activityId: number | null) =>
+      [...reservationKeys.reservedSchedule.all, activityId] as const,
+    byDate: (activityId: number | null, dateKey: string | null) =>
+      [
+        ...reservationKeys.reservedSchedule.byActivity(activityId),
+        dateKey,
+      ] as const,
+  },
+  /** 호스트 예약 대시보드 > 선택 시간대 예약 신청자 목록 */
+  requests: {
+    all: ['myActivityReservations'] as const,
+    byActivity: (activityId: number | null) =>
+      [...reservationKeys.requests.all, activityId] as const,
+    bySchedule: (
+      activityId: number | null,
+      scheduleId: number | null,
+      status: string
+    ) =>
+      [
+        ...reservationKeys.requests.byActivity(activityId),
+        scheduleId,
+        status,
+      ] as const,
+  },
+} as const;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #345 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

예약 도메인에서 여러 훅이 `QUERY_KEYS` 배열 상수를 각자 다른 방식(스프레드/미스프레드/인덱스 추출)으로 쓰던 것을 `reservationKeys` Query Key Factory로 통일

- `src/shared/queryKeys/reservationKeys.ts` : 내 예약 / 예약 가능 시간 / 호스트 대시보드 월별 현황 / 날짜별 예약 스케줄 / 신청자 목록 5개 도메인을 `all → byActivity → byMonth·byDate·bySchedule` 계층으로 구성
- 위 팩토리를 사용하도록 예약 관련 훅 9개 수정 (`useMyReservations`, `useCancelReservation`, `useReviewMutation`, `useActivityReservationAvailability`, `useActivityReservationCardState`, `useReservationCalendarQueries`, `useReservationRequests`, `useReservationStatusUpdate`, `useAutoDeclineExpiredReservations`)
- `reservationKeys.test.ts` : 각 조회 키가 대응하는 무효화 키를 prefix로 포함하는지 검증