### PR TITLE
[Feat/#352] 체험 원본 시간대의 예약 가능 상태 표시 개선

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,25 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(git fetch *)",
-      "Bash(npm run *)",
-      "Bash(gh api *)",
-      "Bash(gh label *)",
-      "Bash(ls scripts *)",
-      "Bash(SEED_USER_COUNT=2 SEED_ACTIVITY_COUNT=1 node scripts/seed-data/seed.mjs)",
-      "Bash(node -e \"console.log\\(typeof FormData, typeof Blob\\)\")",
-      "Bash(node scripts/seed-data/cleanup.mjs scripts/seed-data/output/seed1785252218125.json)",
-      "Bash(rm -f /tmp/seedrun.log scripts/seed-data/output/*.json; rm -rf scripts/seed-data/output; mkdir -p scripts/seed-data/output; git status)",
-      "Bash(npx prettier *)",
-      "Bash(lsof -nP -iTCP:3000 -sTCP:LISTEN)",
-      "Bash(curl -sS -o /dev/null -w \"http_code:%{http_code} time:%{time_total}\\\\n\" --max-time 5 http://localhost:3000)",
-      "Bash(ps -p 75805 -o pid,ppid,%cpu,%mem,etime,command)",
-      "Bash(curl -sS -o /dev/null -w \"http_code:%{http_code} time:%{time_total}\\\\n\" --max-time 30 http://localhost:3000)",
-      "Bash(sample 75805 2 -f)"
-    ],
-    "additionalDirectories": [
-      "/Users/yanghaneul/Desktop/globalnomad/sprint-team2-globalnomad/scripts/seed-data",
-      "/private/tmp"
-    ]
+    "allow": ["Bash(git fetch *)"]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,25 @@
 {
   "permissions": {
-    "allow": ["Bash(git fetch *)"]
+    "allow": [
+      "Bash(git fetch *)",
+      "Bash(npm run *)",
+      "Bash(gh api *)",
+      "Bash(gh label *)",
+      "Bash(ls scripts *)",
+      "Bash(SEED_USER_COUNT=2 SEED_ACTIVITY_COUNT=1 node scripts/seed-data/seed.mjs)",
+      "Bash(node -e \"console.log\\(typeof FormData, typeof Blob\\)\")",
+      "Bash(node scripts/seed-data/cleanup.mjs scripts/seed-data/output/seed1785252218125.json)",
+      "Bash(rm -f /tmp/seedrun.log scripts/seed-data/output/*.json; rm -rf scripts/seed-data/output; mkdir -p scripts/seed-data/output; git status)",
+      "Bash(npx prettier *)",
+      "Bash(lsof -nP -iTCP:3000 -sTCP:LISTEN)",
+      "Bash(curl -sS -o /dev/null -w \"http_code:%{http_code} time:%{time_total}\\\\n\" --max-time 5 http://localhost:3000)",
+      "Bash(ps -p 75805 -o pid,ppid,%cpu,%mem,etime,command)",
+      "Bash(curl -sS -o /dev/null -w \"http_code:%{http_code} time:%{time_total}\\\\n\" --max-time 30 http://localhost:3000)",
+      "Bash(sample 75805 2 -f)"
+    ],
+    "additionalDirectories": [
+      "/Users/yanghaneul/Desktop/globalnomad/sprint-team2-globalnomad/scripts/seed-data",
+      "/private/tmp"
+    ]
   }
 }

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types.ts
@@ -17,3 +17,15 @@ export interface TimeSlot {
   startTime: string;
   endTime: string;
 }
