### PR TITLE
[Chore/#349] 테스트용 사용자 및 더미 데이터 시딩 스크립트 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# seed data script output (계정 비밀번호 등 민감 정보 포함)
+/scripts/seed-data/output/*.json
 next-env.d.ts
 
 # IDE / Editor

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,13 @@ const eslintConfig = defineConfig([
       'simple-import-sort/exports': 'warn',
     },
   },
+  {
+    files: ['scripts/**/*.mjs'],
+    rules: {
+      'no-console': 'off',
+      'no-restricted-imports': 'off',
+    },
+  },
   eslintConfigPrettier,
 ]);
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:run": "vitest run",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "seed": "node scripts/seed-data/seed.mjs",
+    "seed:cleanup": "node scripts/seed-data/cleanup.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/seed-data/README.md
+++ b/scripts/seed-data/README.md
@@ -1,0 +1,49 @@
+# 테스트 데이터 시딩 스크립트
+
+실제 운영 화면처럼 테스트/데모를 진행할 수 있도록, 여러 사용자 계정 + 체험(활동) + 예약 더미
+데이터를 백엔드 API에 직접 생성하는 스크립트입니다. (관련: #349)
+
+## ⚠️ 주의사항
+
+이 프로젝트는 자체 DB 없이 **공용 백엔드**(`sp-globalnomad-api.vercel.app/22-2`)를 사용합니다.
+다른 팀도 같은 서버를 쓸 수 있으므로:
+
+- 생성되는 이메일/닉네임에는 항상 `seed<timestamp>` 접두사가 붙어 실 데이터와 구분됩니다.
+- 필요 이상으로 반복 실행하지 마세요.
+- 백엔드에 회원탈퇴 API가 없어 **시딩된 사용자 계정 자체는 삭제할 수 없습니다.**
+  (체험/예약만 정리 가능)
+
+## 사용법
+
+```bash
+# 기본값(사용자 4명: 호스트 1 + 게스트 3, 체험 2개)으로 시딩
+node scripts/seed-data/seed.mjs
+
+# 옵션 조정
+SEED_USER_COUNT=3 SEED_ACTIVITY_COUNT=1 node scripts/seed-data/seed.mjs
+```
+
+실행이 끝나면 `scripts/seed-data/output/<prefix>.json` 에 생성된 사용자(이메일/비밀번호 포함),
+체험, 예약 정보가 저장됩니다. 이 파일로 로그인해서 실제 화면을 확인하거나, 정리 스크립트에
+넘길 수 있습니다.
+
+```bash
+node scripts/seed-data/cleanup.mjs scripts/seed-data/output/<prefix>.json
+```
+
+`cleanup.mjs` 는 생성된 예약을 취소하고 체험을 삭제합니다. (사용자 계정은 위 이유로 남습니다)
+
+## 환경변수
+
+| 이름 | 기본값 | 설명 |
+|---|---|---|
+| `SEED_USER_COUNT` | `4` | 생성할 사용자 수 (최소 2: 호스트 1 + 게스트 1) |
+| `SEED_ACTIVITY_COUNT` | `2` | 호스트가 등록할 체험 수 |
+| `SEED_PASSWORD` | `Seed1234!` | 생성 계정 공통 비밀번호 |
+| `SEED_PREFIX` | `seed<timestamp>` | 이메일/닉네임 접두사 |
+
+`NEXT_PUBLIC_API_BASE_URL` 은 `.env.local` 에서 자동으로 읽어옵니다.
+
+## 출력 파일 (`output/*.json`)
+
+계정 비밀번호가 평문으로 포함되어 있으므로 `.gitignore` 에 의해 커밋되지 않습니다.

--- a/scripts/seed-data/cleanup.mjs
+++ b/scripts/seed-data/cleanup.mjs
@@ -1,0 +1,87 @@
+/**
+ * seed.mjs 가 생성한 결과 파일(JSON)을 읽어서, 시딩한 예약/체험을 정리(삭제)하는 스크립트.
+ *
+ * 사용법: node scripts/seed-data/cleanup.mjs scripts/seed-data/output/<파일명>.json
+ *
+ * 주의:
+ * - 예약은 취소(PATCH status: 'canceled') 처리되고, 체험은 실제로 삭제(DELETE)된다.
+ * - 백엔드에 회원탈퇴 API가 없어 시딩된 사용자 계정 자체는 삭제되지 않는다.
+ *   (email 에 'seed.test' 접두사가 있어 실제 사용자와는 구분 가능)
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { apiRequest } from './config.mjs';
+
+const resultPath = process.argv[2];
+
+if (!resultPath) {
+  console.error(
+    '사용법: node scripts/seed-data/cleanup.mjs <seed 결과 json 경로>'
+  );
+  process.exit(1);
+}
+
+const result = JSON.parse(readFileSync(path.resolve(resultPath), 'utf-8'));
+
+const login = async (email, password) => {
+  const { accessToken } = await apiRequest('/auth/login', {
+    method: 'POST',
+    body: { email, password },
+  });
+  return accessToken;
+};
+
+const main = async () => {
+  console.log(`정리 시작 (prefix: ${result.prefix})`);
+
+  const tokenByEmail = new Map();
+  const tokenFor = async (email) => {
+    if (!tokenByEmail.has(email)) {
+      const user = result.users.find((u) => u.email === email);
+      if (!user)
+        throw new Error(`결과 파일에서 사용자를 찾을 수 없습니다: ${email}`);
+      tokenByEmail.set(email, await login(user.email, user.password));
+    }
+    return tokenByEmail.get(email);
+  };
+
+  console.log('\n[1/2] 예약 취소');
+  for (const reservation of result.reservations) {
+    try {
+      const accessToken = await tokenFor(reservation.guestEmail);
+      await apiRequest(`/my-reservations/${reservation.id}`, {
+        method: 'PATCH',
+        body: { status: 'canceled' },
+        accessToken,
+      });
+      console.log(`  ✓ 예약 취소: #${reservation.id}`);
+    } catch (error) {
+      console.warn(`  ! 예약 취소 실패: #${reservation.id} (${error.message})`);
+    }
+  }
+
+  console.log('\n[2/2] 체험 삭제');
+  const host = result.users.find((u) => u.role === 'host');
+  const hostToken = await tokenFor(host.email);
+  for (const activity of result.activities) {
+    try {
+      await apiRequest(`/my-activities/${activity.id}`, {
+        method: 'DELETE',
+        accessToken: hostToken,
+      });
+      console.log(`  ✓ 체험 삭제: #${activity.id}`);
+    } catch (error) {
+      console.warn(`  ! 체험 삭제 실패: #${activity.id} (${error.message})`);
+    }
+  }
+
+  console.log(
+    `\n완료. 시딩된 사용자 계정(${result.users.length}개)은 백엔드에 탈퇴 API가 없어 그대로 남아있습니다.`
+  );
+};
+
+main().catch((error) => {
+  console.error('\n정리 중 오류 발생:', error.message);
+  process.exit(1);
+});

--- a/scripts/seed-data/config.mjs
+++ b/scripts/seed-data/config.mjs
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+
+/** .env.local 에서 NEXT_PUBLIC_API_BASE_URL 을 직접 읽어온다 (process.env 에 없을 경우 대비). */
+const readEnvLocal = (key) => {
+  try {
+    const content = readFileSync(path.join(projectRoot, '.env.local'), 'utf-8');
+    const match = content.match(new RegExp(`^${key}=(.*)$`, 'm'));
+    return match?.[1]?.trim();
+  } catch {
+    return undefined;
+  }
+};
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  readEnvLocal('NEXT_PUBLIC_API_BASE_URL');
+
+if (!API_BASE_URL) {
+  throw new Error(
+    'NEXT_PUBLIC_API_BASE_URL 을 찾을 수 없습니다. .env.local 을 확인하거나 환경변수로 넘겨주세요.'
+  );
+}
+
+/**
+ * 백엔드(GlobalNomad API)에 직접 요청을 보내는 얇은 fetch 래퍼.
+ * 이 프로젝트의 seed 스크립트는 Next.js 서버 없이 독립 실행되므로
+ * BFF(/api/proxy)를 거치지 않고 백엔드를 바로 호출한다.
+ */
+export const apiRequest = async (
+  endpoint,
+  { method = 'GET', body, accessToken, isFormData = false } = {}
+) => {
+  const url = `${API_BASE_URL.replace(/\/$/, '')}/${endpoint.replace(/^\//, '')}`;
+
+  const headers = {
+    ...(!isFormData && { 'Content-Type': 'application/json' }),
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+  };
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body ? (isFormData ? body : JSON.stringify(body)) : undefined,
+  });
+
+  const text = await response.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : undefined;
+  } catch {
+    data = undefined;
+  }
+
+  if (!response.ok) {
+    const message = data?.message ?? `API Error: ${response.status}`;
+    throw new Error(`[${method} ${endpoint}] ${message}`);
+  }
+
+  return data;
+};
+
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/scripts/seed-data/seed.mjs
+++ b/scripts/seed-data/seed.mjs
@@ -1,0 +1,237 @@
+/**
+ * 테스트용 사용자 + 체험(활동) + 예약 더미 데이터를 실제 백엔드 API에 생성하는 시딩 스크립트.
+ *
+ * 사용법: node scripts/seed-data/seed.mjs
+ * 옵션(환경변수):
+ *   SEED_USER_COUNT   생성할 사용자 수 (기본 4, 첫 번째는 호스트, 나머지는 게스트)
+ *   SEED_ACTIVITY_COUNT 호스트가 등록할 체험 수 (기본 2)
+ *   SEED_PASSWORD     생성할 계정 공통 비밀번호 (기본 'Seed1234!')
+ *   SEED_PREFIX       이메일/닉네임 접두사 (기본 'seed<timestamp>') — 실 데이터와 구분하기 위함
+ *
+ * 이 프로젝트는 자체 DB 없이 공용 백엔드(GlobalNomad API)를 사용하므로,
+ * 접두사로 만든 계정임을 항상 구분할 수 있게 하고 과도한 실행은 피할 것.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { apiRequest } from './config.mjs';
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+const outputDir = path.join(projectRoot, 'scripts/seed-data/output');
+
+const USER_COUNT = Number(process.env.SEED_USER_COUNT ?? 4);
+const ACTIVITY_COUNT = Number(process.env.SEED_ACTIVITY_COUNT ?? 2);
+const PASSWORD = process.env.SEED_PASSWORD ?? 'Seed1234!';
+const PREFIX = process.env.SEED_PREFIX ?? `seed${Date.now()}`;
+
+const CATEGORIES = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
+
+if (USER_COUNT < 2) {
+  throw new Error(
+    'SEED_USER_COUNT 는 최소 2 이상이어야 합니다 (호스트 1 + 게스트 1).'
+  );
+}
+
+const toDateString = (date) => date.toISOString().slice(0, 10);
+
+const addDays = (days) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
+};
+
+const signupAndLogin = async (email, nickname, password) => {
+  await apiRequest('/users', {
+    method: 'POST',
+    body: { email, nickname, password },
+  });
+
+  const { user, accessToken } = await apiRequest('/auth/login', {
+    method: 'POST',
+    body: { email, password },
+  });
+
+  return { user, email, password, nickname, accessToken };
+};
+
+const createUsers = async () => {
+  const users = [];
+
+  for (let i = 1; i <= USER_COUNT; i += 1) {
+    const role = i === 1 ? 'host' : 'guest';
+    const email = `${PREFIX}.${role}${i}@seed.test`;
+    const nickname =
+      `${role === 'host' ? '시드호스트' : '시드게스트'}${i}`.slice(0, 10);
+
+    const created = await signupAndLogin(email, nickname, PASSWORD);
+    users.push({ ...created, role });
+    console.log(`  ✓ 사용자 생성: ${email} (${role})`);
+  }
+
+  return users;
+};
+
+/**
+ * 배너 이미지를 백엔드가 받아들이는 형식(자체 스토리지 URL)으로 만들기 위해,
+ * 플레이스홀더 이미지를 내려받아 `/activities/image` 에 업로드하고 그 URL을 반환한다.
+ * (임의의 외부 URL은 "배너 이미지 URL 형식이 올바르지 않습니다" 로 거부된다)
+ */
+const uploadPlaceholderBannerImage = async (accessToken, seed) => {
+  const imageResponse = await fetch(
+    `https://picsum.photos/seed/${seed}/800/600`
+  );
+  const imageBlob = await imageResponse.blob();
+
+  const formData = new FormData();
+  formData.append('image', imageBlob, `${seed}.jpg`);
+
+  const { activityImageUrl } = await apiRequest('/activities/image', {
+    method: 'POST',
+    body: formData,
+    accessToken,
+    isFormData: true,
+  });
+
+  return activityImageUrl;
+};
+
+const createActivities = async (host) => {
+  const activities = [];
+
+  for (let i = 1; i <= ACTIVITY_COUNT; i += 1) {
+    const schedules = [
+      { date: toDateString(addDays(1)), startTime: '10:00', endTime: '11:00' },
+      { date: toDateString(addDays(2)), startTime: '14:00', endTime: '15:00' },
+    ];
+
+    const bannerImageUrl = await uploadPlaceholderBannerImage(
+      host.accessToken,
+      `${PREFIX}-${i}`
+    );
+
+    const body = {
+      title: `[${PREFIX}] 시드 체험 ${i}`,
+      category: CATEGORIES[i % CATEGORIES.length],
+      description: '시딩 스크립트로 생성된 테스트용 체험입니다.',
+      price: 10000 * i,
+      address: '서울특별시 중구 세종대로 110',
+      schedules,
+      bannerImageUrl,
+    };
+
+    const activity = await apiRequest('/activities', {
+      method: 'POST',
+      body,
+      accessToken: host.accessToken,
+    });
+
+    activities.push(activity);
+    console.log(`  ✓ 체험 생성: #${activity.id} ${activity.title}`);
+  }
+
+  return activities;
+};
+
+const reserveForGuests = async (activities, guests) => {
+  const reservations = [];
+
+  for (const activity of activities) {
+    const now = new Date();
+    const schedule = await apiRequest(
+      `/activities/${activity.id}/available-schedule?year=${now.getFullYear()}&month=${String(
+        now.getMonth() + 1
+      ).padStart(2, '0')}`
+    );
+
+    const firstSlot = schedule.flatMap((day) => day.times)[0];
+    if (!firstSlot) {
+      console.warn(
+        `  ! 체험 #${activity.id} 예약 가능한 시간이 없어 예약을 건너뜁니다.`
+      );
+      continue;
+    }
+
+    for (const guest of guests) {
+      try {
+        const reservation = await apiRequest(
+          `/activities/${activity.id}/reservations`,
+          {
+            method: 'POST',
+            body: { scheduleId: firstSlot.id, headCount: 1 },
+            accessToken: guest.accessToken,
+          }
+        );
+        reservations.push({
+          ...reservation,
+          activityId: activity.id,
+          guestEmail: guest.email,
+        });
+        console.log(
+          `  ✓ 예약 생성: 체험 #${activity.id} ← ${guest.email} (reservation #${reservation.id})`
+        );
+      } catch (error) {
+        console.warn(
+          `  ! 예약 실패: 체험 #${activity.id} ← ${guest.email} (${error.message})`
+        );
+      }
+    }
+  }
+
+  return reservations;
+};
+
+const main = async () => {
+  console.log(`시딩 시작 (prefix: ${PREFIX})`);
+
+  console.log('\n[1/3] 사용자 생성');
+  const users = await createUsers();
+  const [host, ...guests] = users;
+
+  console.log('\n[2/3] 체험 생성 (호스트 기준)');
+  const activities = await createActivities(host);
+
+  console.log('\n[3/3] 예약 생성 (게스트 기준)');
+  const reservations = await reserveForGuests(activities, guests);
+
+  mkdirSync(outputDir, { recursive: true });
+  const outputPath = path.join(outputDir, `${PREFIX}.json`);
+  writeFileSync(
+    outputPath,
+    JSON.stringify(
+      {
+        prefix: PREFIX,
+        createdAt: new Date().toISOString(),
+        users: users.map(({ user, email, password, nickname, role }) => ({
+          id: user.id,
+          email,
+          password,
+          nickname,
+          role,
+        })),
+        activities: activities.map((a) => ({ id: a.id, title: a.title })),
+        reservations: reservations.map((r) => ({
+          id: r.id,
+          activityId: r.activityId,
+          guestEmail: r.guestEmail,
+        })),
+      },
+      null,
+      2
+    )
+  );
+
+  console.log(`\n완료. 결과 파일: ${path.relative(projectRoot, outputPath)}`);
+  console.log('정리(cleanup)가 필요하면 다음을 실행하세요:');
+  console.log(
+    `  node scripts/seed-data/cleanup.mjs ${path.relative(projectRoot, outputPath)}`
+  );
+};
+
+main().catch((error) => {
+  console.error('\n시딩 중 오류 발생:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 🔗 관련 이슈

- close #349 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

실제 운영 화면처럼 테스트/데모를 진행할 수 있도록 백엔드 API에 직접 사용자 계정, 체험(활동), 예약 더미 데이터를 생성하는 시딩 스크립트 추가

- 이 프로젝트는 자체 DB 없이 공용 백엔드(`sp-globalnomad-api.vercel.app/22-2`)를 사용하므로
  Next.js 서버를 거치지 않고 백엔드 API를 직접 호출하는 독립 Node 스크립트로 작성
- 생성되는 계정은 `seed<timestamp>.host1@seed.test` 형식으로 실제 데이터와 구분 가능
- 배너 이미지는 임의 URL이 거부되어 `/activities/image` 업로드 API로 실제 업로드 후 받은 URL을 사용
- 정리 스크립트(`cleanup.mjs`)는 예약 취소, 체험 삭제를 처리함. 백엔드에 회원탈퇴 API가 없어 시딩된 사용자 계정 자체는 삭제 불가능

## 사용법

`npm run seed`                 # 사용자 4명 + 체험 2개 + 예약 생성
`npm run seed:cleanup <결과 json 경로>`   # 예약 취소 + 체험 삭제