### PR TITLE
[Fix/#354] 라이트박스 종료 후 기존 Tab키 포커스 복원

### DIFF
--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
@@ -40,6 +40,7 @@ export interface ActivityImageLightboxProps {
   urls: string[];
   title: string;
   index: number;
+  returnFocusTo: HTMLElement | null;
   onClose: () => void;
   onNavigate: (nextIndex: number) => void;
 }
@@ -48,6 +49,7 @@ export function ActivityImageLightbox({
   urls,
   title,
   index,
+  returnFocusTo,
   onClose,
   onNavigate,
 }: ActivityImageLightboxProps) {
@@ -67,7 +69,6 @@ export function ActivityImageLightbox({
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const imageSlotRef = useRef<HTMLDivElement>(null);
   const prevIndexRef = useRef<number | null>(null);
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
   const [slideAnim, setSlideAnim] = useState<'from-right' | 'from-left' | null>(
     null
@@ -132,20 +133,12 @@ export function ActivityImageLightbox({
   );
 
   useEffect(() => {
-    lastFocusedElementRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
     const rafId = requestAnimationFrame(() => {
       closeButtonRef.current?.focus();
     });
 
     return () => {
       cancelAnimationFrame(rafId);
-      const restoreTarget = lastFocusedElementRef.current;
-      if (restoreTarget && restoreTarget.isConnected) {
-        restoreTarget.focus();
-      }
     };
   }, []);
 
@@ -242,6 +235,7 @@ export function ActivityImageLightbox({
   return (
     <ModalOverlay
       onClose={onClose}
+      returnFocusTo={returnFocusTo}
       className="px-3 py-6 sm:px-6 md:px-10 md:py-10"
     >
       <div

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { MouseEvent, PointerEvent } from 'react';
+import type { MouseEvent, PointerEvent, RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import {
@@ -40,7 +40,7 @@ export interface ActivityImageLightboxProps {
   urls: string[];
   title: string;
   index: number;
-  returnFocusTo: HTMLElement | null;
+  returnFocusRef: RefObject<HTMLElement | null>;
   onClose: () => void;
   onNavigate: (nextIndex: number) => void;
 }
@@ -49,7 +49,7 @@ export function ActivityImageLightbox({
   urls,
   title,
   index,
-  returnFocusTo,
+  returnFocusRef,
   onClose,
   onNavigate,
 }: ActivityImageLightboxProps) {
@@ -235,7 +235,7 @@ export function ActivityImageLightbox({
   return (
     <ModalOverlay
       onClose={onClose}
-      returnFocusTo={returnFocusTo}
+      returnFocusRef={returnFocusRef}
       className="px-3 py-6 sm:px-6 md:px-10 md:py-10"
     >
       <div

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
@@ -77,6 +77,14 @@ function GalleryImageSlotInner({
 
 const gallerySlotClassName = 'relative min-h-0 overflow-hidden bg-gray-100';
 
+function getCurrentFocusTarget(): HTMLElement | null {
+  const activeElement = document.activeElement;
+
+  return activeElement instanceof HTMLElement && activeElement !== document.body
+    ? activeElement
+    : null;
+}
+
 export function GalleryImageSlot({
   src,
   alt,
@@ -101,19 +109,19 @@ export function GalleryImageSlot({
   const mergedClass = cn(gallerySlotClassName, className);
   const focusBeforePointerDownRef = useRef<HTMLElement | null>(null);
 
-  const getCurrentFocus = () => {
-    const activeElement = document.activeElement;
-    return activeElement instanceof HTMLElement &&
-      activeElement !== document.body
-      ? activeElement
-      : null;
+  const handlePointerDown = () => {
+    focusBeforePointerDownRef.current = getCurrentFocusTarget();
+  };
+
+  const handlePointerCancel = () => {
+    focusBeforePointerDownRef.current = null;
   };
 
   const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
     const returnFocusTo =
       event.detail > 0
         ? (focusBeforePointerDownRef.current ?? event.currentTarget)
-        : (getCurrentFocus() ?? event.currentTarget);
+        : (getCurrentFocusTarget() ?? event.currentTarget);
 
     focusBeforePointerDownRef.current = null;
     onOpen?.(returnFocusTo);
@@ -123,12 +131,8 @@ export function GalleryImageSlot({
     return (
       <button
         type="button"
-        onPointerDown={() => {
-          focusBeforePointerDownRef.current = getCurrentFocus();
-        }}
-        onPointerCancel={() => {
-          focusBeforePointerDownRef.current = null;
-        }}
+        onPointerDown={handlePointerDown}
+        onPointerCancel={handlePointerCancel}
         onClick={handleOpen}
         aria-label={ariaLabel ?? '이미지 크게 보기'}
         className={cn(

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import type { MouseEvent } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 import { cn } from '@/shared/utils/cn';
 
@@ -93,17 +94,42 @@ export function GalleryImageSlot({
   className?: string;
   sizes?: string;
   quality?: number;
-  onOpen?: () => void;
+  onOpen?: (returnFocusTo: HTMLElement | null) => void;
   priority?: boolean;
   loading?: 'eager' | 'lazy';
 }) {
   const mergedClass = cn(gallerySlotClassName, className);
+  const focusBeforePointerDownRef = useRef<HTMLElement | null>(null);
+
+  const getCurrentFocus = () => {
+    const activeElement = document.activeElement;
+    return activeElement instanceof HTMLElement &&
+      activeElement !== document.body
+      ? activeElement
+      : null;
+  };
+
+  const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    const returnFocusTo =
+      event.detail > 0
+        ? (focusBeforePointerDownRef.current ?? event.currentTarget)
+        : (getCurrentFocus() ?? event.currentTarget);
+
+    focusBeforePointerDownRef.current = null;
+    onOpen?.(returnFocusTo);
+  };
 
   if (onOpen) {
     return (
       <button
         type="button"
-        onClick={onOpen}
+        onPointerDown={() => {
+          focusBeforePointerDownRef.current = getCurrentFocus();
+        }}
+        onPointerCancel={() => {
+          focusBeforePointerDownRef.current = null;
+        }}
+        onClick={handleOpen}
         aria-label={ariaLabel ?? '이미지 크게 보기'}
         className={cn(
           mergedClass,

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ActivityImageLightbox } from '@/app/(main)/activity/[id]/components/activity-image-gallery/activity-image-lightbox';
 import { GalleryImageSlot } from '@/app/(main)/activity/[id]/components/activity-image-gallery/gallery-image-slot';
 import { ACTIVITY_IMAGE_GALLERY_FRAME_CLASS } from '@/shared/constants/activityImageGallery.constants';
@@ -62,10 +62,8 @@ export function ActivityImageGallery({
   /** 갤러리에 최대 5장만 노출; 라이트박스도 동일 목록 사용 */
   const lightboxUrls = imageUrls;
 
-  const [lightboxState, setLightboxState] = useState<{
-    index: number;
-    returnFocusTo: HTMLElement | null;
-  } | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
   const renderSlot = ({
     index,
     alt,
@@ -88,25 +86,22 @@ export function ActivityImageGallery({
         quality={quality}
         priority={priority}
         onOpen={(returnFocusTo) => {
-          setLightboxState({ index, returnFocusTo });
+          returnFocusRef.current = returnFocusTo;
+          setLightboxIndex(index);
         }}
       />
     );
   };
 
   const lightbox =
-    lightboxState && lightboxUrls[lightboxState.index] ? (
+    lightboxIndex !== null && lightboxUrls[lightboxIndex] ? (
       <ActivityImageLightbox
         urls={lightboxUrls}
         title={title}
-        index={lightboxState.index}
-        returnFocusTo={lightboxState.returnFocusTo}
-        onClose={() => setLightboxState(null)}
-        onNavigate={(index) => {
-          setLightboxState((current) =>
-            current ? { ...current, index } : current
-          );
-        }}
+        index={lightboxIndex}
+        returnFocusRef={returnFocusRef}
+        onClose={() => setLightboxIndex(null)}
+        onNavigate={setLightboxIndex}
       />
     ) : null;
 

--- a/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
+++ b/src/app/(main)/activity/[id]/components/activity-image-gallery/index.tsx
@@ -62,7 +62,10 @@ export function ActivityImageGallery({
   /** 갤러리에 최대 5장만 노출; 라이트박스도 동일 목록 사용 */
   const lightboxUrls = imageUrls;
 
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [lightboxState, setLightboxState] = useState<{
+    index: number;
+    returnFocusTo: HTMLElement | null;
+  } | null>(null);
   const renderSlot = ({
     index,
     alt,
@@ -84,19 +87,26 @@ export function ActivityImageGallery({
         sizes={sizes}
         quality={quality}
         priority={priority}
-        onOpen={() => setLightboxIndex(index)}
+        onOpen={(returnFocusTo) => {
+          setLightboxState({ index, returnFocusTo });
+        }}
       />
     );
   };
 
   const lightbox =
-    lightboxIndex !== null && lightboxUrls[lightboxIndex] ? (
+    lightboxState && lightboxUrls[lightboxState.index] ? (
       <ActivityImageLightbox
         urls={lightboxUrls}
         title={title}
-        index={lightboxIndex}
-        onClose={() => setLightboxIndex(null)}
-        onNavigate={setLightboxIndex}
+        index={lightboxState.index}
+        returnFocusTo={lightboxState.returnFocusTo}
+        onClose={() => setLightboxState(null)}
+        onNavigate={(index) => {
+          setLightboxState((current) =>
+            current ? { ...current, index } : current
+          );
+        }}
       />
     ) : null;
 

--- a/src/shared/components/modal/modal-overlay/index.tsx
+++ b/src/shared/components/modal/modal-overlay/index.tsx
@@ -11,6 +11,7 @@ const MODAL_EXIT_MS = 220;
 interface ModalOverlayProps {
   children: ReactNode;
   onClose: () => void;
+  returnFocusTo?: HTMLElement | null;
   closeOnOverlayClick?: boolean;
   closeOnEscape?: boolean;
   className?: string;
@@ -38,6 +39,7 @@ interface ModalOverlayProps {
 export function ModalOverlay({
   children,
   onClose,
+  returnFocusTo,
   closeOnOverlayClick = true,
   closeOnEscape = true,
   className,
@@ -51,6 +53,13 @@ export function ModalOverlay({
   /** SSR과 첫 클라이언트 렌더를 맞추기 위해 초기값은 false, 마운트 후 rAF로 동기화 */
   const [reduceMotion, setReduceMotion] = useState(false);
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const restoreFocusTargetRef = useRef<HTMLElement | null>(
+    returnFocusTo ??
+      (typeof document !== 'undefined' &&
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null)
+  );
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -119,6 +128,7 @@ export function ModalOverlay({
   useEffect(() => {
     if (!portalRoot) return;
 
+    const restoreFocusTarget = restoreFocusTargetRef.current;
     const backgroundElements: HTMLElement[] = [];
     const collectBackgroundElements = (element: Element) => {
       if (element === portalRoot) {
@@ -164,6 +174,11 @@ export function ModalOverlay({
           element.removeAttribute('inert');
         }
       });
+
+      // inert가 해제된 뒤에 포커스를 복원해야 브라우저가 focus()를 무시하지 않습니다.
+      if (restoreFocusTarget?.isConnected) {
+        restoreFocusTarget.focus();
+      }
     };
   }, [portalRoot]);
 

--- a/src/shared/components/modal/modal-overlay/index.tsx
+++ b/src/shared/components/modal/modal-overlay/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { MouseEvent, ReactNode } from 'react';
+import type { MouseEvent, ReactNode, RefObject } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ModalOverlayCloseContext } from '@/shared/components/modal/modal-overlay/modal-overlay-close-context';
@@ -11,7 +11,7 @@ const MODAL_EXIT_MS = 220;
 interface ModalOverlayProps {
   children: ReactNode;
   onClose: () => void;
-  returnFocusTo?: HTMLElement | null;
+  returnFocusRef?: RefObject<HTMLElement | null>;
   closeOnOverlayClick?: boolean;
   closeOnEscape?: boolean;
   className?: string;
@@ -39,7 +39,7 @@ interface ModalOverlayProps {
 export function ModalOverlay({
   children,
   onClose,
-  returnFocusTo,
+  returnFocusRef,
   closeOnOverlayClick = true,
   closeOnEscape = true,
   className,
@@ -53,13 +53,6 @@ export function ModalOverlay({
   /** SSR과 첫 클라이언트 렌더를 맞추기 위해 초기값은 false, 마운트 후 rAF로 동기화 */
   const [reduceMotion, setReduceMotion] = useState(false);
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const restoreFocusTargetRef = useRef<HTMLElement | null>(
-    returnFocusTo ??
-      (typeof document !== 'undefined' &&
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null)
-  );
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -128,7 +121,11 @@ export function ModalOverlay({
   useEffect(() => {
     if (!portalRoot) return;
 
-    const restoreFocusTarget = restoreFocusTargetRef.current;
+    const restoreFocusTarget =
+      returnFocusRef?.current ??
+      (document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null);
     const backgroundElements: HTMLElement[] = [];
     const collectBackgroundElements = (element: Element) => {
       if (element === portalRoot) {
@@ -180,7 +177,7 @@ export function ModalOverlay({
         restoreFocusTarget.focus();
       }
     };
-  }, [portalRoot]);
+  }, [portalRoot, returnFocusRef]);
 
   // ESC 닫기를 옵션으로 제공하며, 이벤트 리스너는 unmount 시 제거합니다.
   useEffect(() => {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #354 

## ☑️ 체크 사항

### 1. 기본 확인

- [ ]  PR 올리기 전, 최신 `develop` 브랜치 내용을 작업 브랜치에 반영했는가
- [ ]  불필요한 `console.log`, 주석 처리된 dead code가 남아있지 않은가
- [ ]  콘솔 에러가 발생하지 않았는가

### 2. 코드 컨벤션

- [ ]  폴더 구조와 파일명이 [팀 컨벤션](https://www.notion.so/3421c940ef0680fbb4e6c41d2f57cbfd?pvs=21)과 일치하는가
- [ ]  함수명, 변수명, props명이 역할을 명확하게 설명하는가
- [ ]  `h2` ~ `h6` 태그는 공통 컴포넌트 `<Heading>`을 사용하여 일관성 있게 적용했는가
- [ ]  컴포넌트 분리가 적절한가 (단일책임원칙)

### 3. UI / 접근성 / 반응형

- [ ]  디자인 시안과 비교했을 때 UI가 일치하는가
- [ ]  화면 사이즈를 줄였을 때 레이아웃이 깨지지 않는가
- [ ]  이미지에 `alt` 속성이 적절하게 작성되었는가 (장식용 이미지는 `alt=""`)
- [ ]  기능 구현이 포함된 경우, Preview를 통해 정상 동작을 확인했는가

### 4. Tailwind 점검

- [ ]  `lg:` 검색 → 있다면 `2xl:`로 수정
- [ ]  `text-` 혹은 `text-(size계열)` 검색  → `typo-OOO`로 변경 가능한 부분이면 수정
- [ ]  `z-` 검색  → `globals.css` 공통 z-index 값 사용 여부 확인
- [ ]  `shadow` 검색  → `colors.css` 공통 shadow 값 사용 여부 확인
- [ ]  `-[` 검색  → 임의 값 대신 공식 클래스로 수정

### 5. PR 리뷰 품질

- [ ]  PR 설명만 봐도 작업 내용을 이해할 수 있는가

## 📌 작업 내용

- 라이트박스를 열기 전 체험 상세 페이지의 포커스 요소를 저장
- 이미지 클릭 시 브라우저가 이미지 버튼으로 포커스를 옮기기 전인 `pointerdown` 시점에 기존 포커스를 저장하도록 구현
- 라이트박스가 닫힐 때 배경의 `inert`, `aria-hidden`을 먼저 해제한 후 기존 요소로 포커스를 복원하도록 순서 변경
- 라이트박스 내부에 중복으로 존재하던 포커스 복원 로직을 공통 `ModalOverlay`로 이동
- 이미지 탐색으로 인덱스가 변경되어도 최초 복원 대상이 유지되도록 상태 정리