+
+/**
+ * @description 시간대의 예약 가능 상태
+ * - `available` : 예약 가능(선택 가능)
+ * - `mine` : 내가 이미 예약한 시간대
+ * - `unavailable` : 그 외 예약할 수 없는 시간대(이유 표시 없이 비활성화)
+ */
+export type TimeSlotAvailability = 'available' | 'mine' | 'unavailable';
+
+export interface TimeSlotWithStatus extends TimeSlot {
+  status: TimeSlotAvailability;
+}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/desktopReservationCard.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/desktopReservationCard.tsx
@@ -1,6 +1,7 @@
 import type {
   CalendarValue,
   TimeSlot,
+  TimeSlotWithStatus,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import { HeadCountStepperIconButton } from '@/app/(main)/activity/[id]/components/activity-reservation-card/components/headCountStepperIconButton';
 import { ReservationCalendarView } from '@/app/(main)/activity/[id]/components/activity-reservation-card/components/reservationCalendarView';
@@ -16,8 +17,8 @@ interface DesktopReservationCardProps {
   headCount: number;
   totalPrice: number;
   selectedTimeSlot: TimeSlot | null;
-  availableTimeSlots: TimeSlot[];
-  hasSelectableDate: boolean;
+  timeSlots: TimeSlotWithStatus[];
+  hasBookableSlot: boolean;
   isReservationAvailable: boolean;
   isReservationSubmitting: boolean;
   onDateChange: (value: CalendarValue) => void;
@@ -40,8 +41,8 @@ export function DesktopReservationCard({
   headCount,
   totalPrice,
   selectedTimeSlot,
-  availableTimeSlots,
-  hasSelectableDate,
+  timeSlots,
+  hasBookableSlot,
   isReservationAvailable,
   isReservationSubmitting,
   onDateChange,
@@ -98,12 +99,14 @@ export function DesktopReservationCard({
             <div className="mt-6">
               <p className="typo-lg-bold text-gray-950">예약 가능한 시간</p>
               <div className="mt-3.5 mb-6 flex flex-col gap-3">
-                {availableTimeSlots.length > 0 ? (
-                  availableTimeSlots.map((slot) => (
+                {timeSlots.length > 0 ? (
+                  timeSlots.map((slot) => (
                     <TimeSlotButton
                       key={slot.id}
                       size="pc"
                       isActive={selectedTimeSlot?.id === slot.id}
+                      isMine={slot.status === 'mine'}
+                      disabled={slot.status !== 'available'}
                       onClick={onSelectTimeSlot(slot)}
                     >
                       {slot.startTime} ~ {slot.endTime}
@@ -111,7 +114,7 @@ export function DesktopReservationCard({
                   ))
                 ) : selectedDate ? (
                   <p className="typo-md-medium rounded-xl border border-gray-100 px-4 py-3 text-gray-500">
-                    {hasSelectableDate
+                    {hasBookableSlot
                       ? '선택한 날짜에 예약 가능한 시간이 없습니다.'
                       : '예약 가능한 날짜가 없습니다.'}
                   </p>

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/components/mobileReservationSheet.tsx
@@ -3,6 +3,7 @@ import type {
   CalendarValue,
   MobileSheetStep,
   TimeSlot,
+  TimeSlotWithStatus,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import { HeadCountStepperIconButton } from '@/app/(main)/activity/[id]/components/activity-reservation-card/components/headCountStepperIconButton';
 import { ReservationCalendarView } from '@/app/(main)/activity/[id]/components/activity-reservation-card/components/reservationCalendarView';
@@ -24,13 +25,13 @@ function getMobileReservationSheetCloseMs() {
 interface MobileReservationSheetProps {
   isOpen: boolean;
   mobileSheetStep: MobileSheetStep;
-  hasSelectableDate: boolean;
+  hasBookableSlot: boolean;
   selectedDate: Date | null;
   currentDate: Date;
   monthTitle: string;
   selectedDateText: string;
   selectedTimeSlot: TimeSlot | null;
-  availableTimeSlots: TimeSlot[];
+  timeSlots: TimeSlotWithStatus[];
   headCount: number;
   totalPrice: number;
   isReservationAvailable: boolean;
@@ -53,13 +54,13 @@ interface MobileReservationSheetProps {
 export function MobileReservationSheet({
   isOpen,
   mobileSheetStep,
-  hasSelectableDate,
+  hasBookableSlot,
   selectedDate,
   currentDate,
   monthTitle,
   selectedDateText,
   selectedTimeSlot,
-  availableTimeSlots,
+  timeSlots,
   headCount,
   totalPrice,
   isReservationAvailable,
@@ -145,12 +146,14 @@ export function MobileReservationSheet({
                 <div className="mt-6">
                   <p className="typo-lg-bold text-gray-950">예약 가능한 시간</p>
                   <div className="mt-3 flex flex-col gap-3">
-                    {availableTimeSlots.length > 0 ? (
-                      availableTimeSlots.map((slot) => (
+                    {timeSlots.length > 0 ? (
+                      timeSlots.map((slot) => (
                         <TimeSlotButton
                           key={slot.id}
                           size="tb"
                           isActive={selectedTimeSlot?.id === slot.id}
+                          isMine={slot.status === 'mine'}
+                          disabled={slot.status !== 'available'}
                           onClick={onSelectTimeSlot(slot)}
                           className="w-full"
                         >
@@ -159,7 +162,7 @@ export function MobileReservationSheet({
                       ))
                     ) : selectedDate ? (
                       <p className="typo-md-medium rounded-xl border border-gray-100 px-4 py-3 text-gray-500">
-                        {hasSelectableDate
+                        {hasBookableSlot
                           ? '선택한 날짜에 예약 가능한 시간이 없습니다.'
                           : '예약 가능한 날짜가 없습니다.'}
                       </p>
@@ -257,12 +260,14 @@ export function MobileReservationSheet({
               <div className="shadow-review-card h-102 w-75 overflow-y-auto overscroll-contain rounded-3xl bg-white p-5">
                 <p className="typo-lg-bold text-gray-950">예약 가능한 시간</p>
                 <div className="mt-3 flex flex-col gap-3">
-                  {availableTimeSlots.length > 0 ? (
-                    availableTimeSlots.map((slot) => (
+                  {timeSlots.length > 0 ? (
+                    timeSlots.map((slot) => (
                       <TimeSlotButton
                         key={slot.id}
                         size="tb"
                         isActive={selectedTimeSlot?.id === slot.id}
+                        isMine={slot.status === 'mine'}
+                        disabled={slot.status !== 'available'}
                         onClick={onSelectTimeSlot(slot)}
                         className="w-full"
                       >
@@ -271,7 +276,7 @@ export function MobileReservationSheet({
                     ))
                   ) : selectedDate ? (
                     <p className="typo-md-medium rounded-xl border border-gray-100 px-4 py-3 text-gray-500">
-                      {hasSelectableDate
+                      {hasBookableSlot
                         ? '선택한 날짜에 예약 가능한 시간이 없습니다.'
                         : '예약 가능한 날짜가 없습니다.'}
                     </p>

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -128,11 +128,23 @@ export const useActivityReservationAvailability = ({
       );
     }, [availableScheduleQueries, queryTargetMonths]);
 
-  const { data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES } = useQuery({
+  const {
+    data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES,
+    isLoading: isMyScheduleLoading,
+    isError: isMyScheduleError,
+  } = useQuery({
     queryKey: reservationKeys.myReservations.reservedSchedules(),
     queryFn: fetchMyReservedSchedules,
     enabled: isAuthenticated,
   });
+
+  const myScheduleQueryStatus: AvailableScheduleQueryStatus = !isAuthenticated
+    ? 'success'
+    : isMyScheduleLoading
+      ? 'loading'
+      : isMyScheduleError
+        ? 'error'
+        : 'success';
 
   const myReservedScheduleIds = useMemo(() => {
     return myReservedSchedules
@@ -153,12 +165,14 @@ export const useActivityReservationAvailability = ({
         availableSchedules,
         availableScheduleQueryStatusByMonth,
         myScheduleIds,
+        myScheduleQueryStatus,
         now,
       }),
     [
       availableScheduleQueryStatusByMonth,
       availableSchedules,
       myScheduleIds,
+      myScheduleQueryStatus,
       now,
       schedules,
     ]

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/(main)/activity/[id]/apis/myReservedSchedules';
 import {
   type AvailableScheduleQueryStatus,
+  type AvailableScheduleQueryStatusByMonth,
   buildReservationAvailability,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability';
 import { normalizeDateKey } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
@@ -74,16 +75,26 @@ export const useActivityReservationAvailability = ({
     [availableScheduleQueries]
   );
 
-  const availableScheduleQueryStatus =
-    useMemo<AvailableScheduleQueryStatus>(() => {
-      if (availableScheduleQueries.some((query) => query.isLoading)) {
-        return 'loading';
-      }
-      if (availableScheduleQueries.some((query) => query.isError)) {
-        return 'error';
-      }
-      return 'success';
-    }, [availableScheduleQueries]);
+  const availableScheduleQueryStatusByMonth =
+    useMemo<AvailableScheduleQueryStatusByMonth>(() => {
+      return queryTargetMonths.reduce<AvailableScheduleQueryStatusByMonth>(
+        (accumulator, { year, month }, index) => {
+          const query = availableScheduleQueries[index];
+          const yearMonthKey = `${year}-${String(month).padStart(2, '0')}`;
+          let status: AvailableScheduleQueryStatus = 'success';
+
+          if (!query || query.isLoading) {
+            status = 'loading';
+          } else if (query.isError) {
+            status = 'error';
+          }
+
+          accumulator[yearMonthKey] = status;
+          return accumulator;
+        },
+        {}
+      );
+    }, [availableScheduleQueries, queryTargetMonths]);
 
   const { data: myReservedSchedules = EMPTY_RESERVED_SCHEDULES } = useQuery({
     queryKey: reservationKeys.myReservations.reservedSchedules(),
@@ -108,11 +119,16 @@ export const useActivityReservationAvailability = ({
       buildReservationAvailability({
         schedules,
         availableSchedules,
-        availableScheduleQueryStatus,
+        availableScheduleQueryStatusByMonth,
         myScheduleIds,
         now: new Date(),
       }),
-    [availableScheduleQueryStatus, availableSchedules, myScheduleIds, schedules]
+    [
+      availableScheduleQueryStatusByMonth,
+      availableSchedules,
+      myScheduleIds,
+      schedules,
+    ]
   );
 
   useEffect(() => {
@@ -120,14 +136,20 @@ export const useActivityReservationAvailability = ({
       return;
     }
 
-    if (availableScheduleQueryStatus === 'success') {
+    const unavailableMonths = Object.entries(
+      availableScheduleQueryStatusByMonth
+    ).filter(([, status]) => status !== 'success');
+
+    if (unavailableMonths.length === 0) {
       return;
     }
 
     console.warn(
-      `[useActivityReservationAvailability] activityId=${activityId}: 예약 가능 시간 조회가 ${availableScheduleQueryStatus} 상태라 원본 시간대를 비활성화 상태로 표시 중`
+      `[useActivityReservationAvailability] activityId=${activityId}: 예약 가능 시간을 확인하지 못한 연월의 원본 시간대를 비활성화 상태로 표시 중 (${unavailableMonths
+        .map(([yearMonth, status]) => `${yearMonth}:${status}`)
+        .join(', ')})`
     );
-  }, [activityId, availableScheduleQueryStatus]);
+  }, [activityId, availableScheduleQueryStatusByMonth]);
 
   return { scheduleByDate };
 };

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -97,27 +97,22 @@ export const useActivityReservationAvailability = ({
       .map((reservation) => reservation.scheduleId);
   }, [activityId, myReservedSchedules]);
 
-  const blockedScheduleIds = useMemo(() => {
+  const myScheduleIds = useMemo(() => {
     return Array.from(
       new Set([...myReservedScheduleIds, ...reservedScheduleIds])
     );
   }, [myReservedScheduleIds, reservedScheduleIds]);
 
-  const { availableScheduleByDate, usesFallbackSchedule } = useMemo(
+  const { scheduleByDate } = useMemo(
     () =>
       buildReservationAvailability({
         schedules,
         availableSchedules,
         availableScheduleQueryStatus,
-        blockedScheduleIds,
+        myScheduleIds,
         now: new Date(),
       }),
-    [
-      availableScheduleQueryStatus,
-      availableSchedules,
-      blockedScheduleIds,
-      schedules,
-    ]
+    [availableScheduleQueryStatus, availableSchedules, myScheduleIds, schedules]
   );
 
   useEffect(() => {
@@ -125,14 +120,14 @@ export const useActivityReservationAvailability = ({
       return;
     }
 
-    if (!usesFallbackSchedule || availableScheduleQueryStatus === 'loading') {
+    if (availableScheduleQueryStatus === 'success') {
       return;
     }
 
     console.warn(
-      `[useActivityReservationAvailability] activityId=${activityId}: 예약 가능 시간 API 대신 원본 스케줄로 대체 표시 중 (status=${availableScheduleQueryStatus})`
+      `[useActivityReservationAvailability] activityId=${activityId}: 예약 가능 시간 조회가 ${availableScheduleQueryStatus} 상태라 원본 시간대를 비활성화 상태로 표시 중`
     );
-  }, [activityId, availableScheduleQueryStatus, usesFallbackSchedule]);
+  }, [activityId, availableScheduleQueryStatus]);
 
-  return { availableScheduleByDate, usesFallbackSchedule };
+  return { scheduleByDate };
 };

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { fetchActivityAvailableSchedule } from '@/app/(main)/activity/[id]/apis/activityAvailableSchedule';
 import {
@@ -17,6 +17,7 @@ import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 
 const EMPTY_RESERVED_SCHEDULES: MyReservedScheduleItem[] = [];
+const MINUTE_IN_MILLISECONDS = 60_000;
 
 interface UseActivityReservationAvailabilityProps {
   activityId: number;
@@ -37,6 +38,37 @@ export const useActivityReservationAvailability = ({
   reservedScheduleIds,
   isAuthenticated,
 }: UseActivityReservationAvailabilityProps) => {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    let minuteIntervalId: ReturnType<typeof setInterval> | null = null;
+    const millisecondsUntilNextMinute =
+      MINUTE_IN_MILLISECONDS - (Date.now() % MINUTE_IN_MILLISECONDS);
+
+    const minuteTimeoutId = setTimeout(() => {
+      setNow(new Date());
+      minuteIntervalId = setInterval(() => {
+        setNow(new Date());
+      }, MINUTE_IN_MILLISECONDS);
+    }, millisecondsUntilNextMinute);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        setNow(new Date());
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearTimeout(minuteTimeoutId);
+      if (minuteIntervalId) {
+        clearInterval(minuteIntervalId);
+      }
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
   const queryTargetMonths = useMemo(() => {
     const uniqueYearMonth = new Set<string>();
 
@@ -121,12 +153,13 @@ export const useActivityReservationAvailability = ({
         availableSchedules,
         availableScheduleQueryStatusByMonth,
         myScheduleIds,
-        now: new Date(),
+        now,
       }),
     [
       availableScheduleQueryStatusByMonth,
       availableSchedules,
       myScheduleIds,
+      now,
       schedules,
     ]
   );

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -56,8 +56,8 @@ export const useActivityReservationCardState = ({
     isAuthenticated,
   });
 
-  const scheduleDateKeys = useMemo(
-    () => Object.keys(scheduleByDate).sort(),
+  const earliestScheduleDateKey = useMemo(
+    () => Object.keys(scheduleByDate).sort()[0] ?? null,
     [scheduleByDate]
   );
 
@@ -69,22 +69,15 @@ export const useActivityReservationCardState = ({
     [scheduleByDate]
   );
 
-  const scheduleDateKeysSignature = scheduleDateKeys.join(',');
-
   useEffect(() => {
-    if (!scheduleDateKeysSignature) {
-      return;
-    }
-
-    const earliestDateKey = scheduleDateKeys[0];
-    if (!earliestDateKey) {
+    if (!earliestScheduleDateKey) {
       return;
     }
 
     const now = new Date();
     const todayKey = formatDateKey(now);
 
-    if (earliestDateKey !== todayKey) {
+    if (earliestScheduleDateKey !== todayKey) {
       return;
     }
 
@@ -103,7 +96,7 @@ export const useActivityReservationCardState = ({
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [scheduleDateKeys]);
+  }, [earliestScheduleDateKey]);
   const effectiveSelectedDateKey = selectedDateKey;
 
   const parsedSelectedDate = useMemo(() => {

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -7,6 +7,7 @@ import type {
   CalendarValue,
   MobileSheetStep,
   TimeSlot,
+  TimeSlotWithStatus,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import { useActivityReservationAvailability } from '@/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability';
 import { ApiError } from '@/shared/apis/apiError';
@@ -45,27 +46,34 @@ export const useActivityReservationCardState = ({
   const [mobileSheetStep, setMobileSheetStep] =
     useState<MobileSheetStep>('dateTime');
 
-  const { availableScheduleByDate } = useActivityReservationAvailability({
+  const { scheduleByDate } = useActivityReservationAvailability({
     activityId,
     schedules,
     reservedScheduleIds,
     isAuthenticated,
   });
 
-  const availableDateKeys = useMemo(
-    () => Object.keys(availableScheduleByDate).sort(),
-    [availableScheduleByDate]
+  const scheduleDateKeys = useMemo(
+    () => Object.keys(scheduleByDate).sort(),
+    [scheduleByDate]
   );
 
-  const hasSelectableDate = availableDateKeys.length > 0;
-  const availableDateKeysSignature = availableDateKeys.join(',');
+  const hasBookableSlot = useMemo(
+    () =>
+      Object.values(scheduleByDate).some((slots) =>
+        slots.some((slot) => slot.status === 'available')
+      ),
+    [scheduleByDate]
+  );
+
+  const scheduleDateKeysSignature = scheduleDateKeys.join(',');
 
   useEffect(() => {
-    if (!availableDateKeysSignature) {
+    if (!scheduleDateKeysSignature) {
       return;
     }
 
-    const earliestDateKey = availableDateKeys[0];
+    const earliestDateKey = scheduleDateKeys[0];
     if (!earliestDateKey) {
       return;
     }
@@ -92,12 +100,7 @@ export const useActivityReservationCardState = ({
     return () => {
       cancelAnimationFrame(frameId);
     };
-    /**
-     * 예약 성공 후 setSelectedDateKey(null)로 초기화되면 가용 날짜 시그니처가
-     * 그대로인 경우 effect가 재실행되지 않아 오늘 자동선택이 복구되지 않는다.
-     * selectedDateKey를 함께 구독해 null로 돌아온 뒤에도 동일 규칙으로 적용
-     */
-  }, [availableDateKeys, selectedDateKey]);
+  }, [scheduleDateKeys]);
   const effectiveSelectedDateKey = selectedDateKey;
 
   const parsedSelectedDate = useMemo(() => {
@@ -111,27 +114,37 @@ export const useActivityReservationCardState = ({
 
   const selectedDate = useMemo(() => parsedSelectedDate, [parsedSelectedDate]);
 
-  const availableTimeSlots = useMemo<TimeSlot[]>(() => {
+  const timeSlots = useMemo<TimeSlotWithStatus[]>(() => {
     if (!effectiveSelectedDateKey) {
       return [];
     }
 
-    return availableScheduleByDate[effectiveSelectedDateKey] ?? [];
-  }, [availableScheduleByDate, effectiveSelectedDateKey]);
+    return scheduleByDate[effectiveSelectedDateKey] ?? [];
+  }, [scheduleByDate, effectiveSelectedDateKey]);
 
-  const activeSelectedTimeSlot = useMemo(() => {
-    if (availableTimeSlots.length === 0) {
-      return null;
-    }
-
+  /**
+   * 선택한 시간대가 데이터 갱신 후 예약 불가 상태(`mine`/`unavailable`)로 바뀌면
+   * 선택을 해제하기 위해 최신 timeSlots에서 `available` 상태만 유효한 선택으로 인정한다.
+   */
+  const activeSelectedTimeSlot = useMemo<TimeSlot | null>(() => {
     if (!selectedTimeSlot) {
       return null;
     }
 
-    return (
-      availableTimeSlots.find((slot) => slot.id === selectedTimeSlot.id) ?? null
+    const matchedSlot = timeSlots.find(
+      (slot) => slot.id === selectedTimeSlot.id
     );
-  }, [availableTimeSlots, selectedTimeSlot]);
+
+    if (!matchedSlot || matchedSlot.status !== 'available') {
+      return null;
+    }
+
+    return {
+      id: matchedSlot.id,
+      startTime: matchedSlot.startTime,
+      endTime: matchedSlot.endTime,
+    };
+  }, [timeSlots, selectedTimeSlot]);
 
   const displayCurrentDate = useMemo(
     () => currentDate ?? selectedDate ?? new Date(),
@@ -148,9 +161,7 @@ export const useActivityReservationCardState = ({
     () => pricePerPerson * headCount,
     [headCount, pricePerPerson]
   );
-  const isReservationAvailable = Boolean(
-    activeSelectedTimeSlot && hasSelectableDate
-  );
+  const isReservationAvailable = Boolean(activeSelectedTimeSlot);
 
   const refreshAvailableSchedule = async () => {
     const queryKey = reservationKeys.availableSchedule.byActivity(activityId);
@@ -189,7 +200,6 @@ export const useActivityReservationCardState = ({
 
         await refreshAvailableSchedule();
 
-        setSelectedDateKey(null);
         setSelectedTimeSlot(null);
         setHeadCount(1);
         setIsDateSheetOpen(false);
@@ -205,14 +215,11 @@ export const useActivityReservationCardState = ({
           return;
         }
 
-        if (activeSelectedTimeSlot) {
-          setReservedScheduleIds((prev) =>
-            prev.includes(activeSelectedTimeSlot.id)
-              ? prev
-              : [...prev, activeSelectedTimeSlot.id]
-          );
-        }
-
+        /**
+         * 409는 "내가 예약했다"가 아니라 "이 시간대가 더 이상 예약 가능하지 않다"는 뜻이므로
+         * reservedScheduleIds(=내 예약)에 넣지 않는다. 선택만 해제하고 최신 예약 가능 목록을
+         * 다시 받아오면 해당 슬롯은 자연히 unavailable로 반영된다.
+         */
         setSelectedTimeSlot(null);
         await refreshAvailableSchedule();
       },
@@ -306,13 +313,17 @@ export const useActivityReservationCardState = ({
     submitReservation();
   };
 
+  /**
+   * 원본 일정이 있는 날짜는 예약 가능한 시간이 없어도 선택해 시간표를 확인할 수 있도록,
+   * 스케줄 존재 여부만으로 판단한다(예약 가능 여부는 시간대 단위에서 개별적으로 표시).
+   */
   const tileDisabled = ({ date, view }: { date: Date; view: string }) => {
     if (view !== 'month') {
       return false;
     }
 
     const dateKey = formatDateKey(date);
-    return !Boolean(availableScheduleByDate[dateKey]);
+    return !Boolean(scheduleByDate[dateKey]);
   };
 
   return {
@@ -320,7 +331,7 @@ export const useActivityReservationCardState = ({
     isSuccessModalOpen,
     isLoginRequiredModalOpen,
     mobileSheetStep,
-    hasSelectableDate,
+    hasBookableSlot,
     isReservationAvailable,
     isReservationSubmitting,
     selectedDate,
@@ -328,7 +339,7 @@ export const useActivityReservationCardState = ({
     monthTitle,
     selectedDateText,
     activeSelectedTimeSlot,
-    availableTimeSlots,
+    timeSlots,
     headCount,
     totalPrice,
     handleOpenDateSheet,

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationCardState.ts
@@ -10,9 +10,11 @@ import type {
   TimeSlotWithStatus,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import { useActivityReservationAvailability } from '@/app/(main)/activity/[id]/components/activity-reservation-card/hooks/useActivityReservationAvailability';
+import { isUpcomingTimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
 import { ApiError } from '@/shared/apis/apiError';
 import { fetchInstanceClient } from '@/shared/apis/fetchInstance.client';
 import { reservationKeys } from '@/shared/queryKeys/reservationKeys';
+import { useShowToast } from '@/shared/store/useToastStore';
 import type { ActivitySchedule } from '@/shared/types/activityDetail.types';
 import { formatDateKey } from '@/shared/utils/formatDate';
 
@@ -32,6 +34,7 @@ export const useActivityReservationCardState = ({
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
+  const showToast = useShowToast();
   const [currentDate, setCurrentDate] = useState<Date | null>(null);
   const [headCount, setHeadCount] = useState(1);
   const [reservedScheduleIds, setReservedScheduleIds] = useState<number[]>([]);
@@ -307,9 +310,27 @@ export const useActivityReservationCardState = ({
   };
 
   const handleSubmitReservation = () => {
-    if (!isReservationAvailable || isReservationSubmitting) {
+    if (!activeSelectedTimeSlot || isReservationSubmitting) {
       return;
     }
+
+    if (
+      !effectiveSelectedDateKey ||
+      !isUpcomingTimeSlot(
+        effectiveSelectedDateKey,
+        activeSelectedTimeSlot.startTime,
+        new Date()
+      )
+    ) {
+      setSelectedTimeSlot(null);
+      showToast({
+        theme: 'warning',
+        message:
+          '선택한 시간이 지나 예약할 수 없습니다. 다른 시간을 선택해주세요.',
+      });
+      return;
+    }
+
     submitReservation();
   };
 

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/index.tsx
@@ -34,7 +34,7 @@ export function ActivityReservationCard({
     isSuccessModalOpen,
     isLoginRequiredModalOpen,
     mobileSheetStep,
-    hasSelectableDate,
+    hasBookableSlot,
     isReservationAvailable,
     isReservationSubmitting,
     selectedDate,
@@ -42,7 +42,7 @@ export function ActivityReservationCard({
     monthTitle,
     selectedDateText,
     activeSelectedTimeSlot,
-    availableTimeSlots,
+    timeSlots,
     headCount,
     totalPrice,
     handleOpenDateSheet,
@@ -75,13 +75,13 @@ export function ActivityReservationCard({
       <MobileReservationSheet
         isOpen={isDateSheetOpen}
         mobileSheetStep={mobileSheetStep}
-        hasSelectableDate={hasSelectableDate}
+        hasBookableSlot={hasBookableSlot}
         selectedDate={selectedDate}
         currentDate={displayCurrentDate}
         monthTitle={monthTitle}
         selectedDateText={selectedDateText}
         selectedTimeSlot={activeSelectedTimeSlot}
-        availableTimeSlots={availableTimeSlots}
+        timeSlots={timeSlots}
         headCount={headCount}
         totalPrice={totalPrice}
         isReservationAvailable={isReservationAvailable}
@@ -106,8 +106,8 @@ export function ActivityReservationCard({
         headCount={headCount}
         totalPrice={totalPrice}
         selectedTimeSlot={activeSelectedTimeSlot}
-        availableTimeSlots={availableTimeSlots}
-        hasSelectableDate={hasSelectableDate}
+        timeSlots={timeSlots}
+        hasBookableSlot={hasBookableSlot}
         isReservationAvailable={isReservationAvailable}
         isReservationSubmitting={isReservationSubmitting}
         onDateChange={handleDateChange}

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
@@ -27,6 +27,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules,
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -35,12 +36,45 @@ describe('buildReservationAvailability', () => {
     ]);
   });
 
+  it('내 예약 조회가 끝나지 않았거나 실패하면 예약 가능 응답이 있어도 unavailable이다', () => {
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [{ id: 2, startTime: '09:00', endTime: '10:00' }],
+      },
+    ];
+    const baseParams = {
+      schedules,
+      availableSchedules,
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' } as const,
+      myScheduleIds: [],
+      now: NOW,
+    };
+
+    const loadingResult = buildReservationAvailability({
+      ...baseParams,
+      myScheduleQueryStatus: 'loading',
+    });
+    const errorResult = buildReservationAvailability({
+      ...baseParams,
+      myScheduleQueryStatus: 'error',
+    });
+
+    expect(loadingResult.scheduleByDate['2026-07-20'][0].status).toBe(
+      'unavailable'
+    );
+    expect(errorResult.scheduleByDate['2026-07-20'][0].status).toBe(
+      'unavailable'
+    );
+  });
+
   it('원본 스케줄에는 있지만 예약 가능 결과에는 없는 시간은 unavailable이다', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -65,6 +99,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules,
       availableScheduleQueryStatusByMonth: { '2026-07': 'loading' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
     const errorResult = buildReservationAvailability({
@@ -72,6 +107,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules,
       availableScheduleQueryStatusByMonth: { '2026-07': 'error' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -89,6 +125,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules: [],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -112,6 +149,7 @@ describe('buildReservationAvailability', () => {
       ],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now,
     });
 
@@ -132,6 +170,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules: [],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [10],
+      myScheduleQueryStatus: 'success',
       now,
     });
 
@@ -153,6 +192,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules,
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [2],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -167,6 +207,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules: [],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [3],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -181,6 +222,7 @@ describe('buildReservationAvailability', () => {
       availableSchedules: [],
       availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 
@@ -214,6 +256,7 @@ describe('buildReservationAvailability', () => {
         '2026-08': 'error',
       },
       myScheduleIds: [],
+      myScheduleQueryStatus: 'success',
       now: NOW,
     });
 

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
@@ -14,7 +14,7 @@ const schedules: ActivitySchedule[] = [
 ];
 
 describe('buildReservationAvailability', () => {
-  it('정상 응답이면 API 응답을 그대로 사용하고 usesFallbackSchedule은 false다', () => {
+  it('원본 스케줄과 예약 가능 결과에 모두 포함된 시간은 available이다', () => {
     const availableSchedules: ActivityAvailableScheduleItem[] = [
       {
         date: '2026-07-20',
@@ -26,33 +26,33 @@ describe('buildReservationAvailability', () => {
       schedules,
       availableSchedules,
       availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [],
+      myScheduleIds: [],
       now: NOW,
     });
 
-    expect(result.usesFallbackSchedule).toBe(false);
-    expect(result.availableScheduleByDate).toEqual({
-      '2026-07-20': [{ id: 2, startTime: '09:00', endTime: '10:00' }],
-    });
+    expect(result.scheduleByDate['2026-07-20']).toEqual([
+      { id: 2, startTime: '09:00', endTime: '10:00', status: 'available' },
+    ]);
   });
 
-  it('빈 응답(정상이지만 결과 없음)이면 원본 스케줄로 대체하고 usesFallbackSchedule은 true다', () => {
+  it('원본 스케줄에는 있지만 예약 가능 결과에는 없는 시간은 unavailable이다', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
       availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [],
+      myScheduleIds: [],
       now: NOW,
     });
 
-    expect(result.usesFallbackSchedule).toBe(true);
-    expect(result.availableScheduleByDate).toEqual({
-      '2026-07-20': [{ id: 2, startTime: '09:00', endTime: '10:00' }],
-      '2026-07-21': [{ id: 3, startTime: '13:00', endTime: '14:00' }],
-    });
+    expect(result.scheduleByDate['2026-07-20']).toEqual([
+      { id: 2, startTime: '09:00', endTime: '10:00', status: 'unavailable' },
+    ]);
+    expect(result.scheduleByDate['2026-07-21']).toEqual([
+      { id: 3, startTime: '13:00', endTime: '14:00', status: 'unavailable' },
+    ]);
   });
 
-  it('로딩/오류 상태면 API 응답과 무관하게 원본 스케줄로 대체한다', () => {
+  it('조회가 loading/error 상태면 예약 가능 결과와 무관하게 unavailable로 표시한다', () => {
     const availableSchedules: ActivityAvailableScheduleItem[] = [
       {
         date: '2026-07-20',
@@ -64,81 +64,83 @@ describe('buildReservationAvailability', () => {
       schedules,
       availableSchedules,
       availableScheduleQueryStatus: 'loading',
-      blockedScheduleIds: [],
+      myScheduleIds: [],
       now: NOW,
     });
     const errorResult = buildReservationAvailability({
       schedules,
       availableSchedules,
       availableScheduleQueryStatus: 'error',
-      blockedScheduleIds: [],
+      myScheduleIds: [],
       now: NOW,
     });
 
-    expect(loadingResult.usesFallbackSchedule).toBe(true);
-    expect(errorResult.usesFallbackSchedule).toBe(true);
-    expect(loadingResult.availableScheduleByDate).toEqual(
-      errorResult.availableScheduleByDate
+    expect(loadingResult.scheduleByDate['2026-07-20']).toEqual([
+      { id: 2, startTime: '09:00', endTime: '10:00', status: 'unavailable' },
+    ]);
+    expect(errorResult.scheduleByDate['2026-07-20']).toEqual(
+      loadingResult.scheduleByDate['2026-07-20']
     );
-    expect(Object.keys(loadingResult.availableScheduleByDate)).toEqual([
-      '2026-07-20',
-      '2026-07-21',
-    ]);
   });
 
-  it('지난 시간대는 결과에서 제외한다', () => {
+  it('오늘 이전 날짜는 결과에서 완전히 제외한다', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
       availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [],
+      myScheduleIds: [],
       now: NOW,
     });
 
-    expect(result.availableScheduleByDate['2026-07-01']).toBeUndefined();
+    expect(result.scheduleByDate['2026-07-01']).toBeUndefined();
   });
 
-  it('이미 예약이 완료된 스케줄(blockedScheduleIds)은 대체 데이터에서 제외한다', () => {
-    const result = buildReservationAvailability({
-      schedules,
-      availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [2],
-      now: NOW,
-    });
-
-    expect(result.availableScheduleByDate['2026-07-20']).toBeUndefined();
-    expect(result.availableScheduleByDate['2026-07-21']).toEqual([
-      { id: 3, startTime: '13:00', endTime: '14:00' },
-    ]);
-  });
-
-  it('이미 예약이 완료된 스케줄(blockedScheduleIds)은 API 응답에서도 제외한다', () => {
-    const availableSchedules: ActivityAvailableScheduleItem[] = [
-      {
-        date: '2026-07-20',
-        times: [
-          { id: 2, startTime: '09:00', endTime: '10:00' },
-          { id: 4, startTime: '15:00', endTime: '16:00' },
-        ],
-      },
+  it('오늘 날짜의 지난 시간대는 표시하되 unavailable로 선택할 수 없게 한다', () => {
+    const now = new Date('2026-07-15T12:00:00');
+    const todaySchedules: ActivitySchedule[] = [
+      { id: 10, date: '2026-07-15', startTime: '09:00', endTime: '10:00' },
+      { id: 11, date: '2026-07-15', startTime: '15:00', endTime: '16:00' },
     ];
 
     const result = buildReservationAvailability({
-      schedules,
-      availableSchedules,
+      schedules: todaySchedules,
+      availableSchedules: [
+        {
+          date: '2026-07-15',
+          times: [{ id: 11, startTime: '15:00', endTime: '16:00' }],
+        },
+      ],
       availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [2],
-      now: NOW,
+      myScheduleIds: [],
+      now,
     });
 
-    expect(result.usesFallbackSchedule).toBe(false);
-    expect(result.availableScheduleByDate).toEqual({
-      '2026-07-20': [{ id: 4, startTime: '15:00', endTime: '16:00' }],
-    });
+    expect(result.scheduleByDate['2026-07-15']).toEqual([
+      { id: 10, startTime: '09:00', endTime: '10:00', status: 'unavailable' },
+      { id: 11, startTime: '15:00', endTime: '16:00', status: 'available' },
+    ]);
   });
 
-  it('중복 예약 필터링으로 API 응답의 모든 날짜가 비면 원본 스케줄로 대체한다', () => {
+  it('오늘 날짜의 지난 시간대라도 내 예약이면 mine을 유지한다', () => {
+    const now = new Date('2026-07-15T12:00:00');
+    const todaySchedules: ActivitySchedule[] = [
+      { id: 10, date: '2026-07-15', startTime: '09:00', endTime: '10:00' },
+    ];
+
+    const result = buildReservationAvailability({
+      schedules: todaySchedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      myScheduleIds: [10],
+      now,
+    });
+
+    expect(result.scheduleByDate['2026-07-15']).toEqual([
+      { id: 10, startTime: '09:00', endTime: '10:00', status: 'mine' },
+    ]);
+  });
+
+  it('내 예약 목록에 포함된 시간은 예약 가능 결과와 무관하게 mine이다', () => {
     const availableSchedules: ActivityAvailableScheduleItem[] = [
       {
         date: '2026-07-20',
@@ -150,13 +152,41 @@ describe('buildReservationAvailability', () => {
       schedules,
       availableSchedules,
       availableScheduleQueryStatus: 'success',
-      blockedScheduleIds: [2],
+      myScheduleIds: [2],
       now: NOW,
     });
 
-    expect(result.usesFallbackSchedule).toBe(true);
-    expect(result.availableScheduleByDate['2026-07-21']).toEqual([
-      { id: 3, startTime: '13:00', endTime: '14:00' },
+    expect(result.scheduleByDate['2026-07-20']).toEqual([
+      { id: 2, startTime: '09:00', endTime: '10:00', status: 'mine' },
+    ]);
+  });
+
+  it('내 예약이 예약 가능 결과에 없어도(정상 케이스) mine으로 우선 판단한다', () => {
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      myScheduleIds: [3],
+      now: NOW,
+    });
+
+    expect(result.scheduleByDate['2026-07-21']).toEqual([
+      { id: 3, startTime: '13:00', endTime: '14:00', status: 'mine' },
+    ]);
+  });
+
+  it('예약 가능한 시간이 없는 미래 날짜도 원본 스케줄 기준으로 날짜 키를 유지한다', () => {
+    const result = buildReservationAvailability({
+      schedules,
+      availableSchedules: [],
+      availableScheduleQueryStatus: 'success',
+      myScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(Object.keys(result.scheduleByDate)).toEqual([
+      '2026-07-20',
+      '2026-07-21',
     ]);
   });
 });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.test.ts
@@ -25,7 +25,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules,
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
       now: NOW,
     });
@@ -39,7 +39,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
       now: NOW,
     });
@@ -63,14 +63,14 @@ describe('buildReservationAvailability', () => {
     const loadingResult = buildReservationAvailability({
       schedules,
       availableSchedules,
-      availableScheduleQueryStatus: 'loading',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'loading' },
       myScheduleIds: [],
       now: NOW,
     });
     const errorResult = buildReservationAvailability({
       schedules,
       availableSchedules,
-      availableScheduleQueryStatus: 'error',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'error' },
       myScheduleIds: [],
       now: NOW,
     });
@@ -87,7 +87,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
       now: NOW,
     });
@@ -110,7 +110,7 @@ describe('buildReservationAvailability', () => {
           times: [{ id: 11, startTime: '15:00', endTime: '16:00' }],
         },
       ],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
       now,
     });
@@ -130,7 +130,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules: todaySchedules,
       availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [10],
       now,
     });
@@ -151,7 +151,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules,
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [2],
       now: NOW,
     });
@@ -165,7 +165,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [3],
       now: NOW,
     });
@@ -179,7 +179,7 @@ describe('buildReservationAvailability', () => {
     const result = buildReservationAvailability({
       schedules,
       availableSchedules: [],
-      availableScheduleQueryStatus: 'success',
+      availableScheduleQueryStatusByMonth: { '2026-07': 'success' },
       myScheduleIds: [],
       now: NOW,
     });
@@ -187,6 +187,41 @@ describe('buildReservationAvailability', () => {
     expect(Object.keys(result.scheduleByDate)).toEqual([
       '2026-07-20',
       '2026-07-21',
+    ]);
+  });
+
+  it('일부 연월의 조회만 실패하면 성공한 연월의 시간은 예약 가능 상태를 유지한다', () => {
+    const multiMonthSchedules: ActivitySchedule[] = [
+      { id: 20, date: '2026-07-20', startTime: '09:00', endTime: '10:00' },
+      { id: 21, date: '2026-08-20', startTime: '09:00', endTime: '10:00' },
+    ];
+    const availableSchedules: ActivityAvailableScheduleItem[] = [
+      {
+        date: '2026-07-20',
+        times: [{ id: 20, startTime: '09:00', endTime: '10:00' }],
+      },
+      {
+        date: '2026-08-20',
+        times: [{ id: 21, startTime: '09:00', endTime: '10:00' }],
+      },
+    ];
+
+    const result = buildReservationAvailability({
+      schedules: multiMonthSchedules,
+      availableSchedules,
+      availableScheduleQueryStatusByMonth: {
+        '2026-07': 'success',
+        '2026-08': 'error',
+      },
+      myScheduleIds: [],
+      now: NOW,
+    });
+
+    expect(result.scheduleByDate['2026-07-20']).toEqual([
+      { id: 20, startTime: '09:00', endTime: '10:00', status: 'available' },
+    ]);
+    expect(result.scheduleByDate['2026-08-20']).toEqual([
+      { id: 21, startTime: '09:00', endTime: '10:00', status: 'unavailable' },
     ]);
   });
 });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
@@ -30,6 +30,8 @@ export interface BuildReservationAvailabilityParams {
   availableScheduleQueryStatusByMonth: AvailableScheduleQueryStatusByMonth;
   /** 이미 내가 예약한(또는 이번 세션에 예약 완료한) 스케줄 ID */
   myScheduleIds: number[];
+  /** 내 예약 목록 조회 상태(비로그인 사용자는 `success`) */
+  myScheduleQueryStatus: AvailableScheduleQueryStatus;
   /** 지난 시간 판단 기준 시각 */
   now: Date;
 }
@@ -53,12 +55,14 @@ const resolveTimeSlotStatus = ({
   scheduleId,
   isUpcoming,
   myScheduleIdSet,
+  myScheduleQueryStatus,
   availableScheduleIdSet,
   availableScheduleQueryStatus,
 }: {
   scheduleId: number;
   isUpcoming: boolean;
   myScheduleIdSet: Set<number>;
+  myScheduleQueryStatus: AvailableScheduleQueryStatus;
   availableScheduleIdSet: Set<number>;
   availableScheduleQueryStatus: AvailableScheduleQueryStatus;
 }): TimeSlotAvailability => {
@@ -67,6 +71,10 @@ const resolveTimeSlotStatus = ({
   }
 
   if (!isUpcoming) {
+    return 'unavailable';
+  }
+
+  if (myScheduleQueryStatus !== 'success') {
     return 'unavailable';
   }
 
@@ -85,12 +93,14 @@ const resolveTimeSlotStatus = ({
  * - 오늘 날짜에 속한 시간대는 시작 시간이 지났더라도 표시하되, 지난 시간대는 `unavailable`로
  *   처리해 선택할 수 없게 한다(내 예약이면 지난 시간대여도 `mine`을 유지한다).
  * - 해당 연월의 조회가 loading/error이면 그 연월의 원본 시간대를 예약 가능으로 활성화하지 않는다.
+ * - 로그인 사용자의 내 예약 조회가 끝나지 않았거나 실패하면 중복 예약 방지를 위해 시간대를 활성화하지 않는다.
  */
 export const buildReservationAvailability = ({
   schedules,
   availableSchedules,
   availableScheduleQueryStatusByMonth,
   myScheduleIds,
+  myScheduleQueryStatus,
   now,
 }: BuildReservationAvailabilityParams): ReservationAvailabilityResult => {
   const myScheduleIdSet = new Set(myScheduleIds);
@@ -113,6 +123,7 @@ export const buildReservationAvailability = ({
         scheduleId: schedule.id,
         isUpcoming: isUpcomingTimeSlot(dateKey, schedule.startTime, now),
         myScheduleIdSet,
+        myScheduleQueryStatus,
         availableScheduleIdSet,
         availableScheduleQueryStatus,
       });

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
@@ -16,14 +16,18 @@ import type {
  * loading/error 시에는 원본 시간대를 예약 가능으로 활성화하지 않고 `unavailable`로 표시한다.
  */
 export type AvailableScheduleQueryStatus = 'loading' | 'error' | 'success';
+export type AvailableScheduleQueryStatusByMonth = Record<
+  string,
+  AvailableScheduleQueryStatus
+>;
 
 export interface BuildReservationAvailabilityParams {
   /** 체험 상세에 포함된 원본 스케줄(표시할 시간대의 기준) */
   schedules: ActivitySchedule[];
   /** 월별 예약 가능 시간 조회 API 응답을 합친 목록 */
   availableSchedules: ActivityAvailableScheduleItem[];
-  /** 예약 가능 시간 조회 API의 상태 */
-  availableScheduleQueryStatus: AvailableScheduleQueryStatus;
+  /** 예약 가능 시간 조회 API의 연월(`YYYY-MM`)별 상태 */
+  availableScheduleQueryStatusByMonth: AvailableScheduleQueryStatusByMonth;
   /** 이미 내가 예약한(또는 이번 세션에 예약 완료한) 스케줄 ID */
   myScheduleIds: number[];
   /** 지난 시간 판단 기준 시각 */
@@ -80,12 +84,12 @@ const resolveTimeSlotStatus = ({
  * - 오늘 이전 날짜는 결과에서 완전히 제외한다(달력에서 선택 불가).
  * - 오늘 날짜에 속한 시간대는 시작 시간이 지났더라도 표시하되, 지난 시간대는 `unavailable`로
  *   처리해 선택할 수 없게 한다(내 예약이면 지난 시간대여도 `mine`을 유지한다).
- * - 조회가 loading/error이면 원본 시간대를 예약 가능으로 활성화하지 않는다.
+ * - 해당 연월의 조회가 loading/error이면 그 연월의 원본 시간대를 예약 가능으로 활성화하지 않는다.
  */
 export const buildReservationAvailability = ({
   schedules,
   availableSchedules,
-  availableScheduleQueryStatus,
+  availableScheduleQueryStatusByMonth,
   myScheduleIds,
   now,
 }: BuildReservationAvailabilityParams): ReservationAvailabilityResult => {
@@ -100,6 +104,10 @@ export const buildReservationAvailability = ({
       if (dateKey < todayKey) {
         return accumulator;
       }
+
+      const yearMonthKey = dateKey.slice(0, 7);
+      const availableScheduleQueryStatus =
+        availableScheduleQueryStatusByMonth[yearMonthKey] ?? 'loading';
 
       const status = resolveTimeSlotStatus({
         scheduleId: schedule.id,

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationAvailability.ts
@@ -1,4 +1,7 @@
-import type { TimeSlot } from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
+import type {
+  TimeSlotAvailability,
+  TimeSlotWithStatus,
+} from '@/app/(main)/activity/[id]/components/activity-reservation-card/activityReservationCard.types';
 import {
   isUpcomingTimeSlot,
   normalizeDateKey,
@@ -10,50 +13,107 @@ import type {
 
 /**
  * 예약 가능 시간 조회(API) 상태.
- * loading/error 시에는 원본 스케줄(schedules)을 대체 데이터로 사용한다.
+ * loading/error 시에는 원본 시간대를 예약 가능으로 활성화하지 않고 `unavailable`로 표시한다.
  */
 export type AvailableScheduleQueryStatus = 'loading' | 'error' | 'success';
 
 export interface BuildReservationAvailabilityParams {
-  /** 체험 상세에 포함된 원본 스케줄(대체 데이터 원천) */
+  /** 체험 상세에 포함된 원본 스케줄(표시할 시간대의 기준) */
   schedules: ActivitySchedule[];
   /** 월별 예약 가능 시간 조회 API 응답을 합친 목록 */
   availableSchedules: ActivityAvailableScheduleItem[];
   /** 예약 가능 시간 조회 API의 상태 */
   availableScheduleQueryStatus: AvailableScheduleQueryStatus;
-  /** 이미 예약이 완료되어 선택 불가능한 스케줄 ID */
-  blockedScheduleIds: number[];
+  /** 이미 내가 예약한(또는 이번 세션에 예약 완료한) 스케줄 ID */
+  myScheduleIds: number[];
   /** 지난 시간 판단 기준 시각 */
   now: Date;
 }
 
 export interface ReservationAvailabilityResult {
-  /** 날짜(`YYYY-MM-DD`)별 예약 가능 시간대 */
-  availableScheduleByDate: Record<string, TimeSlot[]>;
-  /** true면 API 응답 대신 원본 스케줄을 대체 데이터로 사용 중임을 의미한다. */
-  usesFallbackSchedule: boolean;
+  /** 날짜(`YYYY-MM-DD`)별 시간대 목록. 오늘 이전 날짜는 제외한다. */
+  scheduleByDate: Record<string, TimeSlotWithStatus[]>;
 }
 
-const buildScheduleByDateFromSchedules = (
-  schedules: ActivitySchedule[],
-  blockedScheduleIds: number[],
-  now: Date
+const buildAvailableScheduleIdSet = (
+  availableSchedules: ActivityAvailableScheduleItem[]
 ) => {
-  return schedules.reduce<Record<string, TimeSlot[]>>(
+  const ids = new Set<number>();
+  availableSchedules.forEach((item) => {
+    item.times.forEach((time) => ids.add(time.id));
+  });
+  return ids;
+};
+
+const resolveTimeSlotStatus = ({
+  scheduleId,
+  isUpcoming,
+  myScheduleIdSet,
+  availableScheduleIdSet,
+  availableScheduleQueryStatus,
+}: {
+  scheduleId: number;
+  isUpcoming: boolean;
+  myScheduleIdSet: Set<number>;
+  availableScheduleIdSet: Set<number>;
+  availableScheduleQueryStatus: AvailableScheduleQueryStatus;
+}): TimeSlotAvailability => {
+  if (myScheduleIdSet.has(scheduleId)) {
+    return 'mine';
+  }
+
+  if (!isUpcoming) {
+    return 'unavailable';
+  }
+
+  if (availableScheduleQueryStatus !== 'success') {
+    return 'unavailable';
+  }
+
+  return availableScheduleIdSet.has(scheduleId) ? 'available' : 'unavailable';
+};
+
+/**
+ * 원본 스케줄을 기준으로 날짜별 시간대 목록을 만들고, 예약 가능 시간 API 응답·내 예약 목록·
+ * 조회 상태·현재 시각을 조합해 각 시간대의 상태(`available`/`mine`/`unavailable`)를 계산하는 순수 함수.
+ *
+ * - 오늘 이전 날짜는 결과에서 완전히 제외한다(달력에서 선택 불가).
+ * - 오늘 날짜에 속한 시간대는 시작 시간이 지났더라도 표시하되, 지난 시간대는 `unavailable`로
+ *   처리해 선택할 수 없게 한다(내 예약이면 지난 시간대여도 `mine`을 유지한다).
+ * - 조회가 loading/error이면 원본 시간대를 예약 가능으로 활성화하지 않는다.
+ */
+export const buildReservationAvailability = ({
+  schedules,
+  availableSchedules,
+  availableScheduleQueryStatus,
+  myScheduleIds,
+  now,
+}: BuildReservationAvailabilityParams): ReservationAvailabilityResult => {
+  const myScheduleIdSet = new Set(myScheduleIds);
+  const availableScheduleIdSet =
+    buildAvailableScheduleIdSet(availableSchedules);
+  const todayKey = normalizeDateKey(now);
+
+  const scheduleByDate = schedules.reduce<Record<string, TimeSlotWithStatus[]>>(
     (accumulator, schedule) => {
-      if (blockedScheduleIds.includes(schedule.id)) {
-        return accumulator;
-      }
-
       const dateKey = normalizeDateKey(schedule.date);
-      if (!isUpcomingTimeSlot(dateKey, schedule.startTime, now)) {
+      if (dateKey < todayKey) {
         return accumulator;
       }
 
-      const nextSlot: TimeSlot = {
+      const status = resolveTimeSlotStatus({
+        scheduleId: schedule.id,
+        isUpcoming: isUpcomingTimeSlot(dateKey, schedule.startTime, now),
+        myScheduleIdSet,
+        availableScheduleIdSet,
+        availableScheduleQueryStatus,
+      });
+
+      const nextSlot: TimeSlotWithStatus = {
         id: schedule.id,
         startTime: schedule.startTime,
         endTime: schedule.endTime,
+        status,
       };
 
       if (!accumulator[dateKey]) {
@@ -66,75 +126,6 @@ const buildScheduleByDateFromSchedules = (
     },
     {}
   );
-};
 
-const buildScheduleByDateFromAvailableSchedules = (
-  availableSchedules: ActivityAvailableScheduleItem[],
-  blockedScheduleIds: number[],
-  now: Date
-) => {
-  return availableSchedules.reduce<Record<string, TimeSlot[]>>(
-    (accumulator, item) => {
-      const dateKey = normalizeDateKey(item.date);
-      const filteredTimes = item.times.filter(
-        (time) =>
-          !blockedScheduleIds.includes(time.id) &&
-          isUpcomingTimeSlot(dateKey, time.startTime, now)
-      );
-
-      if (filteredTimes.length === 0) {
-        return accumulator;
-      }
-
-      accumulator[dateKey] = filteredTimes.map((time) => ({
-        id: time.id,
-        startTime: time.startTime,
-        endTime: time.endTime,
-      }));
-
-      return accumulator;
-    },
-    {}
-  );
-};
-
-/**
- * 원본 스케줄, 예약 가능 시간 API 응답, 조회 상태, 예약 완료 스케줄 ID, 현재 시각을 입력받아
- * 화면에 표시할 날짜별 예약 가능 시간대를 계산하는 순수 함수.
- *
- * - loading/error 이거나 API 응답이 정상이지만 결과가 비어 있으면 원본 스케줄을 대체 데이터로 사용한다.
- * - 지난 시간과 이미 예약이 완료된(blockedScheduleIds) 시간대는 결과에서 제외한다.
- */
-export const buildReservationAvailability = ({
-  schedules,
-  availableSchedules,
-  availableScheduleQueryStatus,
-  blockedScheduleIds,
-  now,
-}: BuildReservationAvailabilityParams): ReservationAvailabilityResult => {
-  const fromAvailableApi = buildScheduleByDateFromAvailableSchedules(
-    availableSchedules,
-    blockedScheduleIds,
-    now
-  );
-
-  const shouldUseFallback =
-    availableScheduleQueryStatus !== 'success' ||
-    Object.keys(fromAvailableApi).length === 0;
-
-  if (shouldUseFallback) {
-    return {
-      availableScheduleByDate: buildScheduleByDateFromSchedules(
-        schedules,
-        blockedScheduleIds,
-        now
-      ),
-      usesFallbackSchedule: true,
-    };
-  }
-
-  return {
-    availableScheduleByDate: fromAvailableApi,
-    usesFallbackSchedule: false,
-  };
+  return { scheduleByDate };
 };

--- a/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
+++ b/src/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isUpcomingTimeSlot,
   normalizeDateKey,
   parseTimeToHourMinute,
 } from '@/app/(main)/activity/[id]/components/activity-reservation-card/utils/reservationDateTime';
@@ -58,5 +59,18 @@ describe('parseTimeToHourMinute', () => {
     expect(parseTimeToHourMinute('12:')).toBeNull();
     expect(parseTimeToHourMinute(':30')).toBeNull();
     expect(parseTimeToHourMinute('aa:bb')).toBeNull();
+  });
+});
+
+describe('isUpcomingTimeSlot', () => {
+  const now = new Date(2026, 6, 15, 12, 0, 0);
+
+  it('현재 시각보다 뒤에 시작하는 시간은 true를 반환한다', () => {
+    expect(isUpcomingTimeSlot('2026-07-15', '12:01', now)).toBe(true);
+  });
+
+  it('현재 시각과 같거나 이미 지난 시간은 false를 반환한다', () => {
+    expect(isUpcomingTimeSlot('2026-07-15', '12:00', now)).toBe(false);
+    expect(isUpcomingTimeSlot('2026-07-15', '11:59', now)).toBe(false);
   });
 });

--- a/src/app/(main)/activity/[id]/components/time-slot-button/index.tsx
+++ b/src/app/(main)/activity/[id]/components/time-slot-button/index.tsx
@@ -7,13 +7,15 @@ import { cn } from '@/shared/utils/cn';
 export type { TimeSlotButtonProps };
 
 /**
- * 예약 가능한 시간대 선택 버튼
+ * 체험 시간대 선택 버튼
  *
  * 버튼 내부 텍스트(시간 범위)는 API에서 받아온 값을 `children`으로 전달
- * 가능한 시간대만 렌더링하므로 `disabled` 상태는 제공하지 않는다.
+ * 예약 불가 시간대는 `disabled`로 전달하며 색상만으로 구분되지 않도록
+ * `aria-disabled`도 함께 전달한다. `isMine`이면 "내 예약" 표시가 추가된다.
  *
  * - 기본 상태 : 흰 배경 + gray-300 테두리 (hover 시 primary 계열로 전환)
  * - 선택 상태(`isActive`) : primary-100 배경 + primary-500 테두리·텍스트
+ * - 비활성 상태(`disabled`) : gray-50 배경 + gray-200 테두리·gray-400 텍스트
  * - `size="pc"` : 350×54 (border 포함)
  * - `size="tb"` : 253×54 (border 포함)
  * - `size="mb"` : 327×48 (border 포함)
@@ -30,6 +32,8 @@ export type { TimeSlotButtonProps };
  *     key={slot.id}
  *     size="pc"
  *     isActive={selectedId === slot.id}
+ *     isMine={slot.status === 'mine'}
+ *     disabled={slot.status !== 'available'}
  *     onClick={() => setSelectedId(slot.id)}
  *   >
  *     {slot.startTime} ~ {slot.endTime}
@@ -39,6 +43,8 @@ export type { TimeSlotButtonProps };
 export function TimeSlotButton({
   size = 'pc',
   isActive = false,
+  isMine = false,
+  disabled = false,
   className,
   children,
   ...rest
@@ -46,10 +52,13 @@ export function TimeSlotButton({
   return (
     <button
       type="button"
+      disabled={disabled}
+      aria-disabled={disabled}
       className={cn(timeSlotVariants({ size, isActive }), className)}
       {...rest}
     >
       {children}
+      {isMine ? <span className="typo-xs-medium shrink-0">내 예약</span> : null}
     </button>
   );
 }

--- a/src/app/(main)/activity/[id]/components/time-slot-button/timeSlotButton.constants.ts
+++ b/src/app/(main)/activity/[id]/components/time-slot-button/timeSlotButton.constants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const timeSlotVariants = cva(
-  'inline-flex w-full cursor-pointer items-center justify-center rounded-xl border font-medium transition-colors duration-200',
+  'inline-flex w-full items-center justify-center gap-1.5 rounded-xl border font-medium transition-colors duration-200 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-400 disabled:hover:border-gray-200 disabled:hover:bg-gray-50 disabled:hover:text-gray-400',
   {
     variants: {
       /**
@@ -15,9 +15,9 @@ export const timeSlotVariants = cva(
         mb: 'text-md h-12 px-3',
       },
       isActive: {
-        true: 'border-primary-500 bg-primary-100 text-primary-500',
+        true: 'border-primary-500 bg-primary-100 text-primary-500 cursor-pointer',
         false:
-          'hover:border-primary-500 hover:bg-primary-100 hover:text-primary-500 border-gray-300 bg-white text-gray-950',
+          'hover:border-primary-500 hover:bg-primary-100 hover:text-primary-500 cursor-pointer border-gray-300 bg-white text-gray-950',
       },
     },
     defaultVariants: { size: 'pc', isActive: false },

--- a/src/app/(main)/activity/[id]/components/time-slot-button/timeSlotButton.types.ts
+++ b/src/app/(main)/activity/[id]/components/time-slot-button/timeSlotButton.types.ts
@@ -12,4 +12,10 @@ export interface TimeSlotButtonProps
    * @defaultValue `false`
    */
   isActive?: boolean;
+  /**
+   * 내가 이미 예약한 시간대 여부
+   * `true`이면 비활성화 스타일에 '내 예약' 표시가 추가된다.
+   * @defaultValue `false`
+   */
+  isMine?: boolean;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #352 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

- `buildReservationAvailability` 순수 함수를 원본 스케줄 기준으로 재작성해, 시간대별로 `available`/`mine`/`unavailable` 상태를 계산하도록 변경
  - 오늘 이전 날짜는 결과에서 제외(기존과 동일)
  - 오늘 날짜에 속한 시간대는 시작 시간이 지났더라도 표시하되, 선택은 막음(`unavailable`) — 단 내 예약이면 지난 시간이어도 `mine` 유지
  - 예약 가능 조회가 loading/error일 때 원본 시간대를 예약 가능으로 활성화하지 않음
- 예약 가능한 시간이 없는 미래 날짜도 캘린더에서 선택해 전체 시간표를 확인할 수 있도록 `tileDisabled` 조건을 "원본 일정 존재 여부"로 변경
- 선택한 시간대가 최신 상태 기준 `available`이 아니게 되면 자동으로 선택 해제
- `TimeSlotButton`에 `disabled`/`aria-disabled` 속성과 '내 예약' 추가 — 데스크톱/태블릿/모바일 동일하게 적용, 색상에만 의존하지 않도록 처리
- 예약 성공 후 선택했던 날짜가 오늘로 초기화되던 문제 수정 — 날짜 선택 유지